### PR TITLE
Add core domain records

### DIFF
--- a/Validation.Domain/Core/SaveAudit.cs
+++ b/Validation.Domain/Core/SaveAudit.cs
@@ -1,0 +1,8 @@
+namespace ValidationFlow.Domain;
+
+public record SaveAudit(
+    string EntityType,
+    Guid EntityId,
+    decimal MetricValue,
+    bool Validated,
+    DateTime Timestamp);

--- a/Validation.Domain/Core/ThresholdType.cs
+++ b/Validation.Domain/Core/ThresholdType.cs
@@ -1,0 +1,7 @@
+namespace ValidationFlow.Domain;
+
+public enum ThresholdType
+{
+    RawDifference,
+    PercentChange
+}

--- a/Validation.Domain/Core/ValidationPlan.cs
+++ b/Validation.Domain/Core/ValidationPlan.cs
@@ -1,0 +1,6 @@
+namespace ValidationFlow.Domain;
+
+public record ValidationPlan<T>(
+    Func<T, decimal> MetricSelector,
+    ThresholdType ThresholdType,
+    decimal ThresholdValue);

--- a/Validation.Tests/DomainEssentialsTests.cs
+++ b/Validation.Tests/DomainEssentialsTests.cs
@@ -1,0 +1,27 @@
+using ValidationFlow.Domain;
+
+namespace Validation.Tests;
+
+public class DomainEssentialsTests
+{
+    [Fact]
+    public void SaveAudit_record_properties_assigned()
+    {
+        var timestamp = DateTime.UtcNow;
+        var audit = new SaveAudit("Item", Guid.NewGuid(), 1.23m, true, timestamp);
+        Assert.Equal("Item", audit.EntityType);
+        Assert.True(audit.Validated);
+        Assert.Equal(1.23m, audit.MetricValue);
+        Assert.Equal(timestamp, audit.Timestamp);
+    }
+
+    [Fact]
+    public void ValidationPlan_initializes_properties()
+    {
+        Func<int, decimal> selector = x => x;
+        var plan = new ValidationPlan<int>(selector, ThresholdType.RawDifference, 5m);
+        Assert.Equal(selector, plan.MetricSelector);
+        Assert.Equal(ThresholdType.RawDifference, plan.ThresholdType);
+        Assert.Equal(5m, plan.ThresholdValue);
+    }
+}


### PR DESCRIPTION
## Summary
- implement core immutable types under `ValidationFlow.Domain`
- add unit tests for the new records

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_688bda4815f88330a44902a350dc17ae