### PR TITLE
Add domain essentials

### DIFF
--- a/Validation.Domain/DomainEssentials.cs
+++ b/Validation.Domain/DomainEssentials.cs
@@ -1,0 +1,19 @@
+namespace ValidationFlow.Domain;
+
+public enum ThresholdType
+{
+    RawDifference,
+    PercentChange
+}
+
+public record SaveAudit(
+    string EntityType,
+    Guid EntityId,
+    decimal MetricValue,
+    bool Validated,
+    DateTime Timestamp);
+
+public record ValidationPlan<T>(
+    Func<T, decimal> MetricSelector,
+    ThresholdType ThresholdType,
+    decimal ThresholdValue);

--- a/Validation.Tests/DomainEssentialsTests.cs
+++ b/Validation.Tests/DomainEssentialsTests.cs
@@ -1,0 +1,31 @@
+using ValidationFlow.Domain;
+
+namespace Validation.Tests;
+
+public class DomainEssentialsTests
+{
+    [Fact]
+    public void SaveAudit_properties_are_set_correctly()
+    {
+        var timestamp = DateTime.UtcNow;
+        var id = Guid.NewGuid();
+        var audit = new SaveAudit("Item", id, 10m, true, timestamp);
+
+        Assert.Equal("Item", audit.EntityType);
+        Assert.Equal(id, audit.EntityId);
+        Assert.Equal(10m, audit.MetricValue);
+        Assert.True(audit.Validated);
+        Assert.Equal(timestamp, audit.Timestamp);
+    }
+
+    [Fact]
+    public void ValidationPlan_properties_are_set_correctly()
+    {
+        Func<int, decimal> selector = x => x;
+        var plan = new ValidationPlan<int>(selector, ThresholdType.PercentChange, 5m);
+
+        Assert.Equal(selector, plan.MetricSelector);
+        Assert.Equal(ThresholdType.PercentChange, plan.ThresholdType);
+        Assert.Equal(5m, plan.ThresholdValue);
+    }
+}


### PR DESCRIPTION
## Summary
- add SaveAudit, ThresholdType and ValidationPlan
- add tests for domain essentials

## Testing
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_688bda4815f88330a44902a350dc17ae