### PR TITLE
Implement ValidationFlow domain essentials

### DIFF
--- a/Validation.Tests/DomainEssentialsTests.cs
+++ b/Validation.Tests/DomainEssentialsTests.cs
@@ -1,0 +1,27 @@
+using ValidationFlow.Domain;
+
+namespace Validation.Tests;
+
+public class DomainEssentialsTests
+{
+    [Fact]
+    public void SaveAudit_properties_round_trip()
+    {
+        var now = DateTime.UtcNow;
+        var audit = new SaveAudit("Item", Guid.NewGuid(), 1.23m, true, now);
+        Assert.Equal("Item", audit.EntityType);
+        Assert.Equal(1.23m, audit.MetricValue);
+        Assert.True(audit.Validated);
+        Assert.Equal(now, audit.Timestamp);
+    }
+
+    [Fact]
+    public void ValidationPlan_stores_configuration()
+    {
+        Func<string, decimal> selector = s => s.Length;
+        var plan = new ValidationPlan<string>(selector, ThresholdType.RawDifference, 5);
+        Assert.Equal(selector, plan.MetricSelector);
+        Assert.Equal(ThresholdType.RawDifference, plan.ThresholdType);
+        Assert.Equal(5, plan.ThresholdValue);
+    }
+}

--- a/Validation.Tests/Validation.Tests.csproj
+++ b/Validation.Tests/Validation.Tests.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Validation.Domain\Validation.Domain.csproj" />
     <ProjectReference Include="..\Validation.Infrastructure\Validation.Infrastructure.csproj" />
+    <ProjectReference Include="..\ValidationFlow.Domain\ValidationFlow.Domain.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Validation.sln
+++ b/Validation.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Validation.Infrastructure",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Validation.Tests", "Validation.Tests\Validation.Tests.csproj", "{8E5CB3AA-8EDB-4DCD-97BC-F98B4DCDFEC9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ValidationFlow.Domain", "ValidationFlow.Domain\ValidationFlow.Domain.csproj", "{604E3775-D68D-4F97-BD30-AA09E7B9B8CA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -55,6 +57,18 @@ Global
 		{8E5CB3AA-8EDB-4DCD-97BC-F98B4DCDFEC9}.Release|x64.Build.0 = Release|Any CPU
 		{8E5CB3AA-8EDB-4DCD-97BC-F98B4DCDFEC9}.Release|x86.ActiveCfg = Release|Any CPU
 		{8E5CB3AA-8EDB-4DCD-97BC-F98B4DCDFEC9}.Release|x86.Build.0 = Release|Any CPU
+		{604E3775-D68D-4F97-BD30-AA09E7B9B8CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{604E3775-D68D-4F97-BD30-AA09E7B9B8CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{604E3775-D68D-4F97-BD30-AA09E7B9B8CA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{604E3775-D68D-4F97-BD30-AA09E7B9B8CA}.Debug|x64.Build.0 = Debug|Any CPU
+		{604E3775-D68D-4F97-BD30-AA09E7B9B8CA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{604E3775-D68D-4F97-BD30-AA09E7B9B8CA}.Debug|x86.Build.0 = Debug|Any CPU
+		{604E3775-D68D-4F97-BD30-AA09E7B9B8CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{604E3775-D68D-4F97-BD30-AA09E7B9B8CA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{604E3775-D68D-4F97-BD30-AA09E7B9B8CA}.Release|x64.ActiveCfg = Release|Any CPU
+		{604E3775-D68D-4F97-BD30-AA09E7B9B8CA}.Release|x64.Build.0 = Release|Any CPU
+		{604E3775-D68D-4F97-BD30-AA09E7B9B8CA}.Release|x86.ActiveCfg = Release|Any CPU
+		{604E3775-D68D-4F97-BD30-AA09E7B9B8CA}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ValidationFlow.Domain/Essentials.cs
+++ b/ValidationFlow.Domain/Essentials.cs
@@ -1,0 +1,11 @@
+namespace ValidationFlow.Domain;
+
+public record SaveAudit(string EntityType, Guid EntityId, decimal MetricValue, bool Validated, DateTime Timestamp);
+
+public enum ThresholdType
+{
+    RawDifference,
+    PercentChange
+}
+
+public record ValidationPlan<T>(Func<T, decimal> MetricSelector, ThresholdType ThresholdType, decimal ThresholdValue);

--- a/ValidationFlow.Domain/ValidationFlow.Domain.csproj
+++ b/ValidationFlow.Domain/ValidationFlow.Domain.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- add new ValidationFlow.Domain project with core record types
- create tests to validate SaveAudit and ValidationPlan behavior
- reference new project in test project

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688bda4815f88330a44902a350dc17ae