### PR TITLE
Add generic integration messages

### DIFF
--- a/Validation.Tests/MessagesTests.cs
+++ b/Validation.Tests/MessagesTests.cs
@@ -1,0 +1,55 @@
+using System.Text.Json;
+using ValidationFlow.Messages;
+
+namespace Validation.Tests;
+
+public class MessagesTests
+{
+    private record Payload(int Value);
+
+    [Fact]
+    public void SaveRequested_serializes_and_compares()
+    {
+        var message = new SaveRequested<Payload>("app", "item", Guid.NewGuid(), new Payload(1));
+        var clone = JsonSerializer.Deserialize<SaveRequested<Payload>>(JsonSerializer.Serialize(message));
+
+        Assert.Equal(message, clone);
+    }
+
+    [Fact]
+    public void SaveValidated_serializes_and_compares()
+    {
+        var message = new SaveValidated<Payload>("app", "item", Guid.NewGuid(), new Payload(2), true);
+        var clone = JsonSerializer.Deserialize<SaveValidated<Payload>>(JsonSerializer.Serialize(message));
+
+        Assert.Equal(message, clone);
+    }
+
+    [Fact]
+    public void SaveCommitFault_serializes_and_compares()
+    {
+        var message = new SaveCommitFault<Payload>("app", "item", Guid.NewGuid(), new Payload(3), "error");
+        var clone = JsonSerializer.Deserialize<SaveCommitFault<Payload>>(JsonSerializer.Serialize(message));
+
+        Assert.Equal(message, clone);
+    }
+
+    [Fact]
+    public void DeleteRequested_serializes_and_compares()
+    {
+        var message = new DeleteRequested("app", "item", Guid.NewGuid());
+        var clone = JsonSerializer.Deserialize<DeleteRequested>(JsonSerializer.Serialize(message));
+
+        Assert.Equal(message, clone);
+    }
+
+    [Fact]
+    public void DeleteValidated_serializes_and_compares()
+    {
+        var message = new DeleteValidated("app", "item", Guid.NewGuid());
+        var clone = JsonSerializer.Deserialize<DeleteValidated>(JsonSerializer.Serialize(message));
+
+        Assert.Equal(message, clone);
+    }
+}
+

--- a/Validation.Tests/Validation.Tests.csproj
+++ b/Validation.Tests/Validation.Tests.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Validation.Domain\Validation.Domain.csproj" />
     <ProjectReference Include="..\Validation.Infrastructure\Validation.Infrastructure.csproj" />
+    <ProjectReference Include="..\ValidationFlow.Messages\ValidationFlow.Messages.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Validation.sln
+++ b/Validation.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Validation.Infrastructure",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Validation.Tests", "Validation.Tests\Validation.Tests.csproj", "{8E5CB3AA-8EDB-4DCD-97BC-F98B4DCDFEC9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ValidationFlow.Messages", "ValidationFlow.Messages\ValidationFlow.Messages.csproj", "{92AE3BA9-BA0B-4A77-8646-B434FBD5164B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -55,6 +57,18 @@ Global
 		{8E5CB3AA-8EDB-4DCD-97BC-F98B4DCDFEC9}.Release|x64.Build.0 = Release|Any CPU
 		{8E5CB3AA-8EDB-4DCD-97BC-F98B4DCDFEC9}.Release|x86.ActiveCfg = Release|Any CPU
 		{8E5CB3AA-8EDB-4DCD-97BC-F98B4DCDFEC9}.Release|x86.Build.0 = Release|Any CPU
+		{92AE3BA9-BA0B-4A77-8646-B434FBD5164B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{92AE3BA9-BA0B-4A77-8646-B434FBD5164B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{92AE3BA9-BA0B-4A77-8646-B434FBD5164B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{92AE3BA9-BA0B-4A77-8646-B434FBD5164B}.Debug|x64.Build.0 = Debug|Any CPU
+		{92AE3BA9-BA0B-4A77-8646-B434FBD5164B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{92AE3BA9-BA0B-4A77-8646-B434FBD5164B}.Debug|x86.Build.0 = Debug|Any CPU
+		{92AE3BA9-BA0B-4A77-8646-B434FBD5164B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{92AE3BA9-BA0B-4A77-8646-B434FBD5164B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{92AE3BA9-BA0B-4A77-8646-B434FBD5164B}.Release|x64.ActiveCfg = Release|Any CPU
+		{92AE3BA9-BA0B-4A77-8646-B434FBD5164B}.Release|x64.Build.0 = Release|Any CPU
+		{92AE3BA9-BA0B-4A77-8646-B434FBD5164B}.Release|x86.ActiveCfg = Release|Any CPU
+		{92AE3BA9-BA0B-4A77-8646-B434FBD5164B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ValidationFlow.Messages/DeleteRequested.cs
+++ b/ValidationFlow.Messages/DeleteRequested.cs
@@ -1,0 +1,4 @@
+namespace ValidationFlow.Messages;
+
+public record DeleteRequested(string AppName, string EntityType, Guid EntityId);
+

--- a/ValidationFlow.Messages/DeleteValidated.cs
+++ b/ValidationFlow.Messages/DeleteValidated.cs
@@ -1,0 +1,4 @@
+namespace ValidationFlow.Messages;
+
+public record DeleteValidated(string AppName, string EntityType, Guid EntityId);
+

--- a/ValidationFlow.Messages/SaveCommitFault.cs
+++ b/ValidationFlow.Messages/SaveCommitFault.cs
@@ -1,0 +1,4 @@
+namespace ValidationFlow.Messages;
+
+public record SaveCommitFault<T>(string AppName, string EntityType, Guid EntityId, T Payload, string ErrorMessage);
+

--- a/ValidationFlow.Messages/SaveRequested.cs
+++ b/ValidationFlow.Messages/SaveRequested.cs
@@ -1,0 +1,4 @@
+namespace ValidationFlow.Messages;
+
+public record SaveRequested<T>(string AppName, string EntityType, Guid EntityId, T Payload);
+

--- a/ValidationFlow.Messages/SaveValidated.cs
+++ b/ValidationFlow.Messages/SaveValidated.cs
@@ -1,0 +1,4 @@
+namespace ValidationFlow.Messages;
+
+public record SaveValidated<T>(string AppName, string EntityType, Guid EntityId, T Payload, bool Validated);
+

--- a/ValidationFlow.Messages/ValidationFlow.Messages.csproj
+++ b/ValidationFlow.Messages/ValidationFlow.Messages.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- implement new ValidationFlow.Messages class library
- define SaveRequested, SaveValidated, SaveCommitFault, DeleteRequested and DeleteValidated records
- reference new library in tests and add unit tests validating serialization and equality

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688bda5f70d88330b23a94dfa54c0bc5