### PR TITLE
Add strongly typed messages

### DIFF
--- a/Validation.Tests/MessagesTests.cs
+++ b/Validation.Tests/MessagesTests.cs
@@ -1,0 +1,62 @@
+using System.Text.Json;
+using ValidationFlow.Messages;
+
+namespace Validation.Tests;
+
+public class MessagesTests
+{
+    [Fact]
+    public void SaveRequested_equality_and_serialization()
+    {
+        var id = Guid.NewGuid();
+        var m1 = new SaveRequested<string>("app", "entity", id, "payload");
+        var m2 = new SaveRequested<string>("app", "entity", id, "payload");
+        Assert.Equal(m1, m2);
+        var json = JsonSerializer.Serialize(m1);
+        Assert.False(string.IsNullOrWhiteSpace(json));
+    }
+
+    [Fact]
+    public void SaveValidated_equality_and_serialization()
+    {
+        var id = Guid.NewGuid();
+        var m1 = new SaveValidated<string>("app", "entity", id, "payload", true);
+        var m2 = new SaveValidated<string>("app", "entity", id, "payload", true);
+        Assert.Equal(m1, m2);
+        var json = JsonSerializer.Serialize(m1);
+        Assert.False(string.IsNullOrWhiteSpace(json));
+    }
+
+    [Fact]
+    public void SaveCommitFault_equality_and_serialization()
+    {
+        var id = Guid.NewGuid();
+        var m1 = new SaveCommitFault<string>("app", "entity", id, "payload", "error");
+        var m2 = new SaveCommitFault<string>("app", "entity", id, "payload", "error");
+        Assert.Equal(m1, m2);
+        var json = JsonSerializer.Serialize(m1);
+        Assert.False(string.IsNullOrWhiteSpace(json));
+    }
+
+    [Fact]
+    public void DeleteRequested_equality_and_serialization()
+    {
+        var id = Guid.NewGuid();
+        var m1 = new DeleteRequested<string>("app", "entity", id);
+        var m2 = new DeleteRequested<string>("app", "entity", id);
+        Assert.Equal(m1, m2);
+        var json = JsonSerializer.Serialize(m1);
+        Assert.False(string.IsNullOrWhiteSpace(json));
+    }
+
+    [Fact]
+    public void DeleteValidated_equality_and_serialization()
+    {
+        var id = Guid.NewGuid();
+        var m1 = new DeleteValidated<string>("app", "entity", id, true);
+        var m2 = new DeleteValidated<string>("app", "entity", id, true);
+        Assert.Equal(m1, m2);
+        var json = JsonSerializer.Serialize(m1);
+        Assert.False(string.IsNullOrWhiteSpace(json));
+    }
+}

--- a/Validation.Tests/Validation.Tests.csproj
+++ b/Validation.Tests/Validation.Tests.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Validation.Domain\Validation.Domain.csproj" />
     <ProjectReference Include="..\Validation.Infrastructure\Validation.Infrastructure.csproj" />
+    <ProjectReference Include="..\ValidationFlow.Messages\ValidationFlow.Messages.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Validation.sln
+++ b/Validation.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Validation.Infrastructure",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Validation.Tests", "Validation.Tests\Validation.Tests.csproj", "{8E5CB3AA-8EDB-4DCD-97BC-F98B4DCDFEC9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ValidationFlow.Messages", "ValidationFlow.Messages\ValidationFlow.Messages.csproj", "{84462E94-026D-46ED-A03D-9D8B021F135D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -55,6 +57,18 @@ Global
 		{8E5CB3AA-8EDB-4DCD-97BC-F98B4DCDFEC9}.Release|x64.Build.0 = Release|Any CPU
 		{8E5CB3AA-8EDB-4DCD-97BC-F98B4DCDFEC9}.Release|x86.ActiveCfg = Release|Any CPU
 		{8E5CB3AA-8EDB-4DCD-97BC-F98B4DCDFEC9}.Release|x86.Build.0 = Release|Any CPU
+		{84462E94-026D-46ED-A03D-9D8B021F135D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{84462E94-026D-46ED-A03D-9D8B021F135D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{84462E94-026D-46ED-A03D-9D8B021F135D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{84462E94-026D-46ED-A03D-9D8B021F135D}.Debug|x64.Build.0 = Debug|Any CPU
+		{84462E94-026D-46ED-A03D-9D8B021F135D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{84462E94-026D-46ED-A03D-9D8B021F135D}.Debug|x86.Build.0 = Debug|Any CPU
+		{84462E94-026D-46ED-A03D-9D8B021F135D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{84462E94-026D-46ED-A03D-9D8B021F135D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{84462E94-026D-46ED-A03D-9D8B021F135D}.Release|x64.ActiveCfg = Release|Any CPU
+		{84462E94-026D-46ED-A03D-9D8B021F135D}.Release|x64.Build.0 = Release|Any CPU
+		{84462E94-026D-46ED-A03D-9D8B021F135D}.Release|x86.ActiveCfg = Release|Any CPU
+		{84462E94-026D-46ED-A03D-9D8B021F135D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ValidationFlow.Messages/IntegrationMessages.cs
+++ b/ValidationFlow.Messages/IntegrationMessages.cs
@@ -1,0 +1,16 @@
+namespace ValidationFlow.Messages;
+
+[System.Serializable]
+public record SaveRequested<T>(string AppName, string EntityType, Guid EntityId, T Payload);
+
+[System.Serializable]
+public record SaveValidated<T>(string AppName, string EntityType, Guid EntityId, T Payload, bool Validated);
+
+[System.Serializable]
+public record SaveCommitFault<T>(string AppName, string EntityType, Guid EntityId, T Payload, string ErrorMessage);
+
+[System.Serializable]
+public record DeleteRequested<T>(string AppName, string EntityType, Guid EntityId);
+
+[System.Serializable]
+public record DeleteValidated<T>(string AppName, string EntityType, Guid EntityId, bool Validated);

--- a/ValidationFlow.Messages/ValidationFlow.Messages.csproj
+++ b/ValidationFlow.Messages/ValidationFlow.Messages.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- add new ValidationFlow.Messages project
- define Save and Delete message types
- reference new messages from tests and verify serialization

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688bda5f70d88330b23a94dfa54c0bc5