### PR TITLE
Add ValidationFlow messages

### DIFF
--- a/Validation.Tests/MessageTests.cs
+++ b/Validation.Tests/MessageTests.cs
@@ -1,0 +1,34 @@
+using System.Text.Json;
+using ValidationFlow.Messages;
+
+namespace Validation.Tests;
+
+public class MessageTests
+{
+    [Fact]
+    public void SaveRequested_round_trips_via_json()
+    {
+        var message = new SaveRequested<string>("app", "Item", Guid.NewGuid(), "payload");
+        var json = JsonSerializer.Serialize(message);
+        var result = JsonSerializer.Deserialize<SaveRequested<string>>(json);
+        Assert.Equal(message, result);
+    }
+
+    [Fact]
+    public void SaveValidated_round_trips_via_json()
+    {
+        var message = new SaveValidated<string>("app", "Item", Guid.NewGuid(), "payload", true);
+        var json = JsonSerializer.Serialize(message);
+        var result = JsonSerializer.Deserialize<SaveValidated<string>>(json);
+        Assert.Equal(message, result);
+    }
+
+    [Fact]
+    public void DeleteRequested_round_trips_via_json()
+    {
+        var message = new DeleteRequested<string>("app", "Item", Guid.NewGuid());
+        var json = JsonSerializer.Serialize(message);
+        var result = JsonSerializer.Deserialize<DeleteRequested<string>>(json);
+        Assert.Equal(message, result);
+    }
+}

--- a/Validation.Tests/Validation.Tests.csproj
+++ b/Validation.Tests/Validation.Tests.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Validation.Domain\Validation.Domain.csproj" />
     <ProjectReference Include="..\Validation.Infrastructure\Validation.Infrastructure.csproj" />
+    <ProjectReference Include="..\ValidationFlow.Messages\ValidationFlow.Messages.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Validation.sln
+++ b/Validation.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Validation.Infrastructure",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Validation.Tests", "Validation.Tests\Validation.Tests.csproj", "{8E5CB3AA-8EDB-4DCD-97BC-F98B4DCDFEC9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ValidationFlow.Messages", "ValidationFlow.Messages\ValidationFlow.Messages.csproj", "{E5920BAE-39BC-457F-874F-332D287F300B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -55,6 +57,18 @@ Global
 		{8E5CB3AA-8EDB-4DCD-97BC-F98B4DCDFEC9}.Release|x64.Build.0 = Release|Any CPU
 		{8E5CB3AA-8EDB-4DCD-97BC-F98B4DCDFEC9}.Release|x86.ActiveCfg = Release|Any CPU
 		{8E5CB3AA-8EDB-4DCD-97BC-F98B4DCDFEC9}.Release|x86.Build.0 = Release|Any CPU
+		{E5920BAE-39BC-457F-874F-332D287F300B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E5920BAE-39BC-457F-874F-332D287F300B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E5920BAE-39BC-457F-874F-332D287F300B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E5920BAE-39BC-457F-874F-332D287F300B}.Debug|x64.Build.0 = Debug|Any CPU
+		{E5920BAE-39BC-457F-874F-332D287F300B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E5920BAE-39BC-457F-874F-332D287F300B}.Debug|x86.Build.0 = Debug|Any CPU
+		{E5920BAE-39BC-457F-874F-332D287F300B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E5920BAE-39BC-457F-874F-332D287F300B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E5920BAE-39BC-457F-874F-332D287F300B}.Release|x64.ActiveCfg = Release|Any CPU
+		{E5920BAE-39BC-457F-874F-332D287F300B}.Release|x64.Build.0 = Release|Any CPU
+		{E5920BAE-39BC-457F-874F-332D287F300B}.Release|x86.ActiveCfg = Release|Any CPU
+		{E5920BAE-39BC-457F-874F-332D287F300B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ValidationFlow.Messages/SaveMessages.cs
+++ b/ValidationFlow.Messages/SaveMessages.cs
@@ -1,0 +1,32 @@
+using System;
+namespace ValidationFlow.Messages;
+
+/// <summary>
+/// Request to persist an entity payload.
+/// </summary>
+[Serializable]
+public sealed record SaveRequested<T>(string AppName, string EntityType, Guid EntityId, T Payload);
+
+/// <summary>
+/// Notification that a save request has been validated.
+/// </summary>
+[Serializable]
+public sealed record SaveValidated<T>(string AppName, string EntityType, Guid EntityId, T Payload, bool Validated);
+
+/// <summary>
+/// Notification that committing a save request failed.
+/// </summary>
+[Serializable]
+public sealed record SaveCommitFault<T>(string AppName, string EntityType, Guid EntityId, T Payload, string ErrorMessage);
+
+/// <summary>
+/// Request to delete an entity.
+/// </summary>
+[Serializable]
+public sealed record DeleteRequested<T>(string AppName, string EntityType, Guid EntityId);
+
+/// <summary>
+/// Notification that a delete request has been validated.
+/// </summary>
+[Serializable]
+public sealed record DeleteValidated<T>(string AppName, string EntityType, Guid EntityId);

--- a/ValidationFlow.Messages/ValidationFlow.Messages.csproj
+++ b/ValidationFlow.Messages/ValidationFlow.Messages.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- add a new `ValidationFlow.Messages` library for strongly typed messages
- define integration message records for save and delete operations
- include new library in the solution and test project
- add unit tests covering message serialization round‑trips

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688bda5f70d88330b23a94dfa54c0bc5