### PR TITLE
Add event publishing repository

### DIFF
--- a/Validation.Domain/Events/SaveRequested.generic.cs
+++ b/Validation.Domain/Events/SaveRequested.generic.cs
@@ -1,0 +1,3 @@
+namespace Validation.Domain.Events;
+
+public record SaveRequested<T>(T Entity, string? App = null);

--- a/Validation.Infrastructure/Repositories/EventPublishingRepository.cs
+++ b/Validation.Infrastructure/Repositories/EventPublishingRepository.cs
@@ -1,0 +1,24 @@
+using MassTransit;
+using Validation.Domain.Events;
+
+namespace Validation.Infrastructure.Repositories;
+
+public class EventPublishingRepository<T> : IEntityRepository<T>
+{
+    private readonly IBus _bus;
+
+    public EventPublishingRepository(IBus bus)
+    {
+        _bus = bus;
+    }
+
+    public Task SaveAsync(T entity, string? app = null, CancellationToken ct = default)
+    {
+        return _bus.Publish(new SaveRequested<T>(entity, app), ct);
+    }
+
+    public Task DeleteAsync(Guid id, string? app = null, CancellationToken ct = default)
+    {
+        return _bus.Publish(new DeleteRequested(id), ct);
+    }
+}

--- a/Validation.Infrastructure/Repositories/IEntityRepository.cs
+++ b/Validation.Infrastructure/Repositories/IEntityRepository.cs
@@ -1,0 +1,7 @@
+namespace Validation.Infrastructure.Repositories;
+
+public interface IEntityRepository<T>
+{
+    Task SaveAsync(T entity, string? app = null, CancellationToken ct = default);
+    Task DeleteAsync(Guid id, string? app = null, CancellationToken ct = default);
+}

--- a/Validation.Tests/EventPublishingRepositoryTests.cs
+++ b/Validation.Tests/EventPublishingRepositoryTests.cs
@@ -1,0 +1,28 @@
+using MassTransit;
+using MassTransit.Testing;
+using Validation.Domain.Events;
+using Validation.Domain.Entities;
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Tests;
+
+public class EventPublishingRepositoryTests
+{
+    [Fact]
+    public async Task SaveAsync_publishes_SaveRequested_event()
+    {
+        var harness = new InMemoryTestHarness();
+        await harness.Start();
+        try
+        {
+            var repo = new EventPublishingRepository<Item>(harness.Bus);
+            var item = new Item(10m);
+            await repo.SaveAsync(item);
+            Assert.True(await harness.Published.Any<SaveRequested<Item>>());
+        }
+        finally
+        {
+            await harness.Stop();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- define `IEntityRepository<T>` for Save/Delete
- publish `SaveRequested<T>` events via `EventPublishingRepository<T>`
- add unit test for event publishing

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688bda6613308330a95fcd8c849a5498