### PR TITLE
Implement event publishing repository

### DIFF
--- a/Validation.Domain/Events/SaveRequested.Generic.cs
+++ b/Validation.Domain/Events/SaveRequested.Generic.cs
@@ -1,0 +1,3 @@
+namespace Validation.Domain.Events;
+
+public record SaveRequested<T>(T Entity, string? App = null);

--- a/Validation.Domain/Repositories/IEntityRepository.cs
+++ b/Validation.Domain/Repositories/IEntityRepository.cs
@@ -1,0 +1,7 @@
+namespace Validation.Domain.Repositories;
+
+public interface IEntityRepository<T>
+{
+    Task SaveAsync(T entity, string? app = null, CancellationToken ct = default);
+    Task DeleteAsync(Guid id, string? app = null, CancellationToken ct = default);
+}

--- a/Validation.Infrastructure/Repositories/EventPublishingRepository.cs
+++ b/Validation.Infrastructure/Repositories/EventPublishingRepository.cs
@@ -1,0 +1,25 @@
+using MassTransit;
+using Validation.Domain.Events;
+using Validation.Domain.Repositories;
+
+namespace Validation.Infrastructure.Repositories;
+
+public class EventPublishingRepository<T> : IEntityRepository<T>
+{
+    private readonly IBus _bus;
+
+    public EventPublishingRepository(IBus bus)
+    {
+        _bus = bus;
+    }
+
+    public Task SaveAsync(T entity, string? app = null, CancellationToken ct = default)
+    {
+        return _bus.Publish(new SaveRequested<T>(entity, app), ct);
+    }
+
+    public Task DeleteAsync(Guid id, string? app = null, CancellationToken ct = default)
+    {
+        return _bus.Publish(new DeleteRequested(id), ct);
+    }
+}

--- a/Validation.Tests/EventPublishingRepositoryTests.cs
+++ b/Validation.Tests/EventPublishingRepositoryTests.cs
@@ -1,0 +1,47 @@
+using MassTransit.Testing;
+using Validation.Domain.Entities;
+using Validation.Domain.Events;
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Tests;
+
+public class EventPublishingRepositoryTests
+{
+    [Fact]
+    public async Task SaveAsync_publishes_event()
+    {
+        var harness = new InMemoryTestHarness();
+
+        await harness.Start();
+        try
+        {
+            var repository = new EventPublishingRepository<Item>(harness.Bus);
+            var item = new Item(5);
+            await repository.SaveAsync(item);
+            Assert.True(await harness.Published.Any<SaveRequested<Item>>());
+        }
+        finally
+        {
+            await harness.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task DeleteAsync_publishes_event()
+    {
+        var harness = new InMemoryTestHarness();
+
+        await harness.Start();
+        try
+        {
+            var repository = new EventPublishingRepository<Item>(harness.Bus);
+            var id = Guid.NewGuid();
+            await repository.DeleteAsync(id);
+            Assert.True(await harness.Published.Any<DeleteRequested>());
+        }
+        finally
+        {
+            await harness.Stop();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- define `IEntityRepository` in domain
- add generic `SaveRequested<T>` event
- implement `EventPublishingRepository<T>` to publish Save and Delete events
- test event publishing repository

## Testing
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_688bda6613308330a95fcd8c849a5498