### PR TITLE
Add event publishing repository

### DIFF
--- a/Validation.Domain/Entities/Item.cs
+++ b/Validation.Domain/Entities/Item.cs
@@ -10,13 +10,13 @@ public class Item : EntityWithEvents
     public Item(decimal metric)
     {
         Metric = metric;
-        AddEvent(new SaveRequested(Id));
+        AddEvent(new SaveRequested<Item>(Id));
     }
 
     public void UpdateMetric(decimal metric)
     {
         Metric = metric;
-        AddEvent(new SaveRequested(Id));
+        AddEvent(new SaveRequested<Item>(Id));
     }
 
     public void Delete()

--- a/Validation.Domain/Events/SaveRequested.cs
+++ b/Validation.Domain/Events/SaveRequested.cs
@@ -1,3 +1,3 @@
 namespace Validation.Domain.Events;
 
-public record SaveRequested(Guid Id);
+public record SaveRequested<T>(Guid Id, string? App = null);

--- a/Validation.Infrastructure/Messaging/SaveRequestedConsumer.cs
+++ b/Validation.Infrastructure/Messaging/SaveRequestedConsumer.cs
@@ -6,7 +6,7 @@ using Validation.Infrastructure;
 
 namespace Validation.Infrastructure.Messaging;
 
-public class SaveRequestedConsumer : IConsumer<SaveRequested>
+public class SaveRequestedConsumer<T> : IConsumer<SaveRequested<T>>
 {
     private readonly ISaveAuditRepository _repository;
     private readonly IValidationRule _rule;
@@ -18,7 +18,7 @@ public class SaveRequestedConsumer : IConsumer<SaveRequested>
         _rule = rule;
     }
 
-    public async Task Consume(ConsumeContext<SaveRequested> context)
+    public async Task Consume(ConsumeContext<SaveRequested<T>> context)
     {
         var metric = new Random().Next(0, 100); // simulate metric
         var isValid = _rule.Validate(_previousMetric, metric);

--- a/Validation.Infrastructure/Repositories/EventPublishingRepository.cs
+++ b/Validation.Infrastructure/Repositories/EventPublishingRepository.cs
@@ -1,0 +1,28 @@
+using MassTransit;
+using Validation.Domain.Events;
+
+namespace Validation.Infrastructure.Repositories;
+
+public class EventPublishingRepository<T> : IEntityRepository<T>
+{
+    private readonly IBus _bus;
+
+    public EventPublishingRepository(IBus bus)
+    {
+        _bus = bus;
+    }
+
+    public Task SaveAsync(T entity, string? app = null)
+    {
+        var idProp = entity?.GetType().GetProperty("Id");
+        if (idProp == null || idProp.PropertyType != typeof(Guid))
+            throw new InvalidOperationException("Entity must have Id property of type Guid");
+        var id = (Guid)(idProp.GetValue(entity)!);
+        return _bus.Publish(new SaveRequested<T>(id, app));
+    }
+
+    public Task DeleteAsync(Guid id, string? app = null)
+    {
+        return _bus.Publish(new DeleteRequested(id));
+    }
+}

--- a/Validation.Infrastructure/Repositories/IEntityRepository.cs
+++ b/Validation.Infrastructure/Repositories/IEntityRepository.cs
@@ -1,0 +1,7 @@
+namespace Validation.Infrastructure.Repositories;
+
+public interface IEntityRepository<T>
+{
+    Task SaveAsync(T entity, string? app = null);
+    Task DeleteAsync(Guid id, string? app = null);
+}

--- a/Validation.Infrastructure/Validation.Infrastructure.csproj
+++ b/Validation.Infrastructure/Validation.Infrastructure.csproj
@@ -5,7 +5,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MassTransit" Version="8.0.8" />
+    <PackageReference Include="MassTransit" Version="9.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0-preview.4.23259.5" />
     <PackageReference Include="MongoDB.Driver" Version="2.19.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.4.0-rc9" />

--- a/Validation.Tests/EventPublishingRepositoryTests.cs
+++ b/Validation.Tests/EventPublishingRepositoryTests.cs
@@ -1,0 +1,27 @@
+using MassTransit.Testing;
+using Validation.Domain.Entities;
+using Validation.Domain.Events;
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Tests;
+
+public class EventPublishingRepositoryTests
+{
+    [Fact]
+    public async Task Save_async_publishes_SaveRequested_event()
+    {
+        var harness = new InMemoryTestHarness();
+        var repo = new EventPublishingRepository<Item>(harness.Bus);
+        await harness.Start();
+        try
+        {
+            var item = new Item(10);
+            await repo.SaveAsync(item);
+            Assert.True(await harness.Published.Any<SaveRequested<Item>>());
+        }
+        finally
+        {
+            await harness.Stop();
+        }
+    }
+}

--- a/Validation.Tests/Validation.Tests.csproj
+++ b/Validation.Tests/Validation.Tests.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
-    <PackageReference Include="MassTransit.TestFramework" Version="8.0.8" />
+    <PackageReference Include="MassTransit.TestFramework" Version="9.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/Validation.Tests/ValidationWorkflowTests.cs
+++ b/Validation.Tests/ValidationWorkflowTests.cs
@@ -3,6 +3,7 @@ using MassTransit.Testing;
 using Validation.Domain.Events;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.Messaging;
+using Validation.Domain.Entities;
 
 namespace Validation.Tests;
 
@@ -13,16 +14,16 @@ public class ValidationWorkflowTests
     {
         var repository = new InMemorySaveAuditRepository();
         var rule = new RawDifferenceRule(100); // always valid
-        var consumer = new SaveRequestedConsumer(repository, rule);
+        var consumer = new SaveRequestedConsumer<Item>(repository, rule);
 
         var harness = new InMemoryTestHarness();
         var consumerHarness = harness.Consumer(() => consumer);
         await harness.Start();
         try
         {
-            await harness.InputQueueSendEndpoint.Send(new SaveRequested(Guid.NewGuid()));
-            Assert.True(await harness.Consumed.Any<SaveRequested>());
-            Assert.True(await consumerHarness.Consumed.Any<SaveRequested>());
+            await harness.InputQueueSendEndpoint.Send(new SaveRequested<Item>(Guid.NewGuid()));
+            Assert.True(await harness.Consumed.Any<SaveRequested<Item>>());
+            Assert.True(await consumerHarness.Consumed.Any<SaveRequested<Item>>());
             Assert.Single(repository.Audits);
         }
         finally


### PR DESCRIPTION
## Summary
- introduce `IEntityRepository<T>` for saving and deleting entities
- implement `EventPublishingRepository<T>` to publish entity events via `IBus`
- make `SaveRequested` generic and update `Item` and consumer
- bump MassTransit packages to `9.1.0`
- update workflow and new tests for publishing repository

## Testing
- `dotnet test --verbosity normal` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_688bda6613308330a95fcd8c849a5498