### PR TITLE
Add validation consumers workflow

### DIFF
--- a/Validation.Domain/Events/SaveCommitFault.cs
+++ b/Validation.Domain/Events/SaveCommitFault.cs
@@ -1,0 +1,3 @@
+namespace Validation.Domain.Events;
+
+public record SaveCommitFault<T>(Guid Id);

--- a/Validation.Domain/Events/SaveValidated.cs
+++ b/Validation.Domain/Events/SaveValidated.cs
@@ -1,0 +1,3 @@
+namespace Validation.Domain.Events;
+
+public record SaveValidated<T>(Guid Id);

--- a/Validation.Infrastructure/Messaging/DeleteValidationConsumer.cs
+++ b/Validation.Infrastructure/Messaging/DeleteValidationConsumer.cs
@@ -1,0 +1,32 @@
+using MassTransit;
+using Validation.Domain.Events;
+using Validation.Infrastructure.Services;
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Infrastructure.Messaging;
+
+public class DeleteValidationConsumer<T> : IConsumer<DeleteRequested>
+{
+    private readonly IValidationPlanProvider _planProvider;
+    private readonly ISaveAuditRepository _repository;
+    private readonly SummarisationValidator _validator;
+
+    public DeleteValidationConsumer(
+        IValidationPlanProvider planProvider,
+        ISaveAuditRepository repository,
+        SummarisationValidator validator)
+    {
+        _planProvider = planProvider;
+        _repository = repository;
+        _validator = validator;
+    }
+
+    public async Task Consume(ConsumeContext<DeleteRequested> context)
+    {
+        var lastAudit = await _repository.GetLastForEntityAsync(context.Message.Id, context.CancellationToken);
+        var metric = lastAudit?.Metric ?? 0m;
+        var plan = _planProvider.GetPlan<T>();
+        _ = _validator.Validate(metric, metric, plan);
+        await _repository.DeleteAsync(context.Message.Id, context.CancellationToken);
+    }
+}

--- a/Validation.Infrastructure/Messaging/SaveCommitConsumer.cs
+++ b/Validation.Infrastructure/Messaging/SaveCommitConsumer.cs
@@ -1,0 +1,31 @@
+using MassTransit;
+using Validation.Domain.Events;
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Infrastructure.Messaging;
+
+public class SaveCommitConsumer<T> : IConsumer<SaveValidated<T>>
+{
+    private readonly ISaveAuditRepository _repository;
+
+    public SaveCommitConsumer(ISaveAuditRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task Consume(ConsumeContext<SaveValidated<T>> context)
+    {
+        try
+        {
+            var audit = await _repository.GetLastForEntityAsync(context.Message.Id, context.CancellationToken);
+            if (audit != null)
+            {
+                await _repository.UpdateAsync(audit, context.CancellationToken);
+            }
+        }
+        catch
+        {
+            await context.Publish(new SaveCommitFault<T>(context.Message.Id));
+        }
+    }
+}

--- a/Validation.Infrastructure/Messaging/SaveValidationConsumer.cs
+++ b/Validation.Infrastructure/Messaging/SaveValidationConsumer.cs
@@ -1,0 +1,45 @@
+using MassTransit;
+using Validation.Domain.Events;
+using Validation.Infrastructure.Services;
+using Validation.Domain.Validation;
+using Validation.Infrastructure.Repositories;
+using Validation.Infrastructure;
+
+namespace Validation.Infrastructure.Messaging;
+
+public class SaveValidationConsumer<T> : IConsumer<SaveRequested>
+{
+    private readonly IValidationPlanProvider _planProvider;
+    private readonly ISaveAuditRepository _repository;
+    private readonly SummarisationValidator _validator;
+
+    public SaveValidationConsumer(
+        IValidationPlanProvider planProvider,
+        ISaveAuditRepository repository,
+        SummarisationValidator validator)
+    {
+        _planProvider = planProvider;
+        _repository = repository;
+        _validator = validator;
+    }
+
+    public async Task Consume(ConsumeContext<SaveRequested> context)
+    {
+        var lastAudit = await _repository.GetLastForEntityAsync(context.Message.Id, context.CancellationToken);
+        var previousMetric = lastAudit?.Metric ?? 0m;
+        var metric = new Random().Next(0, 100); // simulate metric generation
+
+        var plan = _planProvider.GetPlan<T>();
+        var isValid = _validator.Validate(previousMetric, metric, plan);
+
+        var audit = new SaveAudit
+        {
+            Id = Guid.NewGuid(),
+            EntityId = context.Message.Id,
+            IsValid = isValid,
+            Metric = metric
+        };
+        await _repository.AddAsync(audit, context.CancellationToken);
+        await context.Publish(new SaveValidated<T>(context.Message.Id));
+    }
+}

--- a/Validation.Infrastructure/Repositories/EfCoreSaveAuditRepository.cs
+++ b/Validation.Infrastructure/Repositories/EfCoreSaveAuditRepository.cs
@@ -40,4 +40,11 @@ public class EfCoreSaveAuditRepository : ISaveAuditRepository
         _set.Update(entity);
         await _context.SaveChangesAsync(ct);
     }
+
+    public async Task<SaveAudit?> GetLastForEntityAsync(Guid entityId, CancellationToken ct = default)
+    {
+        return await _set.Where(x => x.EntityId == entityId)
+            .OrderByDescending(x => x.Timestamp)
+            .FirstOrDefaultAsync(ct);
+    }
 }

--- a/Validation.Infrastructure/Repositories/ISaveAuditRepository.cs
+++ b/Validation.Infrastructure/Repositories/ISaveAuditRepository.cs
@@ -2,4 +2,5 @@ namespace Validation.Infrastructure.Repositories;
 
 public interface ISaveAuditRepository : IRepository<SaveAudit>
 {
+    Task<SaveAudit?> GetLastForEntityAsync(Guid entityId, CancellationToken ct = default);
 }

--- a/Validation.Infrastructure/Repositories/MongoSaveAuditRepository.cs
+++ b/Validation.Infrastructure/Repositories/MongoSaveAuditRepository.cs
@@ -31,4 +31,12 @@ public class MongoSaveAuditRepository : ISaveAuditRepository
     {
         await _collection.ReplaceOneAsync(x => x.Id == entity.Id, entity, cancellationToken: ct);
     }
+
+    public async Task<SaveAudit?> GetLastForEntityAsync(Guid entityId, CancellationToken ct = default)
+    {
+        return await _collection
+            .Find(x => x.EntityId == entityId)
+            .SortByDescending(x => x.Timestamp)
+            .FirstOrDefaultAsync(ct);
+    }
 }

--- a/Validation.Infrastructure/Services/IValidationPlanProvider.cs
+++ b/Validation.Infrastructure/Services/IValidationPlanProvider.cs
@@ -1,0 +1,9 @@
+namespace Validation.Infrastructure.Services;
+
+using System.Collections.Generic;
+using Validation.Domain.Validation;
+
+public interface IValidationPlanProvider
+{
+    IEnumerable<IValidationRule> GetPlan<T>();
+}

--- a/Validation.Infrastructure/Services/SummarisationValidator.cs
+++ b/Validation.Infrastructure/Services/SummarisationValidator.cs
@@ -1,0 +1,17 @@
+namespace Validation.Infrastructure.Services;
+
+using System.Collections.Generic;
+using Validation.Domain.Validation;
+
+public class SummarisationValidator
+{
+    public bool Validate(decimal previousMetric, decimal newMetric, IEnumerable<IValidationRule> rules)
+    {
+        foreach (var rule in rules)
+        {
+            if (!rule.Validate(previousMetric, newMetric))
+                return false;
+        }
+        return true;
+    }
+}

--- a/Validation.Tests/InMemorySaveAuditRepository.cs
+++ b/Validation.Tests/InMemorySaveAuditRepository.cs
@@ -30,4 +30,13 @@ public class InMemorySaveAuditRepository : ISaveAuditRepository
         if (index >= 0) Audits[index] = entity;
         return Task.CompletedTask;
     }
+
+    public Task<SaveAudit?> GetLastForEntityAsync(Guid entityId, CancellationToken ct = default)
+    {
+        var audit = Audits
+            .Where(a => a.EntityId == entityId)
+            .OrderByDescending(a => a.Timestamp)
+            .FirstOrDefault();
+        return Task.FromResult<SaveAudit?>(audit);
+    }
 }

--- a/Validation.Tests/NewValidationConsumersTests.cs
+++ b/Validation.Tests/NewValidationConsumersTests.cs
@@ -1,0 +1,79 @@
+using MassTransit;
+using MassTransit.Testing;
+using Validation.Domain.Entities;
+using Validation.Domain.Events;
+using Validation.Infrastructure.Services;
+using Validation.Domain.Validation;
+using Validation.Infrastructure.Messaging;
+using Validation.Infrastructure.Repositories;
+using Validation.Infrastructure;
+
+namespace Validation.Tests;
+
+public class NewValidationConsumersTests
+{
+    private class PlanProvider : IValidationPlanProvider
+    {
+        public IEnumerable<IValidationRule> GetPlan<T>()
+        {
+            yield return new RawDifferenceRule(100); // always valid
+        }
+    }
+
+    private class FailingRepository : ISaveAuditRepository
+    {
+        public Task AddAsync(SaveAudit entity, CancellationToken ct = default) => Task.CompletedTask;
+        public Task DeleteAsync(Guid id, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<SaveAudit?> GetAsync(Guid id, CancellationToken ct = default) => Task.FromResult<SaveAudit?>(null);
+        public Task<SaveAudit?> GetLastForEntityAsync(Guid entityId, CancellationToken ct = default)
+        {
+            return Task.FromResult<SaveAudit?>(new SaveAudit { Id = Guid.NewGuid(), EntityId = entityId });
+        }
+        public Task UpdateAsync(SaveAudit entity, CancellationToken ct = default) => throw new Exception("fail");
+    }
+
+    [Fact]
+    public async Task SaveValidationConsumer_publishes_SaveValidated()
+    {
+        var repository = new InMemorySaveAuditRepository();
+        var planProvider = new PlanProvider();
+        var validator = new SummarisationValidator();
+        var consumer = new SaveValidationConsumer<Item>(planProvider, repository, validator);
+
+        var harness = new InMemoryTestHarness();
+        var consumerHarness = harness.Consumer(() => consumer);
+        await harness.Start();
+        try
+        {
+            var id = Guid.NewGuid();
+            await harness.InputQueueSendEndpoint.Send(new SaveRequested(id));
+            Assert.True(await consumerHarness.Consumed.Any<SaveRequested>());
+            Assert.True(await harness.Published.Any<SaveValidated<Item>>());
+            Assert.Single(repository.Audits);
+        }
+        finally
+        {
+            await harness.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task SaveCommitConsumer_publishes_fault_on_error()
+    {
+        var repository = new FailingRepository();
+        var consumer = new SaveCommitConsumer<Item>(repository);
+        var harness = new InMemoryTestHarness();
+        var consumerHarness = harness.Consumer(() => consumer);
+        await harness.Start();
+        try
+        {
+            await harness.InputQueueSendEndpoint.Send(new SaveValidated<Item>(Guid.NewGuid()));
+            Assert.True(await consumerHarness.Consumed.Any<SaveValidated<Item>>());
+            Assert.True(await harness.Published.Any<SaveCommitFault<Item>>());
+        }
+        finally
+        {
+            await harness.Stop();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `SaveValidated<T>` and `SaveCommitFault<T>` events
- extend save audit repositories with a query for the last audit by entity
- implement `SaveValidationConsumer<T>`, `SaveCommitConsumer<T>` and `DeleteValidationConsumer<T>`
- add validation services
- test the new MassTransit consumer workflow

## Testing
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_688bda6de6cc8330bc2c0b29b6e4c910