### PR TITLE
Implement DI helpers and integration flow

### DIFF
--- a/Validation.Domain/Events/SaveValidated.cs
+++ b/Validation.Domain/Events/SaveValidated.cs
@@ -1,0 +1,3 @@
+namespace Validation.Domain.Events;
+
+public record SaveValidated(Guid Id, bool IsValid, decimal Metric);

--- a/Validation.Infrastructure/DI/ValidationFlowBuilder.cs
+++ b/Validation.Infrastructure/DI/ValidationFlowBuilder.cs
@@ -1,0 +1,13 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Validation.Infrastructure.DI;
+
+public class ValidationFlowBuilder
+{
+    public IServiceCollection Services { get; }
+
+    public ValidationFlowBuilder(IServiceCollection services)
+    {
+        Services = services;
+    }
+}

--- a/Validation.Infrastructure/DI/ValidationFlowExtensions.cs
+++ b/Validation.Infrastructure/DI/ValidationFlowExtensions.cs
@@ -1,0 +1,54 @@
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Driver;
+using OpenTelemetry.Trace;
+using Serilog;
+using Validation.Domain.Validation;
+using Validation.Infrastructure.Messaging;
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Infrastructure.DI;
+
+public static class ValidationFlowExtensions
+{
+    public static IServiceCollection AddValidationFlow<TRule>(
+        this IServiceCollection services,
+        Action<ValidationFlowBuilder>? configure = null)
+        where TRule : class, IValidationRule
+    {
+        var builder = new ValidationFlowBuilder(services);
+        configure?.Invoke(builder);
+
+        services.AddMassTransit(x =>
+        {
+            x.AddConsumer<SaveRequestedConsumer>();
+            x.UsingInMemory((context, cfg) => cfg.ConfigureEndpoints(context));
+        });
+
+        services.AddLogging(b => b.AddSerilog());
+        services.AddOpenTelemetry().WithTracing(b => b.AddAspNetCoreInstrumentation());
+
+        return services;
+    }
+
+    public static ValidationFlowBuilder SetupDatabase<TContext>(
+        this ValidationFlowBuilder builder, string connectionString)
+        where TContext : DbContext
+    {
+        builder.Services.AddDbContext<TContext>(o => o.UseInMemoryDatabase(connectionString));
+        builder.Services.AddScoped<DbContext>(sp => sp.GetRequiredService<TContext>());
+        builder.Services.AddScoped<ISaveAuditRepository, EfCoreSaveAuditRepository>();
+        return builder;
+    }
+
+    public static ValidationFlowBuilder SetupMongoDatabase(
+        this ValidationFlowBuilder builder, string connectionString, string dbName)
+    {
+        var client = new MongoClient(connectionString);
+        builder.Services.AddSingleton<IMongoClient>(client);
+        builder.Services.AddSingleton(client.GetDatabase(dbName));
+        builder.Services.AddScoped<ISaveAuditRepository, MongoSaveAuditRepository>();
+        return builder;
+    }
+}

--- a/Validation.Infrastructure/Messaging/SaveRequestedConsumer.cs
+++ b/Validation.Infrastructure/Messaging/SaveRequestedConsumer.cs
@@ -31,5 +31,6 @@ public class SaveRequestedConsumer : IConsumer<SaveRequested>
             Metric = metric
         };
         await _repository.AddAsync(audit, context.CancellationToken);
+        await context.Publish(new SaveValidated(context.Message.Id, isValid, metric));
     }
 }

--- a/Validation.Infrastructure/Validation.Infrastructure.csproj
+++ b/Validation.Infrastructure/Validation.Infrastructure.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="MassTransit" Version="8.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0-preview.4.23259.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0-preview.4.23259.5" />
     <PackageReference Include="MongoDB.Driver" Version="2.19.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.4.0-rc9" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9" />

--- a/Validation.Tests/DependencyInjectionTests.cs
+++ b/Validation.Tests/DependencyInjectionTests.cs
@@ -1,0 +1,68 @@
+using MassTransit;
+using MassTransit.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Validation.Domain.Events;
+using Validation.Domain.Validation;
+using Validation.Infrastructure;
+using Validation.Infrastructure.DI;
+using Validation.Infrastructure.Messaging;
+
+namespace Validation.Tests;
+
+public class DependencyInjectionTests
+{
+    private class TestDbContext : DbContext
+    {
+        public TestDbContext(DbContextOptions<TestDbContext> options) : base(options) {}
+        public DbSet<SaveAudit> SaveAudits => Set<SaveAudit>();
+    }
+
+    private class SaveValidatedHandler : IConsumer<SaveValidated>
+    {
+        public TaskCompletionSource<SaveValidated> Source { get; } = new();
+        public Task Consume(ConsumeContext<SaveValidated> context)
+        {
+            Source.TrySetResult(context.Message);
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task Validation_flow_wires_up_dependencies_and_emits_event()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IValidationRule>(new RawDifferenceRule(100));
+        services.AddValidationFlow<RawDifferenceRule>(builder =>
+        {
+            builder.SetupDatabase<TestDbContext>("testdb");
+        });
+
+        await using var provider = services.BuildServiceProvider(true);
+
+        await using var scope = provider.CreateAsyncScope();
+        var consumer = scope.ServiceProvider.GetRequiredService<SaveRequestedConsumer>();
+        var handler = new SaveValidatedHandler();
+
+        var harness = new InMemoryTestHarness();
+        var consumerHarness = harness.Consumer(() => consumer);
+        harness.Consumer(() => handler);
+
+        await harness.Start();
+        try
+        {
+            await harness.Bus.Publish(new SaveRequested(Guid.NewGuid()));
+
+            Assert.True(await harness.Consumed.Any<SaveRequested>());
+            Assert.True(await consumerHarness.Consumed.Any<SaveRequested>());
+            await handler.Source.Task.WaitAsync(TimeSpan.FromSeconds(3));
+
+            var ctx = scope.ServiceProvider.GetRequiredService<TestDbContext>();
+            Assert.Equal(1, await ctx.Set<SaveAudit>().CountAsync());
+        }
+        finally
+        {
+            await harness.Stop();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `SaveValidated` event and publish from consumer
- support EF or Mongo repository via new `AddValidationFlow` setup helpers
- add validation flow integration test demonstrating in-memory DI

## Testing
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_688bda7480dc8330bd7c1a5b38f3e07e