### PR TITLE
Add validation flow DI helpers with EF and Mongo support

### DIFF
--- a/Validation.Domain/Events/SaveValidated.cs
+++ b/Validation.Domain/Events/SaveValidated.cs
@@ -1,0 +1,3 @@
+namespace Validation.Domain.Events;
+
+public record SaveValidated(Guid Id, bool IsValid, decimal Metric);

--- a/Validation.Infrastructure/Messaging/SaveRequestedConsumer.cs
+++ b/Validation.Infrastructure/Messaging/SaveRequestedConsumer.cs
@@ -2,7 +2,6 @@ using MassTransit;
 using Validation.Domain.Events;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.Repositories;
-using Validation.Infrastructure;
 
 namespace Validation.Infrastructure.Messaging;
 
@@ -31,5 +30,6 @@ public class SaveRequestedConsumer : IConsumer<SaveRequested>
             Metric = metric
         };
         await _repository.AddAsync(audit, context.CancellationToken);
+        await context.Publish(new SaveValidated(context.Message.Id, isValid, metric), context.CancellationToken);
     }
 }

--- a/Validation.Infrastructure/Validation.Infrastructure.csproj
+++ b/Validation.Infrastructure/Validation.Infrastructure.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="MassTransit" Version="8.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0-preview.4.23259.5" />
     <PackageReference Include="MongoDB.Driver" Version="2.19.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0-preview.4.23259.5" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.4.0-rc9" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />

--- a/Validation.Tests/AlwaysValidRule.cs
+++ b/Validation.Tests/AlwaysValidRule.cs
@@ -1,0 +1,8 @@
+using Validation.Domain.Validation;
+
+namespace Validation.Tests;
+
+public class AlwaysValidRule : IValidationRule
+{
+    public bool Validate(decimal previousValue, decimal newValue) => true;
+}

--- a/Validation.Tests/TestDbContext.cs
+++ b/Validation.Tests/TestDbContext.cs
@@ -1,0 +1,13 @@
+using Microsoft.EntityFrameworkCore;
+using Validation.Infrastructure;
+
+namespace Validation.Tests;
+
+public class TestDbContext : DbContext
+{
+    public TestDbContext(DbContextOptions<TestDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<SaveAudit> SaveAudits => Set<SaveAudit>();
+}

--- a/Validation.Tests/ValidationFlowIntegrationTests.cs
+++ b/Validation.Tests/ValidationFlowIntegrationTests.cs
@@ -1,0 +1,41 @@
+using MassTransit.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Validation.Domain.Events;
+using Validation.Infrastructure.Messaging;
+using MassTransit;
+using Validation.Domain.Validation;
+using Validation.Infrastructure.DI;
+
+namespace Validation.Tests;
+
+public class ValidationFlowIntegrationTests
+{
+    [Fact]
+    public async Task Save_requested_triggers_validated_event_and_audit_saved()
+    {
+        var services = new ServiceCollection();
+        services.AddMassTransitTestHarness(cfg => cfg.AddConsumer<SaveRequestedConsumer>());
+        services.AddValidationFlow<AlwaysValidRule>(opts =>
+        {
+            opts.SetupDatabase<TestDbContext>("flowtest");
+        });
+
+        var provider = services.BuildServiceProvider(true);
+        var harness = provider.GetRequiredService<ITestHarness>();
+        await harness.Start();
+        try
+        {
+            using var scope = provider.CreateScope();
+            var publish = scope.ServiceProvider.GetRequiredService<IPublishEndpoint>();
+            await publish.Publish(new SaveRequested(Guid.NewGuid()));
+
+            Assert.True(await harness.Published.Any<SaveValidated>());
+            var ctx = scope.ServiceProvider.GetRequiredService<TestDbContext>();
+            Assert.Equal(1, ctx.SaveAudits.Count());
+        }
+        finally
+        {
+            await harness.Stop();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `SaveValidated` domain event
- implement `ValidationFlowServiceCollectionExtensions` for one-liner setup
- update `SaveRequestedConsumer` to publish `SaveValidated`
- create EF in-memory `SetupDatabase` helper and MongoDB counterpart
- add integration test proving DI flow works

## Testing
- `dotnet test -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_688bda7480dc8330bd7c1a5b38f3e07e