### PR TITLE
Add collection validator and duplicate rule

### DIFF
--- a/Validation.Domain/Validation/DuplicateEqualityRule.cs
+++ b/Validation.Domain/Validation/DuplicateEqualityRule.cs
@@ -1,0 +1,11 @@
+using System.Linq;
+
+namespace Validation.Domain.Validation;
+
+public class DuplicateEqualityRule<TItem, TKey> : IListValidationRule<TItem, TKey>
+{
+    public bool Validate(IGrouping<TKey, TItem> duplicates)
+    {
+        return duplicates.Count() <= 1;
+    }
+}

--- a/Validation.Domain/Validation/IListValidationRule.cs
+++ b/Validation.Domain/Validation/IListValidationRule.cs
@@ -1,0 +1,8 @@
+using System.Linq;
+
+namespace Validation.Domain.Validation;
+
+public interface IListValidationRule<TItem, TKey>
+{
+    bool Validate(IGrouping<TKey, TItem> duplicates);
+}

--- a/Validation.Domain/Validation/SummarisationValidator.cs
+++ b/Validation.Domain/Validation/SummarisationValidator.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 namespace Validation.Domain.Validation;
 
 public class SummarisationValidator
@@ -5,5 +7,13 @@ public class SummarisationValidator
     public bool Validate(decimal previousValue, decimal newValue, IEnumerable<IValidationRule> rules)
     {
         return rules.All(r => r.Validate(previousValue, newValue));
+    }
+
+    public bool Validate<TItem, TKey>(IEnumerable<TItem> items,
+        Func<TItem, TKey> keySelector,
+        IEnumerable<IListValidationRule<TItem, TKey>> rules)
+    {
+        var groups = items.GroupBy(keySelector);
+        return groups.All(g => rules.All(r => r.Validate(g)));
     }
 }

--- a/Validation.Tests/SummarisationValidatorTests.cs
+++ b/Validation.Tests/SummarisationValidatorTests.cs
@@ -1,0 +1,18 @@
+using Validation.Domain.Validation;
+
+namespace Validation.Tests;
+
+public class SummarisationValidatorTests
+{
+    [Fact]
+    public void DuplicateEqualityRule_fails_on_duplicates()
+    {
+        var items = new[] { "car", "jar", "car" };
+        var validator = new SummarisationValidator();
+        var rules = new IListValidationRule<string, string>[] { new DuplicateEqualityRule<string, string>() };
+
+        var result = validator.Validate(items, x => x, rules);
+
+        Assert.False(result);
+    }
+}


### PR DESCRIPTION
## Summary
- add `IListValidationRule` for grouped list checks
- implement `DuplicateEqualityRule`
- extend `SummarisationValidator` with overload for validating collections
- add unit test ensuring duplicate detection works

## Testing
- `~/.dotnet/dotnet test --no-build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_688bf2a13368833091616556e8ba32a7