### PR TITLE
Add list validation and duplicate rule

### DIFF
--- a/Validation.Domain/Validation/DuplicateEqualityRule.cs
+++ b/Validation.Domain/Validation/DuplicateEqualityRule.cs
@@ -1,0 +1,9 @@
+namespace Validation.Domain.Validation;
+
+public class DuplicateEqualityRule<TItem,TKey> : IListValidationRule<TItem,TKey>
+{
+    public bool Validate(IGrouping<TKey, TItem> duplicates)
+    {
+        return duplicates.Count() <= 1;
+    }
+}

--- a/Validation.Domain/Validation/IListValidationRule.cs
+++ b/Validation.Domain/Validation/IListValidationRule.cs
@@ -1,0 +1,6 @@
+namespace Validation.Domain.Validation;
+
+public interface IListValidationRule<TItem,TKey>
+{
+    bool Validate(IGrouping<TKey,TItem> duplicates);
+}

--- a/Validation.Domain/Validation/SummarisationValidator.cs
+++ b/Validation.Domain/Validation/SummarisationValidator.cs
@@ -6,4 +6,21 @@ public class SummarisationValidator
     {
         return rules.All(r => r.Validate(previousValue, newValue));
     }
+
+    public bool Validate<TItem,TKey>(IEnumerable<TItem> items,
+        Func<TItem,TKey> keySelector,
+        IEnumerable<IListValidationRule<TItem,TKey>> rules)
+    {
+        var groups = items.GroupBy(keySelector);
+        foreach (var group in groups)
+        {
+            foreach (var rule in rules)
+            {
+                if (!rule.Validate(group))
+                    return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/Validation.Tests/SummarisationValidatorListTests.cs
+++ b/Validation.Tests/SummarisationValidatorListTests.cs
@@ -1,0 +1,18 @@
+using Validation.Domain.Validation;
+
+namespace Validation.Tests;
+
+public class SummarisationValidatorListTests
+{
+    [Fact]
+    public void Duplicate_items_fail_validation()
+    {
+        var validator = new SummarisationValidator();
+        var rule = new DuplicateEqualityRule<string, string>();
+        var items = new[] { "car", "jar", "car" };
+
+        var result = validator.Validate(items, i => i, new[] { rule });
+
+        Assert.False(result);
+    }
+}


### PR DESCRIPTION
## Summary
- add new IListValidationRule interface
- implement DuplicateEqualityRule
- extend SummarisationValidator with list validation
- test duplicate detection using SummarisationValidator

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688bf2a13368833091616556e8ba32a7