### PR TITLE
Introduce ValidationPlan and add plan-based validation

### DIFF
--- a/Validation.Domain/Validation/PercentChangeRule.cs
+++ b/Validation.Domain/Validation/PercentChangeRule.cs
@@ -1,5 +1,8 @@
+using System;
+
 namespace Validation.Domain.Validation;
 
+[Obsolete("Use ValidationPlan instead")]
 public class PercentChangeRule : IValidationRule
 {
     private readonly decimal _percent;

--- a/Validation.Domain/Validation/RawDifferenceRule.cs
+++ b/Validation.Domain/Validation/RawDifferenceRule.cs
@@ -1,5 +1,8 @@
+using System;
+
 namespace Validation.Domain.Validation;
 
+[Obsolete("Use ValidationPlan instead")]
 public class RawDifferenceRule : IValidationRule
 {
     private readonly decimal _threshold;

--- a/Validation.Domain/Validation/SummarisationValidator.cs
+++ b/Validation.Domain/Validation/SummarisationValidator.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Validation.Domain.Validation;
 
 public class SummarisationValidator
@@ -5,5 +7,17 @@ public class SummarisationValidator
     public bool Validate(decimal previousValue, decimal newValue, IEnumerable<IValidationRule> rules)
     {
         return rules.All(r => r.Validate(previousValue, newValue));
+    }
+
+    public bool Validate(decimal previousValue, decimal newValue, ValidationPlan plan)
+    {
+        return plan.ThresholdType switch
+        {
+            ThresholdType.RawDifference => Math.Abs(newValue - previousValue) <= plan.ThresholdValue,
+            ThresholdType.PercentChange => previousValue == 0
+                ? true
+                : Math.Abs((newValue - previousValue) / previousValue) * 100 <= plan.ThresholdValue,
+            _ => throw new ArgumentOutOfRangeException(nameof(plan.ThresholdType), plan.ThresholdType, null)
+        };
     }
 }

--- a/Validation.Domain/Validation/ValidationPlan.cs
+++ b/Validation.Domain/Validation/ValidationPlan.cs
@@ -1,0 +1,9 @@
+namespace Validation.Domain.Validation;
+
+public enum ThresholdType
+{
+    RawDifference,
+    PercentChange
+}
+
+public record ValidationPlan(Func<object, decimal> MetricSelector, ThresholdType ThresholdType, decimal ThresholdValue);

--- a/Validation.Tests/SummarisationValidatorPlanTests.cs
+++ b/Validation.Tests/SummarisationValidatorPlanTests.cs
@@ -1,0 +1,38 @@
+using Validation.Domain.Validation;
+
+namespace Validation.Tests;
+
+public class SummarisationValidatorPlanTests
+{
+    [Fact]
+    public void Validate_RawDifference_within_threshold_returns_true()
+    {
+        var plan = new ValidationPlan(_ => 0m, ThresholdType.RawDifference, 10m);
+        var validator = new SummarisationValidator();
+        Assert.True(validator.Validate(100m, 105m, plan));
+    }
+
+    [Fact]
+    public void Validate_RawDifference_exceeds_threshold_returns_false()
+    {
+        var plan = new ValidationPlan(_ => 0m, ThresholdType.RawDifference, 5m);
+        var validator = new SummarisationValidator();
+        Assert.False(validator.Validate(100m, 120m, plan));
+    }
+
+    [Fact]
+    public void Validate_PercentChange_within_threshold_returns_true()
+    {
+        var plan = new ValidationPlan(_ => 0m, ThresholdType.PercentChange, 10m);
+        var validator = new SummarisationValidator();
+        Assert.True(validator.Validate(100m, 105m, plan));
+    }
+
+    [Fact]
+    public void Validate_PercentChange_exceeds_threshold_returns_false()
+    {
+        var plan = new ValidationPlan(_ => 0m, ThresholdType.PercentChange, 10m);
+        var validator = new SummarisationValidator();
+        Assert.False(validator.Validate(100m, 120m, plan));
+    }
+}


### PR DESCRIPTION
## Summary
- add `ThresholdType` enum and `ValidationPlan` record
- mark `RawDifferenceRule` and `PercentChangeRule` obsolete
- extend `SummarisationValidator` with plan-based validation
- test new behaviour with `SummarisationValidatorPlanTests`

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_688bf2b404948330a8011babb8923fe7