### PR TITLE
Introduce ValidationPlan for threshold validation

### DIFF
--- a/Validation.Domain/Validation/PercentChangeRule.cs
+++ b/Validation.Domain/Validation/PercentChangeRule.cs
@@ -1,5 +1,7 @@
+using System;
 namespace Validation.Domain.Validation;
 
+[Obsolete("Use ValidationPlan instead")]
 public class PercentChangeRule : IValidationRule
 {
     private readonly decimal _percent;

--- a/Validation.Domain/Validation/RawDifferenceRule.cs
+++ b/Validation.Domain/Validation/RawDifferenceRule.cs
@@ -1,5 +1,7 @@
+using System;
 namespace Validation.Domain.Validation;
 
+[Obsolete("Use ValidationPlan instead")]
 public class RawDifferenceRule : IValidationRule
 {
     private readonly decimal _threshold;

--- a/Validation.Domain/Validation/SummarisationValidator.cs
+++ b/Validation.Domain/Validation/SummarisationValidator.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 namespace Validation.Domain.Validation;
 
 public class SummarisationValidator
@@ -5,5 +7,15 @@ public class SummarisationValidator
     public bool Validate(decimal previousValue, decimal newValue, IEnumerable<IValidationRule> rules)
     {
         return rules.All(r => r.Validate(previousValue, newValue));
+    }
+
+    public bool Validate(decimal previousValue, decimal newValue, ValidationPlan plan)
+    {
+        return plan.ThresholdType switch
+        {
+            ThresholdType.RawDifference => Math.Abs(newValue - previousValue) <= plan.ThresholdValue,
+            ThresholdType.PercentChange => previousValue == 0 ? true : Math.Abs((newValue - previousValue) / previousValue) * 100 <= plan.ThresholdValue,
+            _ => throw new NotSupportedException($"Unsupported threshold type {plan.ThresholdType}")
+        };
     }
 }

--- a/Validation.Domain/Validation/ValidationPlan.cs
+++ b/Validation.Domain/Validation/ValidationPlan.cs
@@ -1,0 +1,10 @@
+using System;
+namespace Validation.Domain.Validation;
+
+public enum ThresholdType
+{
+    RawDifference,
+    PercentChange
+}
+
+public record ValidationPlan(Func<object, decimal> MetricSelector, ThresholdType ThresholdType, decimal ThresholdValue);

--- a/Validation.Tests/SummarisationValidatorPlanTests.cs
+++ b/Validation.Tests/SummarisationValidatorPlanTests.cs
@@ -1,0 +1,29 @@
+using Xunit;
+using Validation.Domain.Validation;
+
+namespace Validation.Tests;
+
+public class SummarisationValidatorPlanTests
+{
+    [Fact]
+    public void Validate_RawDifference_within_threshold_returns_true()
+    {
+        var validator = new SummarisationValidator();
+        var plan = new ValidationPlan(_ => 0m, ThresholdType.RawDifference, 5m);
+
+        var result = validator.Validate(10m, 14m, plan);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void Validate_PercentChange_within_threshold_returns_true()
+    {
+        var validator = new SummarisationValidator();
+        var plan = new ValidationPlan(_ => 0m, ThresholdType.PercentChange, 10m);
+
+        var result = validator.Validate(100m, 109m, plan);
+
+        Assert.True(result);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ThresholdType` enum and `ValidationPlan` record to generalise scalar validation
- mark old rules `RawDifferenceRule` and `PercentChangeRule` as obsolete
- extend `SummarisationValidator` with plan-based validation
- add unit tests for the new plan logic

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_688bf2b404948330a8011babb8923fe7