### PR TITLE
Add ValidationPlan and plan-based validation

### DIFF
--- a/Validation.Domain/Validation/PercentChangeRule.cs
+++ b/Validation.Domain/Validation/PercentChangeRule.cs
@@ -1,5 +1,8 @@
+using System;
+
 namespace Validation.Domain.Validation;
 
+[Obsolete("Use ValidationPlan with ThresholdType instead.")]
 public class PercentChangeRule : IValidationRule
 {
     private readonly decimal _percent;

--- a/Validation.Domain/Validation/RawDifferenceRule.cs
+++ b/Validation.Domain/Validation/RawDifferenceRule.cs
@@ -1,5 +1,8 @@
+using System;
+
 namespace Validation.Domain.Validation;
 
+[Obsolete("Use ValidationPlan with ThresholdType instead.")]
 public class RawDifferenceRule : IValidationRule
 {
     private readonly decimal _threshold;

--- a/Validation.Domain/Validation/SummarisationValidator.cs
+++ b/Validation.Domain/Validation/SummarisationValidator.cs
@@ -1,3 +1,4 @@
+using System;
 namespace Validation.Domain.Validation;
 
 public class SummarisationValidator
@@ -5,5 +6,17 @@ public class SummarisationValidator
     public bool Validate(decimal previousValue, decimal newValue, IEnumerable<IValidationRule> rules)
     {
         return rules.All(r => r.Validate(previousValue, newValue));
+    }
+
+    public bool Validate(decimal previousValue, decimal newValue, ValidationPlan plan)
+    {
+        return plan.ThresholdType switch
+        {
+            ThresholdType.RawDifference => Math.Abs(newValue - previousValue) <= plan.ThresholdValue,
+            ThresholdType.PercentChange => previousValue == 0m
+                ? true
+                : Math.Abs((newValue - previousValue) / previousValue) * 100 <= plan.ThresholdValue,
+            _ => throw new ArgumentOutOfRangeException()
+        };
     }
 }

--- a/Validation.Domain/Validation/ValidationPlan.cs
+++ b/Validation.Domain/Validation/ValidationPlan.cs
@@ -1,0 +1,11 @@
+namespace Validation.Domain.Validation;
+
+public enum ThresholdType
+{
+    RawDifference,
+    PercentChange
+}
+
+public record ValidationPlan(Func<object, decimal> MetricSelector,
+    ThresholdType ThresholdType,
+    decimal ThresholdValue);

--- a/Validation.Tests/SummarisationValidatorPlanTests.cs
+++ b/Validation.Tests/SummarisationValidatorPlanTests.cs
@@ -1,0 +1,22 @@
+using Validation.Domain.Validation;
+
+namespace Validation.Tests;
+
+public class SummarisationValidatorPlanTests
+{
+    [Fact]
+    public void RawDifference_under_threshold_returns_true()
+    {
+        var validator = new SummarisationValidator();
+        var plan = new ValidationPlan(_ => 0m, ThresholdType.RawDifference, 5);
+        Assert.True(validator.Validate(10m, 13m, plan));
+    }
+
+    [Fact]
+    public void PercentChange_over_threshold_returns_false()
+    {
+        var validator = new SummarisationValidator();
+        var plan = new ValidationPlan(_ => 0m, ThresholdType.PercentChange, 10);
+        Assert.False(validator.Validate(100m, 120m, plan));
+    }
+}


### PR DESCRIPTION
## Summary
- extend validation by introducing `ValidationPlan` and `ThresholdType`
- mark old validation rules as obsolete
- add plan-based overload for `SummarisationValidator`
- test plan-based validation logic

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688bf2b404948330a8011babb8923fe7