### PR TITLE
Add validation plan provider

### DIFF
--- a/Validation.Domain/Validation/IValidationPlanProvider.cs
+++ b/Validation.Domain/Validation/IValidationPlanProvider.cs
@@ -1,6 +1,9 @@
+using System;
+
 namespace Validation.Domain.Validation;
 
 public interface IValidationPlanProvider
 {
-    IEnumerable<IValidationRule> GetRules<T>();
+    ValidationPlan GetPlan(Type t);
+    void AddPlan<T>(ValidationPlan plan);
 }

--- a/Validation.Domain/Validation/InMemoryValidationPlanProvider.cs
+++ b/Validation.Domain/Validation/InMemoryValidationPlanProvider.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Concurrent;
+
+namespace Validation.Domain.Validation;
+
+public class InMemoryValidationPlanProvider : IValidationPlanProvider
+{
+    private readonly ConcurrentDictionary<Type, ValidationPlan> _plans = new();
+
+    public ValidationPlan GetPlan(Type t)
+    {
+        return _plans.TryGetValue(t, out var plan) ? plan : new ValidationPlan(Array.Empty<IValidationRule>());
+    }
+
+    public void AddPlan<T>(ValidationPlan plan)
+    {
+        _plans[typeof(T)] = plan;
+    }
+}

--- a/Validation.Domain/Validation/ValidationPlan.cs
+++ b/Validation.Domain/Validation/ValidationPlan.cs
@@ -1,0 +1,3 @@
+namespace Validation.Domain.Validation;
+
+public record ValidationPlan(IEnumerable<IValidationRule> Rules);

--- a/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
+++ b/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
@@ -17,6 +17,7 @@ public static class ServiceCollectionExtensions
         Action<IBusRegistrationConfigurator>? configureBus = null)
     {
         services.AddScoped<ISaveAuditRepository, EfCoreSaveAuditRepository>();
+        services.AddSingleton<IValidationPlanProvider, InMemoryValidationPlanProvider>();
 
         services.AddMassTransit(x =>
         {
@@ -36,6 +37,7 @@ public static class ServiceCollectionExtensions
     {
         services.AddSingleton(database);
         services.AddScoped<ISaveAuditRepository, MongoSaveAuditRepository>();
+        services.AddSingleton<IValidationPlanProvider, InMemoryValidationPlanProvider>();
 
         services.AddMassTransit(x =>
         {

--- a/Validation.Infrastructure/Messaging/DeleteValidationConsumer.cs
+++ b/Validation.Infrastructure/Messaging/DeleteValidationConsumer.cs
@@ -18,7 +18,7 @@ public class DeleteValidationConsumer<T> : IConsumer<DeleteRequested>
 
     public Task Consume(ConsumeContext<DeleteRequested> context)
     {
-        var rules = _planProvider.GetRules<T>();
+        var rules = _planProvider.GetPlan(typeof(T)).Rules;
         // execute manual rules with zero metrics since delete; actual logic omitted
         _validator.Validate(0, 0, rules);
         return Task.CompletedTask;

--- a/Validation.Infrastructure/Messaging/SaveValidationConsumer.cs
+++ b/Validation.Infrastructure/Messaging/SaveValidationConsumer.cs
@@ -22,7 +22,7 @@ public class SaveValidationConsumer<T> : IConsumer<SaveRequested>
     {
         var last = await _repository.GetLastAsync(context.Message.Id, context.CancellationToken);
         var metric = new Random().Next(0, 100);
-        var rules = _planProvider.GetRules<T>();
+        var rules = _planProvider.GetPlan(typeof(T)).Rules;
         var isValid = _validator.Validate(last?.Metric ?? 0m, metric, rules);
 
         var audit = new SaveAudit

--- a/Validation.Tests/InMemoryValidationPlanProviderTests.cs
+++ b/Validation.Tests/InMemoryValidationPlanProviderTests.cs
@@ -1,0 +1,19 @@
+using Validation.Domain.Validation;
+using Xunit;
+
+namespace Validation.Tests;
+
+public class InMemoryValidationPlanProviderTests
+{
+    [Fact]
+    public void Added_plan_can_be_retrieved()
+    {
+        var provider = new InMemoryValidationPlanProvider();
+        var plan = new ValidationPlan(new[] { new AlwaysValidRule() });
+        provider.AddPlan<string>(plan);
+
+        var result = provider.GetPlan(typeof(string));
+
+        Assert.Equal(plan, result);
+    }
+}

--- a/Validation.Tests/SaveValidationConsumerTests.cs
+++ b/Validation.Tests/SaveValidationConsumerTests.cs
@@ -4,21 +4,20 @@ using Validation.Domain.Events;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.Messaging;
 using Validation.Domain.Entities;
+using System;
 
 namespace Validation.Tests;
 
 public class SaveValidationConsumerTests
 {
-    private class TestPlanProvider : IValidationPlanProvider
-    {
-        public IEnumerable<IValidationRule> GetRules<T>() => new[] { new RawDifferenceRule(100) };
-    }
 
     [Fact]
     public async Task Publish_SaveValidated_after_processing()
     {
         var repository = new InMemorySaveAuditRepository();
-        var consumer = new SaveValidationConsumer<Item>(new TestPlanProvider(), repository, new SummarisationValidator());
+        var provider = new InMemoryValidationPlanProvider();
+        provider.AddPlan<Item>(new ValidationPlan(new[] { new RawDifferenceRule(100) }));
+        var consumer = new SaveValidationConsumer<Item>(provider, repository, new SummarisationValidator());
 
         var harness = new InMemoryTestHarness();
         harness.Consumer(() => consumer);


### PR DESCRIPTION
## Summary
- add `ValidationPlan` and `InMemoryValidationPlanProvider`
- expand `IValidationPlanProvider` interface
- refactor consumers to use new provider interface
- register `InMemoryValidationPlanProvider` in DI
- update tests and add provider tests

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688bf3460ce88330a552702637c46089