### PR TITLE
Add validation plan provider

### DIFF
--- a/Validation.Domain/Validation/IValidationPlanProvider.cs
+++ b/Validation.Domain/Validation/IValidationPlanProvider.cs
@@ -2,5 +2,6 @@ namespace Validation.Domain.Validation;
 
 public interface IValidationPlanProvider
 {
-    IEnumerable<IValidationRule> GetRules<T>();
+    ValidationPlan GetPlan(Type t);
+    void AddPlan<T>(ValidationPlan plan);
 }

--- a/Validation.Domain/Validation/InMemoryValidationPlanProvider.cs
+++ b/Validation.Domain/Validation/InMemoryValidationPlanProvider.cs
@@ -1,0 +1,19 @@
+using System.Collections.Concurrent;
+
+namespace Validation.Domain.Validation;
+
+public class InMemoryValidationPlanProvider : IValidationPlanProvider
+{
+    private readonly ConcurrentDictionary<Type, ValidationPlan> _plans = new();
+
+    public ValidationPlan GetPlan(Type t)
+    {
+        _plans.TryGetValue(t, out var plan);
+        return plan ?? new ValidationPlan(Array.Empty<IValidationRule>());
+    }
+
+    public void AddPlan<T>(ValidationPlan plan)
+    {
+        _plans[typeof(T)] = plan;
+    }
+}

--- a/Validation.Domain/Validation/ValidationPlan.cs
+++ b/Validation.Domain/Validation/ValidationPlan.cs
@@ -1,0 +1,11 @@
+namespace Validation.Domain.Validation;
+
+public class ValidationPlan
+{
+    public IEnumerable<IValidationRule> Rules { get; }
+
+    public ValidationPlan(IEnumerable<IValidationRule> rules)
+    {
+        Rules = rules;
+    }
+}

--- a/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
+++ b/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
@@ -17,6 +17,7 @@ public static class ServiceCollectionExtensions
         Action<IBusRegistrationConfigurator>? configureBus = null)
     {
         services.AddScoped<ISaveAuditRepository, EfCoreSaveAuditRepository>();
+        services.AddSingleton<IValidationPlanProvider, InMemoryValidationPlanProvider>();
 
         services.AddMassTransit(x =>
         {
@@ -36,6 +37,7 @@ public static class ServiceCollectionExtensions
     {
         services.AddSingleton(database);
         services.AddScoped<ISaveAuditRepository, MongoSaveAuditRepository>();
+        services.AddSingleton<IValidationPlanProvider, InMemoryValidationPlanProvider>();
 
         services.AddMassTransit(x =>
         {
@@ -83,6 +85,7 @@ public static class ValidationFlowServiceCollectionExtensions
         where TRule : class, IValidationRule
     {
         services.AddScoped<IValidationRule, TRule>();
+        services.AddSingleton<IValidationPlanProvider, InMemoryValidationPlanProvider>();
         services.AddScoped<SummarisationValidator>();
         services.AddMassTransitTestHarness(x =>
         {

--- a/Validation.Infrastructure/Messaging/DeleteValidationConsumer.cs
+++ b/Validation.Infrastructure/Messaging/DeleteValidationConsumer.cs
@@ -18,9 +18,9 @@ public class DeleteValidationConsumer<T> : IConsumer<DeleteRequested>
 
     public Task Consume(ConsumeContext<DeleteRequested> context)
     {
-        var rules = _planProvider.GetRules<T>();
+        var plan = _planProvider.GetPlan(typeof(T));
         // execute manual rules with zero metrics since delete; actual logic omitted
-        _validator.Validate(0, 0, rules);
+        _validator.Validate(0, 0, plan.Rules);
         return Task.CompletedTask;
     }
 }

--- a/Validation.Infrastructure/Messaging/SaveValidationConsumer.cs
+++ b/Validation.Infrastructure/Messaging/SaveValidationConsumer.cs
@@ -22,8 +22,8 @@ public class SaveValidationConsumer<T> : IConsumer<SaveRequested>
     {
         var last = await _repository.GetLastAsync(context.Message.Id, context.CancellationToken);
         var metric = new Random().Next(0, 100);
-        var rules = _planProvider.GetRules<T>();
-        var isValid = _validator.Validate(last?.Metric ?? 0m, metric, rules);
+        var plan = _planProvider.GetPlan(typeof(T));
+        var isValid = _validator.Validate(last?.Metric ?? 0m, metric, plan.Rules);
 
         var audit = new SaveAudit
         {

--- a/Validation.Tests/InMemoryValidationPlanProviderTests.cs
+++ b/Validation.Tests/InMemoryValidationPlanProviderTests.cs
@@ -1,0 +1,18 @@
+using Validation.Domain.Validation;
+
+namespace Validation.Tests;
+
+public class InMemoryValidationPlanProviderTests
+{
+    [Fact]
+    public void Added_plan_can_be_retrieved()
+    {
+        var provider = new InMemoryValidationPlanProvider();
+        var plan = new ValidationPlan(new[] { new RawDifferenceRule(1) });
+        provider.AddPlan<string>(plan);
+
+        var result = provider.GetPlan(typeof(string));
+
+        Assert.Same(plan, result);
+    }
+}

--- a/Validation.Tests/SaveValidationConsumerTests.cs
+++ b/Validation.Tests/SaveValidationConsumerTests.cs
@@ -11,7 +11,8 @@ public class SaveValidationConsumerTests
 {
     private class TestPlanProvider : IValidationPlanProvider
     {
-        public IEnumerable<IValidationRule> GetRules<T>() => new[] { new RawDifferenceRule(100) };
+        public ValidationPlan GetPlan(Type t) => new ValidationPlan(new[] { new RawDifferenceRule(100) });
+        public void AddPlan<T>(ValidationPlan plan) { }
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add new ValidationPlan class to encapsulate validation rules
- create InMemoryValidationPlanProvider and expose `GetPlan` and `AddPlan`
- update consumers to use plans instead of rule lists
- register provider as singleton in DI extensions
- add tests for new provider and update existing consumer tests

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688bf3460ce88330a552702637c46089