### PR TITLE
Enable runtime validator rule registration

### DIFF
--- a/Validation.Infrastructure/DI/ManualValidationExtensions.cs
+++ b/Validation.Infrastructure/DI/ManualValidationExtensions.cs
@@ -1,0 +1,17 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Validation.Infrastructure.DI;
+
+public static class ManualValidationExtensions
+{
+    public static IServiceCollection AddValidatorRule<T>(this IServiceCollection services, Func<T, bool> rule)
+    {
+        services.AddSingleton<IManualValidatorService, ManualValidatorService>();
+        services.AddOptions<ManualValidatorOptions>().Configure(options =>
+        {
+            var list = options.Rules.GetOrAdd(typeof(T), _ => new List<Func<object, bool>>());
+            list.Add(o => rule((T)o));
+        });
+        return services;
+    }
+}

--- a/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
+++ b/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
@@ -17,6 +17,7 @@ public static class ServiceCollectionExtensions
         Action<IBusRegistrationConfigurator>? configureBus = null)
     {
         services.AddScoped<ISaveAuditRepository, EfCoreSaveAuditRepository>();
+        services.AddSingleton<IManualValidatorService, ManualValidatorService>();
 
         services.AddMassTransit(x =>
         {
@@ -36,6 +37,7 @@ public static class ServiceCollectionExtensions
     {
         services.AddSingleton(database);
         services.AddScoped<ISaveAuditRepository, MongoSaveAuditRepository>();
+        services.AddSingleton<IManualValidatorService, ManualValidatorService>();
 
         services.AddMassTransit(x =>
         {
@@ -84,6 +86,7 @@ public static class ValidationFlowServiceCollectionExtensions
     {
         services.AddScoped<IValidationRule, TRule>();
         services.AddScoped<SummarisationValidator>();
+        services.AddSingleton<IManualValidatorService, ManualValidatorService>();
         services.AddMassTransitTestHarness(x =>
         {
             x.AddConsumer<SaveRequestedConsumer>();

--- a/Validation.Infrastructure/IManualValidatorService.cs
+++ b/Validation.Infrastructure/IManualValidatorService.cs
@@ -1,0 +1,6 @@
+namespace Validation.Infrastructure;
+
+public interface IManualValidatorService
+{
+    bool Validate(object instance);
+}

--- a/Validation.Infrastructure/ManualValidatorService.cs
+++ b/Validation.Infrastructure/ManualValidatorService.cs
@@ -1,0 +1,32 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Options;
+
+namespace Validation.Infrastructure;
+
+public class ManualValidatorService : IManualValidatorService
+{
+    private readonly ConcurrentDictionary<Type, List<Func<object, bool>>> _rules;
+
+    public ManualValidatorService(IOptions<ManualValidatorOptions> options)
+    {
+        _rules = options.Value.Rules;
+    }
+
+    public bool Validate(object instance)
+    {
+        if (instance == null) return true;
+        if (_rules.TryGetValue(instance.GetType(), out var list))
+        {
+            foreach (var rule in list)
+            {
+                if (!rule(instance)) return false;
+            }
+        }
+        return true;
+    }
+}
+
+public class ManualValidatorOptions
+{
+    internal ConcurrentDictionary<Type, List<Func<object, bool>>> Rules { get; } = new();
+}

--- a/Validation.Tests/ManualValidatorServiceTests.cs
+++ b/Validation.Tests/ManualValidatorServiceTests.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.DependencyInjection;
+using Validation.Domain.Entities;
+using Validation.Infrastructure.DI;
+using Validation.Infrastructure;
+
+namespace Validation.Tests;
+
+public class ManualValidatorServiceTests
+{
+    [Fact]
+    public void Validate_uses_registered_rule()
+    {
+        var services = new ServiceCollection();
+        services.AddValidatorRule<Item>(i => i.Metric > 10);
+        var provider = services.BuildServiceProvider();
+
+        var svc = provider.GetRequiredService<IManualValidatorService>();
+        Assert.True(svc.Validate(new Item(20)));
+        Assert.False(svc.Validate(new Item(5)));
+    }
+}


### PR DESCRIPTION
## Summary
- add manual validator service and DI extension for adding rules
- register manual validator service in validation DI setup
- test manual validator rule registration

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_688bf3551a108330bb032884fbee1bb3