### PR TITLE
Add manual validator service

### DIFF
--- a/Validation.Domain/Validation/IManualValidatorService.cs
+++ b/Validation.Domain/Validation/IManualValidatorService.cs
@@ -1,0 +1,6 @@
+namespace Validation.Domain.Validation;
+
+public interface IManualValidatorService
+{
+    bool Validate(object instance);
+}

--- a/Validation.Infrastructure/ManualValidatorService.cs
+++ b/Validation.Infrastructure/ManualValidatorService.cs
@@ -1,0 +1,24 @@
+using System.Collections.Concurrent;
+using Validation.Domain.Validation;
+
+namespace Validation.Infrastructure;
+
+public class ManualValidatorService : IManualValidatorService
+{
+    private readonly ConcurrentDictionary<Type, List<Func<object, bool>>> _rules = new();
+
+    public void AddRule<T>(Func<T, bool> rule)
+    {
+        var list = _rules.GetOrAdd(typeof(T), _ => new List<Func<object, bool>>());
+        list.Add(o => rule((T)o));
+    }
+
+    public bool Validate(object instance)
+    {
+        if (instance == null) throw new ArgumentNullException(nameof(instance));
+        var type = instance.GetType();
+        if (!_rules.TryGetValue(type, out var list) || list.Count == 0)
+            return true;
+        return list.All(r => r(instance));
+    }
+}

--- a/Validation.Tests/ManualValidatorServiceTests.cs
+++ b/Validation.Tests/ManualValidatorServiceTests.cs
@@ -1,0 +1,20 @@
+using Xunit;
+using Microsoft.Extensions.DependencyInjection;
+using Validation.Domain.Validation;
+using Validation.Infrastructure.DI;
+
+namespace Validation.Tests;
+
+public class ManualValidatorServiceTests
+{
+    [Fact]
+    public void Registered_rule_is_invoked()
+    {
+        var services = new ServiceCollection();
+        services.AddValidatorRule<string>(s => s.Length > 3);
+        var provider = services.BuildServiceProvider();
+        var svc = provider.GetRequiredService<IManualValidatorService>();
+        Assert.True(svc.Validate("hello"));
+        Assert.False(svc.Validate("hi"));
+    }
+}


### PR DESCRIPTION
## Summary
- implement `IManualValidatorService` and `ManualValidatorService`
- register manual validator in DI and add `AddValidatorRule` helper
- provide test coverage for new functionality

## Testing
- `dotnet test Validation.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_688bf3551a108330bb032884fbee1bb3