### PR TITLE
Add manual validator registration

### DIFF
--- a/Validation.Infrastructure/DI/ManualValidatorExtensions.cs
+++ b/Validation.Infrastructure/DI/ManualValidatorExtensions.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Validation.Infrastructure.DI;
+
+public static class ManualValidatorExtensions
+{
+    public static IServiceCollection AddValidatorRule<T>(this IServiceCollection services, Func<T, bool> rule)
+    {
+        services.TryAddSingleton<IManualValidatorService, ManualValidatorService>();
+        services.AddSingleton(new ManualValidationRule(typeof(T), o => rule((T)o)));
+        return services;
+    }
+}

--- a/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
+++ b/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
@@ -1,12 +1,14 @@
 using MassTransit;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using MongoDB.Driver;
 using OpenTelemetry.Trace;
 using Serilog;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.Messaging;
 using Validation.Infrastructure.Repositories;
+using Validation.Infrastructure;
 
 namespace Validation.Infrastructure.DI;
 
@@ -17,6 +19,7 @@ public static class ServiceCollectionExtensions
         Action<IBusRegistrationConfigurator>? configureBus = null)
     {
         services.AddScoped<ISaveAuditRepository, EfCoreSaveAuditRepository>();
+        services.TryAddSingleton<IManualValidatorService, ManualValidatorService>();
 
         services.AddMassTransit(x =>
         {
@@ -36,6 +39,7 @@ public static class ServiceCollectionExtensions
     {
         services.AddSingleton(database);
         services.AddScoped<ISaveAuditRepository, MongoSaveAuditRepository>();
+        services.TryAddSingleton<IManualValidatorService, ManualValidatorService>();
 
         services.AddMassTransit(x =>
         {
@@ -84,6 +88,7 @@ public static class ValidationFlowServiceCollectionExtensions
     {
         services.AddScoped<IValidationRule, TRule>();
         services.AddScoped<SummarisationValidator>();
+        services.TryAddSingleton<IManualValidatorService, ManualValidatorService>();
         services.AddMassTransitTestHarness(x =>
         {
             x.AddConsumer<SaveRequestedConsumer>();

--- a/Validation.Infrastructure/ManualValidatorService.cs
+++ b/Validation.Infrastructure/ManualValidatorService.cs
@@ -1,0 +1,55 @@
+using System.Collections.Concurrent;
+
+namespace Validation.Infrastructure;
+
+public interface IManualValidatorService
+{
+    bool Validate(object instance);
+}
+
+public record ManualValidationRule(Type EntityType, Func<object, bool> Rule);
+
+public class ManualValidatorService : IManualValidatorService
+{
+    private readonly ConcurrentDictionary<Type, List<Func<object, bool>>> _rules = new();
+
+    public ManualValidatorService(IEnumerable<ManualValidationRule>? rules = null)
+    {
+        if (rules != null)
+        {
+            foreach (var rule in rules)
+            {
+                AddRule(rule.EntityType, rule.Rule);
+            }
+        }
+    }
+
+    private void AddRule(Type type, Func<object, bool> rule)
+    {
+        var list = _rules.GetOrAdd(type, _ => new List<Func<object, bool>>());
+        lock (list)
+        {
+            list.Add(rule);
+        }
+    }
+
+    public void RegisterRule<T>(Func<T, bool> rule)
+    {
+        AddRule(typeof(T), o => rule((T)o));
+    }
+
+    public bool Validate(object instance)
+    {
+        if (_rules.TryGetValue(instance.GetType(), out var list))
+        {
+            foreach (var rule in list)
+            {
+                if (!rule(instance))
+                {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/Validation.Tests/ManualValidatorServiceTests.cs
+++ b/Validation.Tests/ManualValidatorServiceTests.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.DependencyInjection;
+using Validation.Infrastructure.DI;
+using Validation.Infrastructure;
+
+namespace Validation.Tests;
+
+public class ManualValidatorServiceTests
+{
+    private record Dummy(int Value);
+
+    [Fact]
+    public void Validate_runs_registered_predicate()
+    {
+        var services = new ServiceCollection();
+        services.AddValidatorRule<Dummy>(d => d.Value > 10);
+        var provider = services.BuildServiceProvider();
+        var validator = provider.GetRequiredService<IManualValidatorService>();
+
+        Assert.True(validator.Validate(new Dummy(11)));
+        Assert.False(validator.Validate(new Dummy(5)));
+    }
+
+    [Fact]
+    public void AddValidationFlow_registers_service()
+    {
+        var services = new ServiceCollection();
+        services.AddValidationFlow<AlwaysValidRule>();
+        var provider = services.BuildServiceProvider();
+        var svc = provider.GetRequiredService<IManualValidatorService>();
+        Assert.NotNull(svc);
+    }
+}


### PR DESCRIPTION
## Summary
- support runtime manual validation predicates
- add registration extension and DI hookups
- cover new service with tests

## Testing
- `DOTNET_ROLL_FORWARD=Major dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688bf3551a108330bb032884fbee1bb3