### PR TITLE
Add rule set support for summarisation validator

### DIFF
--- a/Validation.Domain/Validation/SummarisationValidator.cs
+++ b/Validation.Domain/Validation/SummarisationValidator.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
 namespace Validation.Domain.Validation;
 
 public class SummarisationValidator
@@ -5,5 +9,34 @@ public class SummarisationValidator
     public bool Validate(decimal previousValue, decimal newValue, IEnumerable<IValidationRule> rules)
     {
         return rules.All(r => r.Validate(previousValue, newValue));
+    }
+
+    public bool ValidateRuleSet<T>(IQueryable<T> all, ValidationRuleSet<T> ruleSet)
+    {
+        foreach (var rule in ruleSet.Rules)
+        {
+            double result = rule.Strategy switch
+            {
+                ValidationStrategy.Sum => all.Sum(ruleSet.Selector),
+                ValidationStrategy.Average => all.Average(ruleSet.Selector),
+                ValidationStrategy.Count => all.Count(),
+                _ => double.NaN
+            };
+
+            if (rule.Strategy == ValidationStrategy.Variance)
+            {
+                var values = all.Select(ruleSet.Selector).ToArray();
+                var avg = values.Average();
+                result = values.Select(v => Math.Pow(v - avg, 2)).Average();
+            }
+
+            if (double.IsNaN(result))
+                throw new ArgumentOutOfRangeException();
+
+            if (result > rule.Threshold)
+                return false;
+        }
+
+        return true;
     }
 }

--- a/Validation.Domain/Validation/ValidationRule.cs
+++ b/Validation.Domain/Validation/ValidationRule.cs
@@ -1,0 +1,3 @@
+namespace Validation.Domain.Validation;
+
+public record ValidationRule(ValidationStrategy Strategy, double Threshold);

--- a/Validation.Domain/Validation/ValidationRuleSet.cs
+++ b/Validation.Domain/Validation/ValidationRuleSet.cs
@@ -1,0 +1,15 @@
+using System.Linq.Expressions;
+
+namespace Validation.Domain.Validation;
+
+public class ValidationRuleSet<T>
+{
+    public Expression<Func<T, double>> Selector { get; }
+    public IReadOnlyList<ValidationRule> Rules { get; }
+
+    public ValidationRuleSet(Expression<Func<T, double>> selector, params ValidationRule[] rules)
+    {
+        Selector = selector;
+        Rules = rules;
+    }
+}

--- a/Validation.Domain/Validation/ValidationStrategy.cs
+++ b/Validation.Domain/Validation/ValidationStrategy.cs
@@ -1,0 +1,9 @@
+namespace Validation.Domain.Validation;
+
+public enum ValidationStrategy
+{
+    Sum,
+    Average,
+    Count,
+    Variance
+}

--- a/Validation.Tests/SummarisationValidatorRuleSetTests.cs
+++ b/Validation.Tests/SummarisationValidatorRuleSetTests.cs
@@ -1,0 +1,41 @@
+using System.Linq;
+using Validation.Domain.Validation;
+
+namespace Validation.Tests;
+
+public class SummarisationValidatorRuleSetTests
+{
+    private record Data(double Metric);
+
+    [Fact]
+    public void ValidateRuleSet_supports_multiple_rules()
+    {
+        var validator = new SummarisationValidator();
+        var data = new[] { new Data(1), new Data(2), new Data(3) }.AsQueryable();
+        var rules = new ValidationRuleSet<Data>(d => d.Metric,
+            new ValidationRule(ValidationStrategy.Sum, 6),
+            new ValidationRule(ValidationStrategy.Average, 2));
+        Assert.True(validator.ValidateRuleSet(data, rules));
+    }
+
+    [Fact]
+    public void ValidateRuleSet_fails_when_threshold_exceeded()
+    {
+        var validator = new SummarisationValidator();
+        var data = new[] { new Data(1), new Data(2), new Data(3) }.AsQueryable();
+        var rules = new ValidationRuleSet<Data>(d => d.Metric,
+            new ValidationRule(ValidationStrategy.Sum, 5));
+        Assert.False(validator.ValidateRuleSet(data, rules));
+    }
+
+    [Fact]
+    public void ValidateRuleSet_supports_count_and_variance()
+    {
+        var validator = new SummarisationValidator();
+        var data = new[] { new Data(1), new Data(2), new Data(3), new Data(4) }.AsQueryable();
+        var rules = new ValidationRuleSet<Data>(d => d.Metric,
+            new ValidationRule(ValidationStrategy.Count, 4),
+            new ValidationRule(ValidationStrategy.Variance, 1.25));
+        Assert.True(validator.ValidateRuleSet(data, rules));
+    }
+}


### PR DESCRIPTION
## Summary
- add `ValidationStrategy` enum supporting Sum, Average, Count and Variance
- introduce `ValidationRule` and `ValidationRuleSet` for multiple rules on a metric
- extend `SummarisationValidator` with `ValidateRuleSet` to evaluate datasets
- test new rule set validation scenarios

## Testing
- `dotnet test --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_688bf35dbdc08330992f0ae02b3fa303