### PR TITLE
Add rule set summarisation validation

### DIFF
--- a/Validation.Domain/Validation/SummarisationValidator.cs
+++ b/Validation.Domain/Validation/SummarisationValidator.cs
@@ -6,4 +6,25 @@ public class SummarisationValidator
     {
         return rules.All(r => r.Validate(previousValue, newValue));
     }
+
+    public bool ValidateRuleSet<T>(IQueryable<T> all, ValidationRuleSet<T> ruleSet)
+    {
+        var values = all.Select(ruleSet.Selector).ToList();
+
+        foreach (var rule in ruleSet.Rules)
+        {
+            double summary = rule.Strategy switch
+            {
+                ValidationStrategy.Sum => values.Sum(),
+                ValidationStrategy.Average => values.Average(),
+                ValidationStrategy.Count => values.Count,
+                ValidationStrategy.Variance => values.Count == 0 ? 0 : values.Select(v => Math.Pow(v - values.Average(), 2)).Average(),
+                _ => throw new ArgumentOutOfRangeException()
+            };
+
+            if (summary > rule.Threshold) return false;
+        }
+
+        return true;
+    }
 }

--- a/Validation.Domain/Validation/ValidationRule.cs
+++ b/Validation.Domain/Validation/ValidationRule.cs
@@ -1,0 +1,3 @@
+namespace Validation.Domain.Validation;
+
+public record ValidationRule(ValidationStrategy Strategy, double Threshold);

--- a/Validation.Domain/Validation/ValidationRuleSet.cs
+++ b/Validation.Domain/Validation/ValidationRuleSet.cs
@@ -1,0 +1,15 @@
+using System.Linq.Expressions;
+
+namespace Validation.Domain.Validation;
+
+public class ValidationRuleSet<T>
+{
+    public Expression<Func<T, double>> Selector { get; }
+    public IReadOnlyList<ValidationRule> Rules { get; }
+
+    public ValidationRuleSet(Expression<Func<T, double>> selector, params ValidationRule[] rules)
+    {
+        Selector = selector;
+        Rules = rules;
+    }
+}

--- a/Validation.Domain/Validation/ValidationStrategy.cs
+++ b/Validation.Domain/Validation/ValidationStrategy.cs
@@ -1,0 +1,9 @@
+namespace Validation.Domain.Validation;
+
+public enum ValidationStrategy
+{
+    Sum,
+    Average,
+    Count,
+    Variance
+}

--- a/Validation.Tests/SummarisationValidatorRuleSetTests.cs
+++ b/Validation.Tests/SummarisationValidatorRuleSetTests.cs
@@ -1,0 +1,32 @@
+using System.Linq;
+using Validation.Domain.Validation;
+
+namespace Validation.Tests;
+
+public class SummarisationValidatorRuleSetTests
+{
+    [Fact]
+    public void ValidateRuleSet_returns_true_when_all_rules_pass()
+    {
+        var data = new double[] {1,2,3,4,5}.AsQueryable();
+        var ruleSet = new ValidationRuleSet<double>(x => x,
+            new ValidationRule(ValidationStrategy.Sum, 20),
+            new ValidationRule(ValidationStrategy.Average, 4),
+            new ValidationRule(ValidationStrategy.Count, 6),
+            new ValidationRule(ValidationStrategy.Variance, 2));
+        var validator = new SummarisationValidator();
+
+        Assert.True(validator.ValidateRuleSet(data, ruleSet));
+    }
+
+    [Fact]
+    public void ValidateRuleSet_returns_false_when_any_rule_fails()
+    {
+        var data = new double[] {1,2,3,4,5}.AsQueryable();
+        var ruleSet = new ValidationRuleSet<double>(x => x,
+            new ValidationRule(ValidationStrategy.Sum, 10));
+        var validator = new SummarisationValidator();
+
+        Assert.False(validator.ValidateRuleSet(data, ruleSet));
+    }
+}


### PR DESCRIPTION
## Summary
- add new validation strategies enum
- add record for strategy/threshold pairs
- implement ValidationRuleSet<T>
- extend SummarisationValidator with ValidateRuleSet overload
- test summarisation rule sets

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688bf35dbdc08330992f0ae02b3fa303