### PR TITLE
Add multi-strategy validation rule sets

### DIFF
--- a/Validation.Domain/Validation/SummarisationValidator.cs
+++ b/Validation.Domain/Validation/SummarisationValidator.cs
@@ -6,4 +6,26 @@ public class SummarisationValidator
     {
         return rules.All(r => r.Validate(previousValue, newValue));
     }
+
+    public bool ValidateRuleSet<T>(IQueryable<T> all, ValidationRuleSet<T> ruleSet)
+    {
+        foreach (var rule in ruleSet.Rules)
+        {
+            var values = all.Select(ruleSet.Selector);
+            double summary = rule.Strategy switch
+            {
+                ValidationStrategy.Sum => values.Sum(),
+                ValidationStrategy.Average => values.Average(),
+                ValidationStrategy.Count => values.Count(),
+                ValidationStrategy.Variance =>
+                    values.Any() ? values.Select(v => Math.Pow(v - values.Average(), 2)).Average() : 0,
+                _ => throw new ArgumentOutOfRangeException()
+            };
+
+            if (summary > rule.Threshold)
+                return false;
+        }
+
+        return true;
+    }
 }

--- a/Validation.Domain/Validation/ValidationRule.cs
+++ b/Validation.Domain/Validation/ValidationRule.cs
@@ -1,0 +1,3 @@
+namespace Validation.Domain.Validation;
+
+public record ValidationRule(ValidationStrategy Strategy, double Threshold);

--- a/Validation.Domain/Validation/ValidationRuleSet.cs
+++ b/Validation.Domain/Validation/ValidationRuleSet.cs
@@ -1,0 +1,15 @@
+using System.Linq.Expressions;
+
+namespace Validation.Domain.Validation;
+
+public class ValidationRuleSet<T>
+{
+    public Expression<Func<T, double>> Selector { get; }
+    public ValidationRule[] Rules { get; }
+
+    public ValidationRuleSet(Expression<Func<T, double>> selector, params ValidationRule[] rules)
+    {
+        Selector = selector;
+        Rules = rules;
+    }
+}

--- a/Validation.Domain/Validation/ValidationStrategy.cs
+++ b/Validation.Domain/Validation/ValidationStrategy.cs
@@ -1,0 +1,9 @@
+namespace Validation.Domain.Validation;
+
+public enum ValidationStrategy
+{
+    Sum,
+    Average,
+    Count,
+    Variance
+}

--- a/Validation.Tests/SummarisationValidatorRuleSetTests.cs
+++ b/Validation.Tests/SummarisationValidatorRuleSetTests.cs
@@ -1,0 +1,47 @@
+using System.Linq;
+using Validation.Domain.Validation;
+using Xunit;
+
+namespace Validation.Tests;
+
+public class SummarisationValidatorRuleSetTests
+{
+    private class Sample { public double Value { get; set; } }
+
+    [Fact]
+    public void ValidateRuleSet_returns_true_when_all_rules_pass()
+    {
+        var data = new[]
+        {
+            new Sample { Value = 1 },
+            new Sample { Value = 2 },
+            new Sample { Value = 3 },
+            new Sample { Value = 4 }
+        }.AsQueryable();
+
+        var ruleSet = new ValidationRuleSet<Sample>(s => s.Value,
+            new ValidationRule(ValidationStrategy.Sum, 15),
+            new ValidationRule(ValidationStrategy.Average, 4),
+            new ValidationRule(ValidationStrategy.Count, 4));
+
+        var validator = new SummarisationValidator();
+        Assert.True(validator.ValidateRuleSet(data, ruleSet));
+    }
+
+    [Fact]
+    public void ValidateRuleSet_returns_false_when_any_rule_fails()
+    {
+        var data = new[]
+        {
+            new Sample { Value = 10 },
+            new Sample { Value = 5 }
+        }.AsQueryable();
+
+        var ruleSet = new ValidationRuleSet<Sample>(s => s.Value,
+            new ValidationRule(ValidationStrategy.Sum, 10),
+            new ValidationRule(ValidationStrategy.Average, 10));
+
+        var validator = new SummarisationValidator();
+        Assert.False(validator.ValidateRuleSet(data, ruleSet));
+    }
+}


### PR DESCRIPTION
## Summary
- support validation strategy enum with Sum, Average, Count and Variance
- introduce `ValidationRule` and `ValidationRuleSet`
- extend `SummarisationValidator` with `ValidateRuleSet`
- cover rule set scenarios with unit tests

## Testing
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_688bf35dbdc08330992f0ae02b3fa303