### PR TITLE
Add validation rule sets

### DIFF
--- a/Validation.Domain/Validation/SummarisationValidator.cs
+++ b/Validation.Domain/Validation/SummarisationValidator.cs
@@ -6,4 +6,25 @@ public class SummarisationValidator
     {
         return rules.All(r => r.Validate(previousValue, newValue));
     }
+
+    public bool ValidateRuleSet<T>(IQueryable<T> all, ValidationRuleSet<T> ruleSet)
+    {
+        var values = all.Select(ruleSet.Selector).ToList();
+        var average = values.Count > 0 ? values.Average() : 0;
+        foreach (var rule in ruleSet.Rules)
+        {
+            double summary = rule.Strategy switch
+            {
+                ValidationStrategy.Sum => values.Sum(),
+                ValidationStrategy.Average => average,
+                ValidationStrategy.Count => values.Count,
+                ValidationStrategy.Variance => values.Count > 0 ? values.Select(v => Math.Pow(v - average, 2)).Average() : 0,
+                _ => throw new ArgumentOutOfRangeException()
+            };
+
+            if (summary > rule.Threshold)
+                return false;
+        }
+        return true;
+    }
 }

--- a/Validation.Domain/Validation/ValidationRule.cs
+++ b/Validation.Domain/Validation/ValidationRule.cs
@@ -1,0 +1,3 @@
+namespace Validation.Domain.Validation;
+
+public record ValidationRule(ValidationStrategy Strategy, double Threshold);

--- a/Validation.Domain/Validation/ValidationRuleSet.cs
+++ b/Validation.Domain/Validation/ValidationRuleSet.cs
@@ -1,0 +1,15 @@
+using System.Linq.Expressions;
+
+namespace Validation.Domain.Validation;
+
+public class ValidationRuleSet<T>
+{
+    public Expression<Func<T, double>> Selector { get; }
+    public IReadOnlyList<ValidationRule> Rules { get; }
+
+    public ValidationRuleSet(Expression<Func<T, double>> selector, params ValidationRule[] rules)
+    {
+        Selector = selector;
+        Rules = rules;
+    }
+}

--- a/Validation.Domain/Validation/ValidationStrategy.cs
+++ b/Validation.Domain/Validation/ValidationStrategy.cs
@@ -1,0 +1,9 @@
+namespace Validation.Domain.Validation;
+
+public enum ValidationStrategy
+{
+    Sum,
+    Average,
+    Count,
+    Variance
+}

--- a/Validation.Tests/SummarisationValidatorRuleSetTests.cs
+++ b/Validation.Tests/SummarisationValidatorRuleSetTests.cs
@@ -1,0 +1,33 @@
+using Validation.Domain.Validation;
+
+namespace Validation.Tests;
+
+public class SummarisationValidatorRuleSetTests
+{
+    private record NumericItem(double Metric);
+
+    [Fact]
+    public void ValidateRuleSet_returns_true_when_all_rules_pass()
+    {
+        var data = new[] { new NumericItem(1), new NumericItem(2), new NumericItem(3) }.AsQueryable();
+        var ruleSet = new ValidationRuleSet<NumericItem>(x => x.Metric,
+            new ValidationRule(ValidationStrategy.Sum, 6),
+            new ValidationRule(ValidationStrategy.Average, 3),
+            new ValidationRule(ValidationStrategy.Count, 3),
+            new ValidationRule(ValidationStrategy.Variance, 1));
+
+        var validator = new SummarisationValidator();
+        Assert.True(validator.ValidateRuleSet(data, ruleSet));
+    }
+
+    [Fact]
+    public void ValidateRuleSet_returns_false_if_any_rule_fails()
+    {
+        var data = new[] { new NumericItem(1), new NumericItem(2), new NumericItem(3) }.AsQueryable();
+        var ruleSet = new ValidationRuleSet<NumericItem>(x => x.Metric,
+            new ValidationRule(ValidationStrategy.Sum, 5));
+
+        var validator = new SummarisationValidator();
+        Assert.False(validator.ValidateRuleSet(data, ruleSet));
+    }
+}


### PR DESCRIPTION
## Summary
- add ValidationStrategy enum and ValidationRule record
- introduce ValidationRuleSet for metric selectors
- extend SummarisationValidator with ValidateRuleSet
- add unit tests for rule set validation

## Testing
- `dotnet test Validation.Tests/Validation.Tests.csproj --no-build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_688bf35dbdc08330992f0ae02b3fa303