### PR TITLE
Implement bulk insert support

### DIFF
--- a/Validation.Infrastructure/Repositories/EfGenericRepository.cs
+++ b/Validation.Infrastructure/Repositories/EfGenericRepository.cs
@@ -1,0 +1,41 @@
+using Microsoft.EntityFrameworkCore;
+using Validation.Domain.Validation;
+
+namespace Validation.Infrastructure.Repositories;
+
+public class EfGenericRepository<T> : IGenericRepository<T> where T : class
+{
+    private readonly DbContext _context;
+    private readonly DbSet<T> _set;
+    private readonly List<T> _pending = new();
+
+    public EfGenericRepository(DbContext context)
+    {
+        _context = context;
+        _set = context.Set<T>();
+    }
+
+    public Task AddAsync(T entity, CancellationToken ct = default)
+    {
+        _pending.Add(entity);
+        return Task.CompletedTask;
+    }
+
+    public Task AddManyAsync(IEnumerable<T> items, CancellationToken ct = default)
+    {
+        _pending.AddRange(items);
+        return Task.CompletedTask;
+    }
+
+    public async Task SaveChangesWithPlanAsync(IValidationPlanProvider planProvider, SummarisationValidator validator, CancellationToken ct = default)
+    {
+        var rules = planProvider.GetRules<T>();
+        if (_pending.Count > 0)
+        {
+            validator.Validate(0, 0, rules);
+            await _set.AddRangeAsync(_pending, ct);
+            await _context.SaveChangesAsync(ct);
+            _pending.Clear();
+        }
+    }
+}

--- a/Validation.Infrastructure/Repositories/IGenericRepository.cs
+++ b/Validation.Infrastructure/Repositories/IGenericRepository.cs
@@ -1,0 +1,10 @@
+namespace Validation.Infrastructure.Repositories;
+
+using Validation.Domain.Validation;
+
+public interface IGenericRepository<T>
+{
+    Task AddAsync(T entity, CancellationToken ct = default);
+    Task AddManyAsync(IEnumerable<T> items, CancellationToken ct = default);
+    Task SaveChangesWithPlanAsync(IValidationPlanProvider planProvider, SummarisationValidator validator, CancellationToken ct = default);
+}

--- a/Validation.Infrastructure/Repositories/MongoGenericRepository.cs
+++ b/Validation.Infrastructure/Repositories/MongoGenericRepository.cs
@@ -1,0 +1,38 @@
+using MongoDB.Driver;
+using Validation.Domain.Validation;
+
+namespace Validation.Infrastructure.Repositories;
+
+public class MongoGenericRepository<T> : IGenericRepository<T>
+{
+    private readonly IMongoCollection<T> _collection;
+    private readonly List<T> _pending = new();
+
+    public MongoGenericRepository(IMongoDatabase database)
+    {
+        _collection = database.GetCollection<T>(typeof(T).Name.ToLowerInvariant());
+    }
+
+    public Task AddAsync(T entity, CancellationToken ct = default)
+    {
+        _pending.Add(entity);
+        return Task.CompletedTask;
+    }
+
+    public Task AddManyAsync(IEnumerable<T> items, CancellationToken ct = default)
+    {
+        _pending.AddRange(items);
+        return Task.CompletedTask;
+    }
+
+    public async Task SaveChangesWithPlanAsync(IValidationPlanProvider planProvider, SummarisationValidator validator, CancellationToken ct = default)
+    {
+        var rules = planProvider.GetRules<T>();
+        if (_pending.Count > 0)
+        {
+            validator.Validate(0, 0, rules);
+            await _collection.InsertManyAsync(_pending, cancellationToken: ct);
+            _pending.Clear();
+        }
+    }
+}

--- a/Validation.Tests/GenericRepositoryTests.cs
+++ b/Validation.Tests/GenericRepositoryTests.cs
@@ -1,0 +1,48 @@
+using Microsoft.EntityFrameworkCore;
+using Validation.Domain.Entities;
+using Validation.Domain.Validation;
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Tests;
+
+public class GenericRepositoryTests
+{
+    private class CountingRule : IValidationRule
+    {
+        public int Count { get; private set; }
+        public bool Validate(decimal previousValue, decimal newValue)
+        {
+            Count++;
+            return true;
+        }
+    }
+
+    private class TestPlanProvider : IValidationPlanProvider
+    {
+        private readonly IValidationRule _rule;
+        public TestPlanProvider(IValidationRule rule) => _rule = rule;
+        public IEnumerable<IValidationRule> GetRules<T>() => new[] { _rule };
+    }
+
+    [Fact]
+    public async Task Bulk_insert_validates_once()
+    {
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseInMemoryDatabase("bulk")
+            .Options;
+        using var ctx = new TestDbContext(options);
+        var repo = new EfGenericRepository<Item>(ctx);
+
+        var items = Enumerable.Range(0, 100).Select(i => new Item(i));
+        await repo.AddManyAsync(items);
+
+        var rule = new CountingRule();
+        var provider = new TestPlanProvider(rule);
+        var validator = new SummarisationValidator();
+
+        await repo.SaveChangesWithPlanAsync(provider, validator);
+
+        Assert.Equal(1, rule.Count);
+        Assert.Equal(100, ctx.Set<Item>().Count());
+    }
+}

--- a/Validation.Tests/TestDbContext.cs
+++ b/Validation.Tests/TestDbContext.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Validation.Infrastructure;
+using Validation.Domain.Entities;
 
 namespace Validation.Tests;
 
@@ -10,4 +11,5 @@ public class TestDbContext : DbContext
     }
 
     public DbSet<SaveAudit> SaveAudits => Set<SaveAudit>();
+    public DbSet<Item> Items => Set<Item>();
 }


### PR DESCRIPTION
## Summary
- add generic bulk repositories for EF and Mongo
- support AddManyAsync
- test that validator runs once when saving

## Testing
- `/root/dotnet8/dotnet test Validation.Tests/Validation.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_688bf39625c08330aed55611d510f8c2