### PR TITLE
Add delete flow parity

### DIFF
--- a/Validation.Domain/Events/DeleteCommitted.cs
+++ b/Validation.Domain/Events/DeleteCommitted.cs
@@ -1,0 +1,3 @@
+namespace Validation.Domain.Events;
+
+public record DeleteCommitted(Guid Id);

--- a/Validation.Domain/Events/DeleteValidated.cs
+++ b/Validation.Domain/Events/DeleteValidated.cs
@@ -1,0 +1,3 @@
+namespace Validation.Domain.Events;
+
+public record DeleteValidated(Guid Id, bool Validated);

--- a/Validation.Infrastructure/Messaging/DeleteCommitConsumer.cs
+++ b/Validation.Infrastructure/Messaging/DeleteCommitConsumer.cs
@@ -1,0 +1,12 @@
+using MassTransit;
+using Validation.Domain.Events;
+
+namespace Validation.Infrastructure.Messaging;
+
+public class DeleteCommitConsumer : IConsumer<DeleteValidated>
+{
+    public async Task Consume(ConsumeContext<DeleteValidated> context)
+    {
+        await context.Publish(new DeleteCommitted(context.Message.Id));
+    }
+}

--- a/Validation.Infrastructure/Messaging/DeleteValidationConsumer.cs
+++ b/Validation.Infrastructure/Messaging/DeleteValidationConsumer.cs
@@ -16,11 +16,11 @@ public class DeleteValidationConsumer<T> : IConsumer<DeleteRequested>
         _validator = validator;
     }
 
-    public Task Consume(ConsumeContext<DeleteRequested> context)
+    public async Task Consume(ConsumeContext<DeleteRequested> context)
     {
         var rules = _planProvider.GetRules<T>();
-        // execute manual rules with zero metrics since delete; actual logic omitted
-        _validator.Validate(0, 0, rules);
-        return Task.CompletedTask;
+        // execute manual rules with zero metrics since delete
+        var isValid = _validator.Validate(0, 0, rules);
+        await context.Publish(new DeleteValidated(context.Message.Id, isValid));
     }
 }

--- a/Validation.Tests/DeleteCommitConsumerTests.cs
+++ b/Validation.Tests/DeleteCommitConsumerTests.cs
@@ -1,0 +1,29 @@
+using MassTransit;
+using MassTransit.Testing;
+using Validation.Domain.Events;
+using Validation.Infrastructure.Messaging;
+
+namespace Validation.Tests;
+
+public class DeleteCommitConsumerTests
+{
+    [Fact]
+    public async Task Publish_DeleteCommitted_on_success()
+    {
+        var consumer = new DeleteCommitConsumer();
+        var harness = new InMemoryTestHarness();
+        harness.Consumer(() => consumer);
+
+        await harness.Start();
+        try
+        {
+            await harness.InputQueueSendEndpoint.Send(new DeleteValidated(Guid.NewGuid(), true));
+
+            Assert.True(await harness.Published.Any<DeleteCommitted>());
+        }
+        finally
+        {
+            await harness.Stop();
+        }
+    }
+}

--- a/Validation.Tests/DeleteValidationConsumerTests.cs
+++ b/Validation.Tests/DeleteValidationConsumerTests.cs
@@ -1,0 +1,36 @@
+using MassTransit;
+using MassTransit.Testing;
+using Validation.Domain.Events;
+using Validation.Domain.Validation;
+using Validation.Infrastructure.Messaging;
+
+namespace Validation.Tests;
+
+public class DeleteValidationConsumerTests
+{
+    private class TestPlanProvider : IValidationPlanProvider
+    {
+        public IEnumerable<IValidationRule> GetRules<T>() => new[] { new RawDifferenceRule(100) };
+    }
+
+    [Fact]
+    public async Task Publish_DeleteValidated_after_processing()
+    {
+        var consumer = new DeleteValidationConsumer<string>(new TestPlanProvider(), new SummarisationValidator());
+
+        var harness = new InMemoryTestHarness();
+        harness.Consumer(() => consumer);
+
+        await harness.Start();
+        try
+        {
+            await harness.InputQueueSendEndpoint.Send(new DeleteRequested(Guid.NewGuid()));
+
+            Assert.True(await harness.Published.Any<DeleteValidated>());
+        }
+        finally
+        {
+            await harness.Stop();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add DeleteValidated and DeleteCommitted events
- implement DeleteValidationConsumer to publish DeleteValidated
- implement DeleteCommitConsumer to publish DeleteCommitted
- test new consumers

## Testing
- `dotnet test --no-build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_688bf3c1185c8330acf9a4c30854bfce