### PR TITLE
Add EF unit of work with validation

### DIFF
--- a/Validation.Infrastructure/Repositories/EfCoreRepository.cs
+++ b/Validation.Infrastructure/Repositories/EfCoreRepository.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Validation.Infrastructure.Repositories;
+
+public class EfCoreRepository<T> : IRepository<T> where T : class
+{
+    private readonly DbContext _context;
+    private readonly DbSet<T> _set;
+
+    public EfCoreRepository(DbContext context)
+    {
+        _context = context;
+        _set = context.Set<T>();
+    }
+
+    public async Task<T?> GetAsync(Guid id, CancellationToken ct = default)
+    {
+        return await _set.FindAsync(new object?[] { id }, ct);
+    }
+
+    public Task AddAsync(T entity, CancellationToken ct = default)
+    {
+        return _set.AddAsync(entity, ct).AsTask();
+    }
+
+    public Task UpdateAsync(T entity, CancellationToken ct = default)
+    {
+        _set.Update(entity);
+        return Task.CompletedTask;
+    }
+
+    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
+    {
+        var entity = await _set.FindAsync(new object?[] { id }, ct);
+        if (entity != null)
+        {
+            _set.Remove(entity);
+        }
+    }
+}

--- a/Validation.Infrastructure/UnitOfWork/IUnitOfWork.cs
+++ b/Validation.Infrastructure/UnitOfWork/IUnitOfWork.cs
@@ -1,0 +1,10 @@
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Infrastructure.UnitOfWork;
+
+public interface IUnitOfWork
+{
+    IRepository<T> Repository<T>() where T : class;
+    Task<int> SaveChangesAsync(CancellationToken ct = default);
+    Task<int> SaveChangesWithPlanAsync<T>(CancellationToken ct = default) where T : class;
+}

--- a/Validation.Infrastructure/UnitOfWork/UnitOfWork.cs
+++ b/Validation.Infrastructure/UnitOfWork/UnitOfWork.cs
@@ -1,0 +1,52 @@
+using Microsoft.EntityFrameworkCore;
+using Validation.Domain.Validation;
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Infrastructure.UnitOfWork;
+
+public class UnitOfWork<TContext> : IUnitOfWork where TContext : DbContext
+{
+    private readonly TContext _context;
+    private readonly SummarisationValidator _validator;
+    private readonly IValidationPlanProvider _planProvider;
+
+    public UnitOfWork(TContext context, SummarisationValidator validator, IValidationPlanProvider planProvider)
+    {
+        _context = context;
+        _validator = validator;
+        _planProvider = planProvider;
+    }
+
+    public IRepository<T> Repository<T>() where T : class => new EfCoreRepository<T>(_context);
+
+    public Task<int> SaveChangesAsync(CancellationToken ct = default)
+    {
+        return _context.SaveChangesAsync(ct);
+    }
+
+    public async Task<int> SaveChangesWithPlanAsync<T>(CancellationToken ct = default) where T : class
+    {
+        foreach (var entry in _context.ChangeTracker.Entries<T>())
+        {
+            if (entry.State == EntityState.Modified || entry.State == EntityState.Added)
+            {
+                var rules = _planProvider.GetRules<T>();
+                decimal previous = 0m;
+                decimal current = 0m;
+                if (entry.Properties.Any(p => p.Metadata.Name == "Metric"))
+                {
+                    if (entry.State == EntityState.Modified)
+                        previous = entry.OriginalValues.GetValue<decimal>("Metric");
+                    current = entry.CurrentValues.GetValue<decimal>("Metric");
+                }
+
+                if (!_validator.Validate(previous, current, rules))
+                {
+                    throw new InvalidOperationException("Validation failed");
+                }
+            }
+        }
+
+        return await _context.SaveChangesAsync(ct);
+    }
+}

--- a/Validation.Tests/TestDbContext.cs
+++ b/Validation.Tests/TestDbContext.cs
@@ -10,4 +10,5 @@ public class TestDbContext : DbContext
     }
 
     public DbSet<SaveAudit> SaveAudits => Set<SaveAudit>();
+    public DbSet<Validation.Domain.Entities.Item> Items => Set<Validation.Domain.Entities.Item>();
 }

--- a/Validation.Tests/UnitOfWorkTests.cs
+++ b/Validation.Tests/UnitOfWorkTests.cs
@@ -1,0 +1,47 @@
+using Microsoft.EntityFrameworkCore;
+using Validation.Domain.Entities;
+using Validation.Domain.Validation;
+using Validation.Infrastructure.Repositories;
+using Validation.Infrastructure.UnitOfWork;
+using Xunit;
+
+namespace Validation.Tests;
+
+public class UnitOfWorkTests
+{
+    private class TestPlanProvider : IValidationPlanProvider
+    {
+        public IEnumerable<IValidationRule> GetRules<T>() => new[] { new RawDifferenceRule(50) };
+    }
+
+    private static UnitOfWork<TestDbContext> CreateUow(string db)
+    {
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseInMemoryDatabase(db)
+            .Options;
+        var context = new TestDbContext(options);
+        return new UnitOfWork<TestDbContext>(context, new SummarisationValidator(), new TestPlanProvider());
+    }
+
+    [Fact]
+    public async Task SaveChangesWithPlanAsync_valid_succeeds()
+    {
+        var uow = CreateUow("valid_db");
+        var repo = uow.Repository<Item>();
+        await repo.AddAsync(new Item(10));
+        var result = await uow.SaveChangesWithPlanAsync<Item>();
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public async Task SaveChangesWithPlanAsync_invalid_throws()
+    {
+        var uow = CreateUow("invalid_db");
+        var repo = uow.Repository<Item>();
+        var item = new Item(10);
+        await repo.AddAsync(item);
+        await uow.SaveChangesWithPlanAsync<Item>();
+        item.UpdateMetric(100);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => uow.SaveChangesWithPlanAsync<Item>());
+    }
+}


### PR DESCRIPTION
## Summary
- implement `IUnitOfWork` and `UnitOfWork` using EF Core
- add generic `EfCoreRepository`
- extend `TestDbContext` with `Items`
- test validation inside `UnitOfWork`

## Testing
- `dotnet test Validation.Tests/Validation.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_688bf3a39a30833092b819fae566e418