### PR TITLE
Implement UnitOfWork pattern

### DIFF
--- a/Validation.Infrastructure/Repositories/EfCoreRepository.cs
+++ b/Validation.Infrastructure/Repositories/EfCoreRepository.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Validation.Infrastructure.Repositories;
+
+public class EfCoreRepository<T> : IRepository<T> where T : class
+{
+    private readonly DbContext _context;
+    private readonly DbSet<T> _set;
+
+    public EfCoreRepository(DbContext context)
+    {
+        _context = context;
+        _set = context.Set<T>();
+    }
+
+    public async Task<T?> GetAsync(Guid id, CancellationToken ct = default)
+    {
+        return await _set.FindAsync(new object?[] { id }, ct);
+    }
+
+    public async Task AddAsync(T entity, CancellationToken ct = default)
+    {
+        await _set.AddAsync(entity, ct);
+    }
+
+    public Task UpdateAsync(T entity, CancellationToken ct = default)
+    {
+        _set.Update(entity);
+        return Task.CompletedTask;
+    }
+
+    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
+    {
+        var entity = await _set.FindAsync(new object?[] { id }, ct);
+        if (entity != null)
+            _set.Remove(entity);
+    }
+}

--- a/Validation.Infrastructure/UnitOfWork/IUnitOfWork.cs
+++ b/Validation.Infrastructure/UnitOfWork/IUnitOfWork.cs
@@ -1,0 +1,10 @@
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Infrastructure.UnitOfWork;
+
+public interface IUnitOfWork
+{
+    IRepository<T> Repository<T>() where T : class;
+    Task<int> SaveChangesAsync(CancellationToken ct = default);
+    Task<int> SaveChangesWithPlanAsync<T>(CancellationToken ct = default);
+}

--- a/Validation.Infrastructure/UnitOfWork/UnitOfWork.cs
+++ b/Validation.Infrastructure/UnitOfWork/UnitOfWork.cs
@@ -1,0 +1,51 @@
+using Microsoft.EntityFrameworkCore;
+using Validation.Domain.Validation;
+using Validation.Infrastructure;
+using Validation.Infrastructure.Repositories;
+namespace Validation.Infrastructure.UnitOfWork;
+
+
+public class UnitOfWork<TContext> : IUnitOfWork where TContext : DbContext
+{
+    private readonly TContext _context;
+    private readonly SummarisationValidator _validator;
+    private readonly IValidationPlanProvider _planProvider;
+    private readonly Dictionary<Type, object> _repos = new();
+
+    public UnitOfWork(TContext context, SummarisationValidator validator, IValidationPlanProvider planProvider)
+    {
+        _context = context;
+        _validator = validator;
+        _planProvider = planProvider;
+    }
+
+    public IRepository<T> Repository<T>() where T : class
+    {
+        if (!_repos.TryGetValue(typeof(T), out var repo))
+        {
+            repo = new EfCoreRepository<T>(_context);
+            _repos[typeof(T)] = repo;
+        }
+        return (IRepository<T>)repo;
+    }
+
+    public Task<int> SaveChangesAsync(CancellationToken ct = default)
+    {
+        return _context.SaveChangesAsync(ct);
+    }
+
+    public async Task<int> SaveChangesWithPlanAsync<T>(CancellationToken ct = default)
+    {
+        var rules = _planProvider.GetRules<T>();
+        foreach (var entry in _context.ChangeTracker.Entries<SaveAudit>().Where(e => e.State == EntityState.Added))
+        {
+            var audit = entry.Entity;
+            var last = await _context.Set<SaveAudit>()
+                .Where(a => a.EntityId == audit.EntityId && a.Id != audit.Id)
+                .OrderByDescending(a => a.Timestamp)
+                .FirstOrDefaultAsync(ct);
+            audit.IsValid = _validator.Validate(last?.Metric ?? 0m, audit.Metric, rules);
+        }
+        return await _context.SaveChangesAsync(ct);
+    }
+}

--- a/Validation.Tests/UnitOfWorkTests.cs
+++ b/Validation.Tests/UnitOfWorkTests.cs
@@ -1,0 +1,63 @@
+using Microsoft.EntityFrameworkCore;
+using Validation.Domain.Entities;
+using Validation.Domain.Validation;
+using Validation.Infrastructure;
+using Validation.Infrastructure.Repositories;
+using Validation.Infrastructure.UnitOfWork;
+
+namespace Validation.Tests;
+
+public class UnitOfWorkTests
+{
+    private class TestPlanProvider : IValidationPlanProvider
+    {
+        private readonly decimal _threshold;
+        public TestPlanProvider(decimal threshold)
+        {
+            _threshold = threshold;
+        }
+        public IEnumerable<IValidationRule> GetRules<T>() => new[] { new RawDifferenceRule(_threshold) };
+    }
+
+    [Fact]
+    public async Task SaveChangesWithPlanAsync_sets_IsValid_based_on_rules()
+    {
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseInMemoryDatabase("uow_valid")
+            .Options;
+        var context = new TestDbContext(options);
+        var previous = new SaveAudit { Id = Guid.NewGuid(), EntityId = Guid.NewGuid(), Metric = 10m };
+        context.SaveAudits.Add(previous);
+        await context.SaveChangesAsync();
+
+        var uow = new UnitOfWork<TestDbContext>(context, new SummarisationValidator(), new TestPlanProvider(100m));
+        var repo = uow.Repository<SaveAudit>();
+        var audit = new SaveAudit { Id = Guid.NewGuid(), EntityId = previous.EntityId, Metric = 20m };
+        await repo.AddAsync(audit);
+
+        await uow.SaveChangesWithPlanAsync<Item>();
+
+        Assert.True(audit.IsValid);
+    }
+
+    [Fact]
+    public async Task SaveChangesWithPlanAsync_marks_invalid_when_rule_fails()
+    {
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseInMemoryDatabase("uow_invalid")
+            .Options;
+        var context = new TestDbContext(options);
+        var previous = new SaveAudit { Id = Guid.NewGuid(), EntityId = Guid.NewGuid(), Metric = 10m };
+        context.SaveAudits.Add(previous);
+        await context.SaveChangesAsync();
+
+        var uow = new UnitOfWork<TestDbContext>(context, new SummarisationValidator(), new TestPlanProvider(5m));
+        var repo = uow.Repository<SaveAudit>();
+        var audit = new SaveAudit { Id = Guid.NewGuid(), EntityId = previous.EntityId, Metric = 20m };
+        await repo.AddAsync(audit);
+
+        await uow.SaveChangesWithPlanAsync<Item>();
+
+        Assert.False(audit.IsValid);
+    }
+}


### PR DESCRIPTION
## Summary
- add generic EF Core repository
- add IUnitOfWork interface and EF Core implementation
- validate SaveAudit entries through SummarisationValidator before saving
- test UnitOfWork behaviour

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688bf3a39a30833092b819fae566e418