### PR TITLE
Introduce EF Core unit of work

### DIFF
--- a/Validation.Infrastructure/Repositories/EfCoreRepository.cs
+++ b/Validation.Infrastructure/Repositories/EfCoreRepository.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Validation.Infrastructure.Repositories;
+
+internal class EfCoreRepository<T> : IRepository<T> where T : class
+{
+    private readonly DbContext _context;
+    private readonly DbSet<T> _set;
+
+    public EfCoreRepository(DbContext context)
+    {
+        _context = context;
+        _set = context.Set<T>();
+    }
+
+    public async Task<T?> GetAsync(Guid id, CancellationToken ct = default)
+    {
+        return await _set.FindAsync(new object?[] { id }, ct);
+    }
+
+    public async Task AddAsync(T entity, CancellationToken ct = default)
+    {
+        await _set.AddAsync(entity, ct);
+    }
+
+    public Task UpdateAsync(T entity, CancellationToken ct = default)
+    {
+        _set.Update(entity);
+        return Task.CompletedTask;
+    }
+
+    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
+    {
+        var entity = await _set.FindAsync(new object?[] { id }, ct);
+        if (entity != null)
+        {
+            _set.Remove(entity);
+        }
+    }
+}

--- a/Validation.Infrastructure/UnitOfWork/IUnitOfWork.cs
+++ b/Validation.Infrastructure/UnitOfWork/IUnitOfWork.cs
@@ -1,0 +1,12 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Infrastructure.UnitOfWork;
+
+public interface IUnitOfWork
+{
+    IRepository<T> Repository<T>() where T : class;
+    Task<int> SaveChangesAsync(CancellationToken ct = default);
+    Task<int> SaveChangesWithPlanAsync<T>(CancellationToken ct = default);
+}

--- a/Validation.Infrastructure/UnitOfWork/UnitOfWork.cs
+++ b/Validation.Infrastructure/UnitOfWork/UnitOfWork.cs
@@ -1,0 +1,53 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Validation.Domain.Validation;
+using Validation.Infrastructure.Repositories;
+using Validation.Infrastructure;
+
+namespace Validation.Infrastructure.UnitOfWork;
+
+public class UnitOfWork<TContext> : IUnitOfWork where TContext : DbContext
+{
+    private readonly TContext _context;
+    private readonly IValidationPlanProvider _planProvider;
+    private readonly SummarisationValidator _validator;
+
+    public UnitOfWork(TContext context, IValidationPlanProvider planProvider, SummarisationValidator validator)
+    {
+        _context = context;
+        _planProvider = planProvider;
+        _validator = validator;
+    }
+
+    public IRepository<T> Repository<T>() where T : class
+    {
+        return new EfCoreRepository<T>(_context);
+    }
+
+    public Task<int> SaveChangesAsync(CancellationToken ct = default)
+    {
+        return _context.SaveChangesAsync(ct);
+    }
+
+    public async Task<int> SaveChangesWithPlanAsync<T>(CancellationToken ct = default)
+    {
+        var rules = _planProvider.GetRules<T>();
+        var audits = _context.ChangeTracker.Entries<SaveAudit>()
+            .Where(e => e.State == EntityState.Added)
+            .Select(e => e.Entity)
+            .ToList();
+
+        foreach (var audit in audits)
+        {
+            var last = await _context.Set<SaveAudit>()
+                .Where(a => a.EntityId == audit.EntityId && a.Id != audit.Id)
+                .OrderByDescending(a => a.Timestamp)
+                .FirstOrDefaultAsync(ct);
+            audit.IsValid = _validator.Validate(last?.Metric ?? 0m, audit.Metric, rules);
+        }
+
+        return await _context.SaveChangesAsync(ct);
+    }
+}

--- a/Validation.Tests/UnitOfWorkTests.cs
+++ b/Validation.Tests/UnitOfWorkTests.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore;
+using Validation.Domain.Entities;
+using Validation.Domain.Validation;
+using System.Linq;
+using Validation.Infrastructure.UnitOfWork;
+using Validation.Infrastructure;
+
+namespace Validation.Tests;
+
+public class UnitOfWorkTests
+{
+    private class TestPlanProvider : IValidationPlanProvider
+    {
+        public IEnumerable<IValidationRule> GetRules<T>() => new[] { new RawDifferenceRule(100) };
+    }
+
+    [Fact]
+    public async Task SaveChangesWithPlan_sets_validation_result()
+    {
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseInMemoryDatabase("uow-test")
+            .Options;
+        using var context = new TestDbContext(options);
+
+        var entityId = Guid.NewGuid();
+        context.SaveAudits.Add(new SaveAudit { Id = Guid.NewGuid(), EntityId = entityId, Metric = 50m });
+        await context.SaveChangesAsync();
+
+        var uow = new UnitOfWork<TestDbContext>(context, new TestPlanProvider(), new SummarisationValidator());
+        var repo = uow.Repository<SaveAudit>();
+        await repo.AddAsync(new SaveAudit { Id = Guid.NewGuid(), EntityId = entityId, Metric = 60m });
+
+        await uow.SaveChangesWithPlanAsync<Item>();
+
+        var latest = context.SaveAudits.OrderByDescending(a => a.Timestamp).First();
+        Assert.True(latest.IsValid);
+    }
+}


### PR DESCRIPTION
## Summary
- add `IUnitOfWork` interface
- implement EF Core `UnitOfWork<TContext>`
- add generic EF repository
- test unit of work validation logic

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688bf3a39a30833092b819fae566e418