### PR TITLE
Implement metric validation strategies

### DIFF
--- a/Validation.Domain/Validation/IMetricService.cs
+++ b/Validation.Domain/Validation/IMetricService.cs
@@ -1,0 +1,8 @@
+using System.Linq.Expressions;
+
+namespace Validation.Domain.Validation;
+
+public interface IMetricService
+{
+    Task<double> ComputeAsync<T>(IQueryable<T> source, Expression<Func<T, double>> selector, ValidationStrategy strategy);
+}

--- a/Validation.Domain/Validation/SummarisationValidator.cs
+++ b/Validation.Domain/Validation/SummarisationValidator.cs
@@ -1,0 +1,9 @@
+namespace Validation.Domain.Validation;
+
+public static class SummarisationValidator
+{
+    public static bool Validate<T>(double currentMetric, double previousMetric, ValidationPlan<T> plan)
+    {
+        return plan.Rule.Validate((decimal)previousMetric, (decimal)currentMetric);
+    }
+}

--- a/Validation.Domain/Validation/ValidationPlan.cs
+++ b/Validation.Domain/Validation/ValidationPlan.cs
@@ -1,0 +1,17 @@
+using System.Linq.Expressions;
+
+namespace Validation.Domain.Validation;
+
+public class ValidationPlan<T>
+{
+    public Expression<Func<T, double>> Selector { get; }
+    public ValidationStrategy Strategy { get; }
+    public IValidationRule Rule { get; }
+
+    public ValidationPlan(Expression<Func<T, double>> selector, ValidationStrategy strategy, IValidationRule rule)
+    {
+        Selector = selector;
+        Strategy = strategy;
+        Rule = rule;
+    }
+}

--- a/Validation.Domain/Validation/ValidationStrategy.cs
+++ b/Validation.Domain/Validation/ValidationStrategy.cs
@@ -1,0 +1,9 @@
+namespace Validation.Domain.Validation;
+
+public enum ValidationStrategy
+{
+    Sum,
+    Average,
+    Count,
+    Variance
+}

--- a/Validation.Infrastructure/Metrics/InMemoryMetricService.cs
+++ b/Validation.Infrastructure/Metrics/InMemoryMetricService.cs
@@ -1,0 +1,28 @@
+using System.Linq.Expressions;
+using Validation.Domain.Validation;
+
+namespace Validation.Infrastructure.Metrics;
+
+public class InMemoryMetricService : IMetricService
+{
+    public Task<double> ComputeAsync<T>(IQueryable<T> source, Expression<Func<T, double>> selector, ValidationStrategy strategy)
+    {
+        var values = source.Select(selector).ToList();
+        double result = strategy switch
+        {
+            ValidationStrategy.Sum => values.Sum(),
+            ValidationStrategy.Average => values.Count == 0 ? 0 : values.Average(),
+            ValidationStrategy.Count => values.Count,
+            ValidationStrategy.Variance => values.Count == 0 ? 0 : CalculateVariance(values),
+            _ => throw new ArgumentOutOfRangeException(nameof(strategy), strategy, null)
+        };
+        return Task.FromResult(result);
+    }
+
+    private static double CalculateVariance(IList<double> values)
+    {
+        var mean = values.Average();
+        var variance = values.Sum(v => Math.Pow(v - mean, 2)) / values.Count;
+        return variance;
+    }
+}

--- a/Validation.Tests/MetricServiceTests.cs
+++ b/Validation.Tests/MetricServiceTests.cs
@@ -1,0 +1,20 @@
+using Validation.Domain.Validation;
+using Validation.Infrastructure.Metrics;
+
+namespace Validation.Tests;
+
+public class MetricServiceTests
+{
+    [Theory]
+    [InlineData(ValidationStrategy.Sum, 6)]
+    [InlineData(ValidationStrategy.Average, 2)]
+    [InlineData(ValidationStrategy.Count, 3)]
+    [InlineData(ValidationStrategy.Variance, 0.6666666666666666)]
+    public async Task ComputeAsync_returns_expected_value(ValidationStrategy strategy, double expected)
+    {
+        var service = new InMemoryMetricService();
+        var data = new[] {1d, 2d, 3d}.AsQueryable();
+        var result = await service.ComputeAsync(data, x => x, strategy);
+        Assert.Equal(expected, result, 10);
+    }
+}

--- a/Validation.Tests/SummarisationValidatorTests.cs
+++ b/Validation.Tests/SummarisationValidatorTests.cs
@@ -1,0 +1,39 @@
+using Validation.Domain.Validation;
+using Validation.Infrastructure.Metrics;
+
+namespace Validation.Tests;
+
+public class SummarisationValidatorTests
+{
+    private readonly InMemoryMetricService _service = new();
+    private readonly IQueryable<double> _previous = new[] {10d, 20d, 30d}.AsQueryable();
+    private readonly IQueryable<double> _current = new[] {11d, 22d, 33d}.AsQueryable();
+
+    [Theory]
+    [InlineData(ValidationStrategy.Sum, true)]
+    [InlineData(ValidationStrategy.Average, true)]
+    [InlineData(ValidationStrategy.Count, true)]
+    [InlineData(ValidationStrategy.Variance, false)]
+    public async Task Validate_with_raw_difference_rule(ValidationStrategy strategy, bool expected)
+    {
+        var plan = new ValidationPlan<double>(x => x, strategy, new RawDifferenceRule(10));
+        var prev = await _service.ComputeAsync(_previous, x => x, strategy);
+        var curr = await _service.ComputeAsync(_current, x => x, strategy);
+        var result = SummarisationValidator.Validate(curr, prev, plan);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(ValidationStrategy.Sum, true)]
+    [InlineData(ValidationStrategy.Average, true)]
+    [InlineData(ValidationStrategy.Count, true)]
+    [InlineData(ValidationStrategy.Variance, false)]
+    public async Task Validate_with_percent_change_rule(ValidationStrategy strategy, bool expected)
+    {
+        var plan = new ValidationPlan<double>(x => x, strategy, new PercentChangeRule(15));
+        var prev = await _service.ComputeAsync(_previous, x => x, strategy);
+        var curr = await _service.ComputeAsync(_current, x => x, strategy);
+        var result = SummarisationValidator.Validate(curr, prev, plan);
+        Assert.Equal(expected, result);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ValidationStrategy` enum
- create `IMetricService` interface with in-memory implementation
- implement `SummarisationValidator` and supporting `ValidationPlan`
- add deterministic unit tests for metrics and validator

## Testing
- `dotnet test`
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_688bda57b634833081cdbbf99b0317dd