### PR TITLE
Add metric validation strategies and validator

### DIFF
--- a/Validation.Domain/Validation/IMetricService.cs
+++ b/Validation.Domain/Validation/IMetricService.cs
@@ -1,0 +1,8 @@
+using System.Linq.Expressions;
+
+namespace Validation.Domain.Validation;
+
+public interface IMetricService
+{
+    Task<double> ComputeAsync<T>(IQueryable<T> query, Expression<Func<T, double>> selector, ValidationStrategy strategy);
+}

--- a/Validation.Domain/Validation/MetricService.cs
+++ b/Validation.Domain/Validation/MetricService.cs
@@ -1,0 +1,23 @@
+using System.Linq.Expressions;
+
+namespace Validation.Domain.Validation;
+
+public class MetricService : IMetricService
+{
+    public Task<double> ComputeAsync<T>(IQueryable<T> query, Expression<Func<T, double>> selector, ValidationStrategy strategy)
+    {
+        var list = query.Select(selector.Compile()).ToList();
+        double result = strategy switch
+        {
+            ValidationStrategy.Sum => list.Sum(),
+            ValidationStrategy.Average => list.Average(),
+            ValidationStrategy.Count => list.Count,
+            ValidationStrategy.Variance =>
+                list.Count > 0
+                    ? list.Select(v => v - list.Average()).Select(d => d * d).Average()
+                    : 0,
+            _ => throw new NotImplementedException()
+        };
+        return Task.FromResult(result);
+    }
+}

--- a/Validation.Domain/Validation/SummarisationValidator.cs
+++ b/Validation.Domain/Validation/SummarisationValidator.cs
@@ -1,0 +1,9 @@
+namespace Validation.Domain.Validation;
+
+public static class SummarisationValidator
+{
+    public static bool Validate<T>(double currentMetric, double previousMetric, ValidationPlan<T> plan)
+    {
+        return plan.Rule.Validate((decimal)previousMetric, (decimal)currentMetric);
+    }
+}

--- a/Validation.Domain/Validation/ValidationPlan.cs
+++ b/Validation.Domain/Validation/ValidationPlan.cs
@@ -1,0 +1,17 @@
+using System.Linq.Expressions;
+
+namespace Validation.Domain.Validation;
+
+public class ValidationPlan<T>
+{
+    public Expression<Func<T, double>> MetricSelector { get; }
+    public ValidationStrategy Strategy { get; }
+    public IValidationRule Rule { get; }
+
+    public ValidationPlan(Expression<Func<T, double>> selector, ValidationStrategy strategy, IValidationRule rule)
+    {
+        MetricSelector = selector;
+        Strategy = strategy;
+        Rule = rule;
+    }
+}

--- a/Validation.Domain/Validation/ValidationStrategy.cs
+++ b/Validation.Domain/Validation/ValidationStrategy.cs
@@ -1,0 +1,9 @@
+namespace Validation.Domain.Validation;
+
+public enum ValidationStrategy
+{
+    Sum,
+    Average,
+    Count,
+    Variance
+}

--- a/Validation.Tests/MetricServiceTests.cs
+++ b/Validation.Tests/MetricServiceTests.cs
@@ -1,0 +1,20 @@
+using Validation.Domain.Validation;
+using Xunit;
+using System.Linq;
+using System.Threading.Tasks;
+
+public class MetricServiceTests
+{
+    [Theory]
+    [InlineData(ValidationStrategy.Sum, 6)]
+    [InlineData(ValidationStrategy.Average, 2)]
+    [InlineData(ValidationStrategy.Count, 3)]
+    [InlineData(ValidationStrategy.Variance, 2.0/3.0)]
+    public async Task ComputeAsync_returns_expected_result(ValidationStrategy strategy, double expected)
+    {
+        var data = new[] {1.0, 2.0, 3.0}.AsQueryable();
+        var service = new MetricService();
+        var result = await service.ComputeAsync(data, x => x, strategy);
+        Assert.Equal(expected, result, 5);
+    }
+}

--- a/Validation.Tests/SummarisationValidatorTests.cs
+++ b/Validation.Tests/SummarisationValidatorTests.cs
@@ -1,0 +1,53 @@
+using Validation.Domain.Validation;
+using Xunit;
+using System.Linq;
+using System.Threading.Tasks;
+
+public class SummarisationValidatorTests
+{
+    public static TheoryData<ValidationStrategy, bool> RawDifferenceData => new()
+    {
+        { ValidationStrategy.Sum, false },
+        { ValidationStrategy.Average, true },
+        { ValidationStrategy.Count, true },
+        { ValidationStrategy.Variance, true }
+    };
+
+    public static TheoryData<ValidationStrategy, bool> PercentChangeData => new()
+    {
+        { ValidationStrategy.Sum, true },
+        { ValidationStrategy.Average, true },
+        { ValidationStrategy.Count, true },
+        { ValidationStrategy.Variance, true }
+    };
+
+    [Theory]
+    [MemberData(nameof(RawDifferenceData))]
+    public async Task Validate_with_raw_difference_rule(ValidationStrategy strategy, bool expected)
+    {
+        var prevData = new[] {1.0, 2.0, 3.0}.AsQueryable();
+        var curData = new[] {2.0, 3.0, 4.0}.AsQueryable();
+        var service = new MetricService();
+        var prevMetric = await service.ComputeAsync(prevData, x => x, strategy);
+        var curMetric = await service.ComputeAsync(curData, x => x, strategy);
+
+        var plan = new ValidationPlan<double>(x => x, strategy, new RawDifferenceRule(2));
+        var result = SummarisationValidator.Validate(curMetric, prevMetric, plan);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [MemberData(nameof(PercentChangeData))]
+    public async Task Validate_with_percent_change_rule(ValidationStrategy strategy, bool expected)
+    {
+        var prevData = new[] {1.0, 2.0, 3.0}.AsQueryable();
+        var curData = new[] {2.0, 3.0, 4.0}.AsQueryable();
+        var service = new MetricService();
+        var prevMetric = await service.ComputeAsync(prevData, x => x, strategy);
+        var curMetric = await service.ComputeAsync(curData, x => x, strategy);
+
+        var plan = new ValidationPlan<double>(x => x, strategy, new PercentChangeRule(50));
+        var result = SummarisationValidator.Validate(curMetric, prevMetric, plan);
+        Assert.Equal(expected, result);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `ValidationStrategy` enum with Sum, Average, Count and Variance
- implement `IMetricService` and in-memory `MetricService`
- create `ValidationPlan` and `SummarisationValidator`
- test metric calculations and validation logic for all strategies and rule types

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688bda57b634833081cdbbf99b0317dd