### PR TITLE
Implement metric strategies and validator

### DIFF
--- a/Validation.Domain/Metrics/IMetricService.cs
+++ b/Validation.Domain/Metrics/IMetricService.cs
@@ -1,0 +1,8 @@
+using System.Linq.Expressions;
+
+namespace Validation.Domain.Metrics;
+
+public interface IMetricService
+{
+    Task<double> ComputeAsync<T>(IQueryable<T> source, Expression<Func<T, double>> selector, ValidationStrategy strategy);
+}

--- a/Validation.Domain/Metrics/SummarisationValidator.cs
+++ b/Validation.Domain/Metrics/SummarisationValidator.cs
@@ -1,0 +1,9 @@
+namespace Validation.Domain.Metrics;
+
+public static class SummarisationValidator
+{
+    public static bool Validate<T>(double currentMetric, double previousMetric, ValidationPlan<T> plan)
+    {
+        return plan.Rule.Validate((decimal)previousMetric, (decimal)currentMetric);
+    }
+}

--- a/Validation.Domain/Metrics/ValidationPlan.cs
+++ b/Validation.Domain/Metrics/ValidationPlan.cs
@@ -1,0 +1,6 @@
+using System.Linq.Expressions;
+using Validation.Domain.Validation;
+
+namespace Validation.Domain.Metrics;
+
+public record ValidationPlan<T>(Expression<Func<T, double>> Selector, ValidationStrategy Strategy, IValidationRule Rule);

--- a/Validation.Domain/Metrics/ValidationStrategy.cs
+++ b/Validation.Domain/Metrics/ValidationStrategy.cs
@@ -1,0 +1,9 @@
+namespace Validation.Domain.Metrics;
+
+public enum ValidationStrategy
+{
+    Sum,
+    Average,
+    Count,
+    Variance
+}

--- a/Validation.Infrastructure/Services/InMemoryMetricService.cs
+++ b/Validation.Infrastructure/Services/InMemoryMetricService.cs
@@ -1,0 +1,29 @@
+using System.Linq.Expressions;
+using Validation.Domain.Metrics;
+
+namespace Validation.Infrastructure.Services;
+
+public class InMemoryMetricService : IMetricService
+{
+    public Task<double> ComputeAsync<T>(IQueryable<T> source, Expression<Func<T, double>> selector, ValidationStrategy strategy)
+    {
+        double result = strategy switch
+        {
+            ValidationStrategy.Sum => source.Sum(selector),
+            ValidationStrategy.Average => source.Average(selector),
+            ValidationStrategy.Count => source.Count(),
+            ValidationStrategy.Variance => ComputeVariance(source.Select(selector)),
+            _ => throw new ArgumentOutOfRangeException(nameof(strategy))
+        };
+        return Task.FromResult(result);
+    }
+
+    private static double ComputeVariance(IEnumerable<double> values)
+    {
+        var list = values.ToList();
+        if (list.Count == 0) return 0;
+        var mean = list.Average();
+        var variance = list.Sum(v => Math.Pow(v - mean, 2)) / list.Count;
+        return variance;
+    }
+}

--- a/Validation.Tests/SummarisationValidatorTests.cs
+++ b/Validation.Tests/SummarisationValidatorTests.cs
@@ -1,0 +1,75 @@
+using System.Linq.Expressions;
+using Validation.Domain.Validation;
+using Validation.Domain.Metrics;
+using Validation.Infrastructure.Services;
+
+namespace Validation.Tests;
+
+public class SummarisationValidatorTests
+{
+    private readonly IMetricService _service = new InMemoryMetricService();
+
+    private class DataItem { public double Value { get; set; } }
+
+    [Theory]
+    [InlineData(ValidationStrategy.Sum, 5, true)]
+    [InlineData(ValidationStrategy.Average, 0.5, false)]
+    [InlineData(ValidationStrategy.Count, 0, false)]
+    [InlineData(ValidationStrategy.Variance, 3, false)]
+    public async Task RawDifference_rule_validates_correctly(ValidationStrategy strategy, double threshold, bool expected)
+    {
+        var previous = GetPreviousData(strategy);
+        var current = GetCurrentData(strategy);
+        var selector = (Expression<Func<DataItem,double>>)(x => x.Value);
+        var plan = new ValidationPlan<DataItem>(selector, strategy, new RawDifferenceRule((decimal)threshold));
+
+        var prevMetric = await _service.ComputeAsync(previous.AsQueryable(), selector, strategy);
+        var currMetric = await _service.ComputeAsync(current.AsQueryable(), selector, strategy);
+
+        var result = SummarisationValidator.Validate(currMetric, prevMetric, plan);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(ValidationStrategy.Sum, 10, false)]
+    [InlineData(ValidationStrategy.Average, 60, true)]
+    [InlineData(ValidationStrategy.Count, 60, true)]
+    [InlineData(ValidationStrategy.Variance, 700, true)]
+    public async Task PercentChange_rule_validates_correctly(ValidationStrategy strategy, double threshold, bool expected)
+    {
+        var previous = GetPreviousData(strategy);
+        var current = GetCurrentData(strategy);
+        var selector = (Expression<Func<DataItem,double>>)(x => x.Value);
+        var plan = new ValidationPlan<DataItem>(selector, strategy, new PercentChangeRule((decimal)threshold));
+
+        var prevMetric = await _service.ComputeAsync(previous.AsQueryable(), selector, strategy);
+        var currMetric = await _service.ComputeAsync(current.AsQueryable(), selector, strategy);
+
+        var result = SummarisationValidator.Validate(currMetric, prevMetric, plan);
+        Assert.Equal(expected, result);
+    }
+
+    private static IEnumerable<DataItem> GetPreviousData(ValidationStrategy strategy)
+    {
+        return strategy switch
+        {
+            ValidationStrategy.Sum => new[] { new DataItem { Value = 10 }, new DataItem { Value = 20 } },
+            ValidationStrategy.Average => new[] { new DataItem { Value = 1 }, new DataItem { Value = 2 }, new DataItem { Value = 3 } },
+            ValidationStrategy.Count => new[] { new DataItem { Value = 1 }, new DataItem { Value = 2 } },
+            ValidationStrategy.Variance => new[] { new DataItem { Value = 1 }, new DataItem { Value = 2 }, new DataItem { Value = 3 } },
+            _ => throw new NotSupportedException()
+        };
+    }
+
+    private static IEnumerable<DataItem> GetCurrentData(ValidationStrategy strategy)
+    {
+        return strategy switch
+        {
+            ValidationStrategy.Sum => new[] { new DataItem { Value = 15 }, new DataItem { Value = 20 } },
+            ValidationStrategy.Average => new[] { new DataItem { Value = 1 }, new DataItem { Value = 2 }, new DataItem { Value = 6 } },
+            ValidationStrategy.Count => new[] { new DataItem { Value = 1 }, new DataItem { Value = 2 }, new DataItem { Value = 3 } },
+            ValidationStrategy.Variance => new[] { new DataItem { Value = 1 }, new DataItem { Value = 2 }, new DataItem { Value = 6 } },
+            _ => throw new NotSupportedException()
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- support metric-based validation via `ValidationStrategy` enumeration
- add `IMetricService` with `InMemoryMetricService` implementation
- introduce `ValidationPlan` and `SummarisationValidator`
- add comprehensive unit tests for summarisation validator

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688bda57b634833081cdbbf99b0317dd