### PR TITLE
Implement metric strategies and validation

### DIFF
--- a/Validation.Domain/Metrics/IMetricService.cs
+++ b/Validation.Domain/Metrics/IMetricService.cs
@@ -1,0 +1,8 @@
+using System.Linq.Expressions;
+
+namespace Validation.Domain.Metrics;
+
+public interface IMetricService
+{
+    Task<double> ComputeAsync<T>(IQueryable<T> source, Expression<Func<T, double>> selector, ValidationStrategy strategy);
+}

--- a/Validation.Domain/Metrics/SummarisationValidator.cs
+++ b/Validation.Domain/Metrics/SummarisationValidator.cs
@@ -1,0 +1,9 @@
+namespace Validation.Domain.Metrics;
+
+public static class SummarisationValidator
+{
+    public static bool Validate<T>(double currentMetric, double previousMetric, ValidationPlan<T> plan)
+    {
+        return plan.Rule.Validate((decimal)previousMetric, (decimal)currentMetric);
+    }
+}

--- a/Validation.Domain/Metrics/ValidationPlan.cs
+++ b/Validation.Domain/Metrics/ValidationPlan.cs
@@ -1,0 +1,18 @@
+using System.Linq.Expressions;
+using Validation.Domain.Validation;
+
+namespace Validation.Domain.Metrics;
+
+public class ValidationPlan<T>
+{
+    public ValidationStrategy Strategy { get; }
+    public Expression<Func<T, double>> Selector { get; }
+    public IValidationRule Rule { get; }
+
+    public ValidationPlan(ValidationStrategy strategy, Expression<Func<T, double>> selector, IValidationRule rule)
+    {
+        Strategy = strategy;
+        Selector = selector;
+        Rule = rule;
+    }
+}

--- a/Validation.Domain/Metrics/ValidationStrategy.cs
+++ b/Validation.Domain/Metrics/ValidationStrategy.cs
@@ -1,0 +1,9 @@
+namespace Validation.Domain.Metrics;
+
+public enum ValidationStrategy
+{
+    Sum,
+    Average,
+    Count,
+    Variance
+}

--- a/Validation.Infrastructure/Metrics/InMemoryMetricService.cs
+++ b/Validation.Infrastructure/Metrics/InMemoryMetricService.cs
@@ -1,0 +1,29 @@
+using System.Linq.Expressions;
+using Validation.Domain.Metrics;
+
+namespace Validation.Infrastructure.Metrics;
+
+public class InMemoryMetricService : IMetricService
+{
+    public Task<double> ComputeAsync<T>(IQueryable<T> source, Expression<Func<T, double>> selector, ValidationStrategy strategy)
+    {
+        var values = source.Select(selector.Compile()).ToList();
+        double result = strategy switch
+        {
+            ValidationStrategy.Sum => values.Sum(),
+            ValidationStrategy.Average => values.Average(),
+            ValidationStrategy.Count => values.Count,
+            ValidationStrategy.Variance => ComputeVariance(values),
+            _ => throw new ArgumentOutOfRangeException(nameof(strategy))
+        };
+        return Task.FromResult(result);
+    }
+
+    private static double ComputeVariance(List<double> values)
+    {
+        if (values.Count == 0) return 0;
+        var avg = values.Average();
+        var variance = values.Select(v => (v - avg) * (v - avg)).Average();
+        return variance;
+    }
+}

--- a/Validation.Tests/MetricServiceTests.cs
+++ b/Validation.Tests/MetricServiceTests.cs
@@ -1,0 +1,107 @@
+using Validation.Domain.Metrics;
+using Validation.Infrastructure.Metrics;
+using Validation.Domain.Validation;
+
+namespace Validation.Tests;
+
+public class MetricServiceTests
+{
+    private class Sample { public double Value { get; set; } }
+
+    private readonly IMetricService _service = new InMemoryMetricService();
+
+    private static IQueryable<Sample> Previous => new List<Sample>
+    {
+        new() { Value = 1 },
+        new() { Value = 2 },
+        new() { Value = 3 }
+    }.AsQueryable();
+
+    private static IQueryable<Sample> Current => new List<Sample>
+    {
+        new() { Value = 1 },
+        new() { Value = 2 },
+        new() { Value = 3 },
+        new() { Value = 4 }
+    }.AsQueryable();
+
+    [Fact]
+    public async Task Sum_with_raw_difference_rule()
+    {
+        var plan = new ValidationPlan<Sample>(ValidationStrategy.Sum, s => s.Value, new RawDifferenceRule(3m));
+        var previous = await _service.ComputeAsync(Previous, plan.Selector, plan.Strategy);
+        var current = await _service.ComputeAsync(Current, plan.Selector, plan.Strategy);
+        var result = SummarisationValidator.Validate(current, previous, plan);
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task Sum_with_percent_change_rule()
+    {
+        var plan = new ValidationPlan<Sample>(ValidationStrategy.Sum, s => s.Value, new PercentChangeRule(100m));
+        var previous = await _service.ComputeAsync(Previous, plan.Selector, plan.Strategy);
+        var current = await _service.ComputeAsync(Current, plan.Selector, plan.Strategy);
+        var result = SummarisationValidator.Validate(current, previous, plan);
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task Average_with_raw_difference_rule()
+    {
+        var plan = new ValidationPlan<Sample>(ValidationStrategy.Average, s => s.Value, new RawDifferenceRule(1m));
+        var previous = await _service.ComputeAsync(Previous, plan.Selector, plan.Strategy);
+        var current = await _service.ComputeAsync(Current, plan.Selector, plan.Strategy);
+        var result = SummarisationValidator.Validate(current, previous, plan);
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task Average_with_percent_change_rule()
+    {
+        var plan = new ValidationPlan<Sample>(ValidationStrategy.Average, s => s.Value, new PercentChangeRule(20m));
+        var previous = await _service.ComputeAsync(Previous, plan.Selector, plan.Strategy);
+        var current = await _service.ComputeAsync(Current, plan.Selector, plan.Strategy);
+        var result = SummarisationValidator.Validate(current, previous, plan);
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task Count_with_raw_difference_rule()
+    {
+        var plan = new ValidationPlan<Sample>(ValidationStrategy.Count, s => s.Value, new RawDifferenceRule(0m));
+        var previous = await _service.ComputeAsync(Previous, plan.Selector, plan.Strategy);
+        var current = await _service.ComputeAsync(Current, plan.Selector, plan.Strategy);
+        var result = SummarisationValidator.Validate(current, previous, plan);
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task Count_with_percent_change_rule()
+    {
+        var plan = new ValidationPlan<Sample>(ValidationStrategy.Count, s => s.Value, new PercentChangeRule(50m));
+        var previous = await _service.ComputeAsync(Previous, plan.Selector, plan.Strategy);
+        var current = await _service.ComputeAsync(Current, plan.Selector, plan.Strategy);
+        var result = SummarisationValidator.Validate(current, previous, plan);
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task Variance_with_raw_difference_rule()
+    {
+        var plan = new ValidationPlan<Sample>(ValidationStrategy.Variance, s => s.Value, new RawDifferenceRule(1m));
+        var previous = await _service.ComputeAsync(Previous, plan.Selector, plan.Strategy);
+        var current = await _service.ComputeAsync(Current, plan.Selector, plan.Strategy);
+        var result = SummarisationValidator.Validate(current, previous, plan);
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task Variance_with_percent_change_rule()
+    {
+        var plan = new ValidationPlan<Sample>(ValidationStrategy.Variance, s => s.Value, new PercentChangeRule(50m));
+        var previous = await _service.ComputeAsync(Previous, plan.Selector, plan.Strategy);
+        var current = await _service.ComputeAsync(Current, plan.Selector, plan.Strategy);
+        var result = SummarisationValidator.Validate(current, previous, plan);
+        Assert.False(result);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ValidationStrategy` enum and metric service interfaces
- implement in-memory metric calculation
- introduce summarisation validator and plan
- add tests for each metric strategy and rule type

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688bda57b634833081cdbbf99b0317dd