### PR TITLE
Add configurable validation flows

### DIFF
--- a/Validation.Infrastructure/DI/ValidationFlowConfiguration.cs
+++ b/Validation.Infrastructure/DI/ValidationFlowConfiguration.cs
@@ -1,0 +1,79 @@
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.DependencyInjection;
+using Serilog;
+using MassTransit;
+using Validation.Infrastructure.Messaging;
+using Validation.Domain.Validation;
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Infrastructure.DI;
+
+public enum ThresholdType
+{
+    Raw,
+    Percent
+}
+
+public class ValidationFlowDefinition
+{
+    public string Type { get; set; } = string.Empty;
+    public bool SaveValidation { get; set; }
+    public bool SaveCommit { get; set; }
+    public string? MetricProperty { get; set; }
+    public ThresholdType ThresholdType { get; set; }
+    public decimal ThresholdValue { get; set; }
+}
+
+public class ValidationFlowOptions
+{
+    public List<ValidationFlowDefinition> Flows { get; set; } = new();
+
+    public static ValidationFlowOptions Load(string json)
+    {
+        var opts = new JsonSerializerOptions();
+        opts.Converters.Add(new JsonStringEnumConverter());
+        return JsonSerializer.Deserialize<ValidationFlowOptions>(json, opts) ?? new ValidationFlowOptions();
+    }
+}
+
+public static class ValidationFlowRegistrationExtensions
+{
+    public static IServiceCollection AddSaveValidation<T>(this IServiceCollection services)
+    {
+        services.AddScoped<SaveValidationConsumer<T>>();
+        services.AddScoped<SummarisationValidator>();
+        services.AddMassTransitTestHarness(cfg => cfg.AddConsumer<SaveValidationConsumer<T>>());
+        services.AddLogging(b => b.AddSerilog());
+        return services;
+    }
+
+    public static IServiceCollection AddSaveCommit<T>(this IServiceCollection services)
+    {
+        services.AddScoped<SaveCommitConsumer<T>>();
+        services.AddMassTransitTestHarness(cfg => cfg.AddConsumer<SaveCommitConsumer<T>>());
+        services.AddLogging(b => b.AddSerilog());
+        return services;
+    }
+
+    public static IServiceCollection AddValidationFlows(this IServiceCollection services, ValidationFlowOptions opts)
+    {
+        foreach (var flow in opts.Flows)
+        {
+            var type = Type.GetType(flow.Type) ?? throw new InvalidOperationException($"Type {flow.Type} not found");
+            if (flow.SaveValidation)
+            {
+                var method = typeof(ValidationFlowRegistrationExtensions).GetMethod(nameof(AddSaveValidation))!.MakeGenericMethod(type);
+                method.Invoke(null, new object[] { services });
+            }
+            if (flow.SaveCommit)
+            {
+                var method = typeof(ValidationFlowRegistrationExtensions).GetMethod(nameof(AddSaveCommit))!.MakeGenericMethod(type);
+                method.Invoke(null, new object[] { services });
+            }
+        }
+        return services;
+    }
+}
+

--- a/Validation.Tests/Features/ValidationFlows.feature
+++ b/Validation.Tests/Features/ValidationFlows.feature
@@ -1,0 +1,6 @@
+Feature: Validation flow registration
+  Scenario: Services are registered from config
+    Given a valid item flow configuration
+    When services are built
+    Then SaveValidationConsumer can be resolved for Item
+    And SaveCommitConsumer can be resolved for Item

--- a/Validation.Tests/Validation.Tests.csproj
+++ b/Validation.Tests/Validation.Tests.csproj
@@ -12,11 +12,16 @@
     <PackageReference Include="MassTransit.TestFramework" Version="8.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="Xunit.Gherkin.Quick" Version="3.7.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>
 
   <ItemGroup>
     <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="Features\**\*.feature" CopyToOutputDirectory="Always" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Validation.Tests/ValidationFlowsFeature.cs
+++ b/Validation.Tests/ValidationFlowsFeature.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Gherkin.Quick;
+using Validation.Infrastructure.DI;
+using Validation.Infrastructure.Messaging;
+using Validation.Infrastructure.Repositories;
+using Validation.Domain.Validation;
+using Validation.Tests;
+using Validation.Domain.Entities;
+
+[FeatureFile("./Features/ValidationFlows.feature")]
+public sealed class ValidationFlowsFeature : Feature
+{
+    private ValidationFlowOptions _options = null!;
+    private ServiceProvider _provider = null!;
+
+    [Given("a valid item flow configuration")]
+    public void GivenConfiguration()
+    {
+        var json = "{ \"Flows\": [ { \"Type\": \"Validation.Domain.Entities.Item, Validation.Domain\", \"SaveValidation\": true, \"SaveCommit\": true, \"MetricProperty\": \"Metric\", \"ThresholdType\": \"Raw\", \"ThresholdValue\": 5 } ] }";
+        _options = ValidationFlowOptions.Load(json);
+    }
+
+    [When("services are built")]
+    public void WhenServicesAreBuilt()
+    {
+        var services = new ServiceCollection();
+        services.AddScoped<IValidationPlanProvider, DummyPlanProvider>();
+        services.AddScoped<ISaveAuditRepository, InMemorySaveAuditRepository>();
+        services.AddValidationFlows(_options);
+        _provider = services.BuildServiceProvider();
+    }
+
+    private class DummyPlanProvider : IValidationPlanProvider
+    {
+        public IEnumerable<IValidationRule> GetRules<T>() => new[] { new RawDifferenceRule(10m) };
+    }
+
+    [Then("SaveValidationConsumer can be resolved for Item")]
+    public void ThenSaveValidationConsumerCanBeResolved()
+    {
+        Assert.NotNull(_provider.GetService<SaveValidationConsumer<Item>>());
+    }
+
+    [And("SaveCommitConsumer can be resolved for Item")]
+    public void ThenSaveCommitConsumerCanBeResolved()
+    {
+        Assert.NotNull(_provider.GetService<SaveCommitConsumer<Item>>());
+    }
+}
+


### PR DESCRIPTION
## Summary
- define new flow configuration types
- implement service registration extensions using reflection
- load enum values from config via `JsonStringEnumConverter`
- add BDD scenario verifying services are registered from config

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688bf3c8d4c08330b3677b606dd0577d