### PR TITLE
Add configurable validation flow registration

### DIFF
--- a/Validation.Infrastructure/DI/ValidationFlowConfiguration.cs
+++ b/Validation.Infrastructure/DI/ValidationFlowConfiguration.cs
@@ -1,0 +1,68 @@
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Validation.Infrastructure.Messaging;
+
+namespace Validation.Infrastructure.DI;
+
+public enum ThresholdType
+{
+    RawDifference,
+    PercentChange
+}
+
+public class ValidationFlowDefinition
+{
+    public string Type { get; set; } = "";
+    public bool SaveValidation { get; set; }
+    public bool SaveCommit { get; set; }
+    public string? MetricProperty { get; set; }
+    public ThresholdType ThresholdType { get; set; }
+    public decimal ThresholdValue { get; set; }
+}
+
+public class ValidationFlowOptions
+{
+    public List<ValidationFlowDefinition> Flows { get; set; } = new();
+
+    public static ValidationFlowOptions Load(string json)
+    {
+        var opts = JsonSerializer.Deserialize<ValidationFlowOptions>(json);
+        return opts ?? new ValidationFlowOptions();
+    }
+}
+
+public static class ValidationFlowRegistrationExtensions
+{
+    public static IServiceCollection AddSaveValidation<T>(this IServiceCollection services)
+    {
+        services.AddScoped<SaveValidationConsumer<T>>();
+        return services;
+    }
+
+    public static IServiceCollection AddSaveCommit<T>(this IServiceCollection services)
+    {
+        services.AddScoped<SaveCommitConsumer<T>>();
+        return services;
+    }
+
+    public static IServiceCollection AddValidationFlows(this IServiceCollection services, ValidationFlowOptions opts)
+    {
+        foreach (var flow in opts.Flows)
+        {
+            var type = Type.GetType(flow.Type, throwOnError: true)!;
+            if (flow.SaveValidation)
+            {
+                var m = typeof(ValidationFlowRegistrationExtensions).GetMethod(nameof(AddSaveValidation))!
+                    .MakeGenericMethod(type);
+                m.Invoke(null, new object[] { services });
+            }
+            if (flow.SaveCommit)
+            {
+                var m = typeof(ValidationFlowRegistrationExtensions).GetMethod(nameof(AddSaveCommit))!
+                    .MakeGenericMethod(type);
+                m.Invoke(null, new object[] { services });
+            }
+        }
+        return services;
+    }
+}

--- a/Validation.Tests/ConfigSteps.cs
+++ b/Validation.Tests/ConfigSteps.cs
@@ -1,0 +1,45 @@
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Gherkin.Quick;
+using Validation.Domain.Entities;
+using Validation.Domain.Validation;
+using Validation.Infrastructure.Repositories;
+using Validation.Infrastructure.DI;
+using Validation.Infrastructure.Messaging;
+using Validation.Tests;
+
+[FeatureFile("./ValidationFlowConfig.feature")]
+public sealed class ConfigSteps : Feature
+{
+    private class TestPlanProvider : IValidationPlanProvider
+    {
+        public IEnumerable<IValidationRule> GetRules<T>() => new[] { new RawDifferenceRule(100) };
+    }
+    private string _json = string.Empty;
+    private ServiceProvider? _provider;
+
+    [Given("a validation flow configuration")]
+    public void GivenConfiguration()
+    {
+        _json = "{\"Flows\":[{\"Type\":\"Validation.Domain.Entities.Item, Validation.Domain\",\"SaveValidation\":true,\"SaveCommit\":true}]}";
+    }
+
+    [When("I load the options and configure services")]
+    public void WhenLoadOptions()
+    {
+        var opts = ValidationFlowOptions.Load(_json);
+        var services = new ServiceCollection();
+        services.AddSingleton<IValidationPlanProvider, TestPlanProvider>();
+        services.AddSingleton<ISaveAuditRepository, InMemorySaveAuditRepository>();
+        services.AddSingleton<SummarisationValidator>();
+        services.AddValidationFlows(opts);
+        _provider = services.BuildServiceProvider();
+    }
+
+    [Then("services for Item are resolvable")]
+    public void ThenServicesResolvable()
+    {
+        Assert.NotNull(_provider!.GetService<SaveValidationConsumer<Item>>());
+        Assert.NotNull(_provider!.GetService<SaveCommitConsumer<Item>>());
+    }
+}

--- a/Validation.Tests/Validation.Tests.csproj
+++ b/Validation.Tests/Validation.Tests.csproj
@@ -12,11 +12,18 @@
     <PackageReference Include="MassTransit.TestFramework" Version="8.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="Xunit.Gherkin.Quick" Version="4.1.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>
 
   <ItemGroup>
     <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="**/*.feature">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/Validation.Tests/ValidationFlowConfig.feature
+++ b/Validation.Tests/ValidationFlowConfig.feature
@@ -1,0 +1,5 @@
+Feature: Validation flow configuration
+  Scenario: Config loads and services resolved
+    Given a validation flow configuration
+    When I load the options and configure services
+    Then services for Item are resolvable


### PR DESCRIPTION
## Summary
- support specifying validation flows via JSON config
- register validation consumers via reflection
- verify configuration with BDD scenario

## Testing
- `dotnet test -v n`

------
https://chatgpt.com/codex/tasks/task_e_688bf3c8d4c08330b3677b606dd0577d