### PR TITLE
Implement save validation flow

### DIFF
--- a/Validation.Domain/Entities/Item.cs
+++ b/Validation.Domain/Entities/Item.cs
@@ -10,13 +10,13 @@ public class Item : EntityWithEvents
     public Item(decimal metric)
     {
         Metric = metric;
-        AddEvent(new SaveRequested(Id));
+        AddEvent(new SaveRequested(Id, metric));
     }
 
     public void UpdateMetric(decimal metric)
     {
         Metric = metric;
-        AddEvent(new SaveRequested(Id));
+        AddEvent(new SaveRequested(Id, metric));
     }
 
     public void Delete()

--- a/Validation.Domain/Events/SaveRequested.cs
+++ b/Validation.Domain/Events/SaveRequested.cs
@@ -1,3 +1,3 @@
 namespace Validation.Domain.Events;
 
-public record SaveRequested(Guid Id);
+public record SaveRequested(Guid Id, object Payload);

--- a/Validation.Domain/Events/SaveValidated.cs
+++ b/Validation.Domain/Events/SaveValidated.cs
@@ -1,3 +1,3 @@
 namespace Validation.Domain.Events;
 
-public record SaveValidated(Guid Id, bool IsValid, decimal Metric);
+public record SaveValidated(Guid Id, bool Validated);

--- a/Validation.Infrastructure/Messaging/SaveCommitConsumer.cs
+++ b/Validation.Infrastructure/Messaging/SaveCommitConsumer.cs
@@ -1,10 +1,11 @@
 using MassTransit;
 using Validation.Domain.Events;
 using Validation.Infrastructure.Repositories;
+using Validation.Infrastructure;
 
 namespace Validation.Infrastructure.Messaging;
 
-public class SaveCommitConsumer<T> : IConsumer<SaveValidated<T>>
+public class SaveCommitConsumer : IConsumer<SaveValidated>
 {
     private readonly ISaveAuditRepository _repository;
 
@@ -13,19 +14,16 @@ public class SaveCommitConsumer<T> : IConsumer<SaveValidated<T>>
         _repository = repository;
     }
 
-    public async Task Consume(ConsumeContext<SaveValidated<T>> context)
+    public async Task Consume(ConsumeContext<SaveValidated> context)
     {
-        try
+        var audit = new SaveAudit
         {
-            var audit = await _repository.GetAsync(context.Message.AuditId, context.CancellationToken);
-            if (audit != null)
-            {
-                await _repository.UpdateAsync(audit, context.CancellationToken);
-            }
-        }
-        catch (Exception ex)
-        {
-            await context.Publish(new SaveCommitFault<T>(context.Message.EntityId, context.Message.AuditId, ex.Message));
-        }
+            Id = Guid.NewGuid(),
+            EntityId = context.Message.Id,
+            IsValid = context.Message.Validated,
+            Metric = 0
+        };
+
+        await _repository.AddAsync(audit, context.CancellationToken);
     }
 }

--- a/Validation.Infrastructure/Messaging/SaveRequestedConsumer.cs
+++ b/Validation.Infrastructure/Messaging/SaveRequestedConsumer.cs
@@ -31,6 +31,6 @@ public class SaveRequestedConsumer : IConsumer<SaveRequested>
             Metric = metric
         };
         await _repository.AddAsync(audit, context.CancellationToken);
-        await context.Publish(new SaveValidated(context.Message.Id, isValid, metric), context.CancellationToken);
+        await context.Publish(new SaveValidated(context.Message.Id, isValid), context.CancellationToken);
     }
 }

--- a/Validation.Infrastructure/Messaging/SaveValidationConsumer.cs
+++ b/Validation.Infrastructure/Messaging/SaveValidationConsumer.cs
@@ -23,17 +23,8 @@ public class SaveValidationConsumer<T> : IConsumer<SaveRequested>
         var last = await _repository.GetLastAsync(context.Message.Id, context.CancellationToken);
         var metric = new Random().Next(0, 100);
         var rules = _planProvider.GetRules<T>();
-        var isValid = _validator.Validate(last?.Metric ?? 0m, metric, rules);
+        var validated = _validator.Validate(last?.Metric ?? 0m, metric, rules);
 
-        var audit = new SaveAudit
-        {
-            Id = Guid.NewGuid(),
-            EntityId = context.Message.Id,
-            IsValid = isValid,
-            Metric = metric
-        };
-
-        await _repository.AddAsync(audit, context.CancellationToken);
-        await context.Publish(new SaveValidated<T>(context.Message.Id, audit.Id));
+        await context.Publish(new SaveValidated(context.Message.Id, validated));
     }
 }

--- a/Validation.Tests/SaveCommitConsumerTests.cs
+++ b/Validation.Tests/SaveCommitConsumerTests.cs
@@ -10,20 +10,11 @@ namespace Validation.Tests;
 
 public class SaveCommitConsumerTests
 {
-    private class FailingRepository : ISaveAuditRepository
-    {
-        public Task AddAsync(SaveAudit entity, CancellationToken ct = default) => Task.CompletedTask;
-        public Task DeleteAsync(Guid id, CancellationToken ct = default) => Task.CompletedTask;
-        public Task<SaveAudit?> GetAsync(Guid id, CancellationToken ct = default) => Task.FromResult<SaveAudit?>(new SaveAudit { Id = id, EntityId = id });
-        public Task UpdateAsync(SaveAudit entity, CancellationToken ct = default) => throw new Exception("fail");
-        public Task<SaveAudit?> GetLastAsync(Guid entityId, CancellationToken ct = default) => Task.FromResult<SaveAudit?>(null);
-    }
-
     [Fact]
-    public async Task Publish_SaveCommitFault_on_error()
+    public async Task Persist_audit_record_when_validated()
     {
-        var repo = new FailingRepository();
-        var consumer = new SaveCommitConsumer<Item>(repo);
+        var repo = new InMemorySaveAuditRepository();
+        var consumer = new SaveCommitConsumer(repo);
 
         var harness = new InMemoryTestHarness();
         harness.Consumer(() => consumer);
@@ -31,9 +22,10 @@ public class SaveCommitConsumerTests
         await harness.Start();
         try
         {
-            await harness.InputQueueSendEndpoint.Send(new SaveValidated<Item>(Guid.NewGuid(), Guid.NewGuid()));
+            await harness.InputQueueSendEndpoint.Send(new SaveValidated(Guid.NewGuid(), true));
 
-            Assert.True(await harness.Published.Any<SaveCommitFault<Item>>());
+            Assert.True(await harness.Consumed.Any<SaveValidated>());
+            Assert.Single(repo.Audits);
         }
         finally
         {

--- a/Validation.Tests/ValidationFlowIntegrationTests.cs
+++ b/Validation.Tests/ValidationFlowIntegrationTests.cs
@@ -5,6 +5,7 @@ using Validation.Infrastructure.Messaging;
 using MassTransit;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.DI;
+using Validation.Domain.Entities;
 
 namespace Validation.Tests;
 
@@ -27,7 +28,7 @@ public class ValidationFlowIntegrationTests
         {
             using var scope = provider.CreateScope();
             var publish = scope.ServiceProvider.GetRequiredService<IPublishEndpoint>();
-            await publish.Publish(new SaveRequested(Guid.NewGuid()));
+            await publish.Publish(new SaveRequested(Guid.NewGuid(), "p"));
 
             Assert.True(await harness.Published.Any<SaveValidated>());
             var ctx = scope.ServiceProvider.GetRequiredService<TestDbContext>();

--- a/Validation.Tests/ValidationWorkflowTests.cs
+++ b/Validation.Tests/ValidationWorkflowTests.cs
@@ -3,6 +3,7 @@ using MassTransit.Testing;
 using Validation.Domain.Events;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.Messaging;
+using Validation.Domain.Entities;
 
 namespace Validation.Tests;
 
@@ -20,7 +21,7 @@ public class ValidationWorkflowTests
         await harness.Start();
         try
         {
-            await harness.InputQueueSendEndpoint.Send(new SaveRequested(Guid.NewGuid()));
+            await harness.InputQueueSendEndpoint.Send(new SaveRequested(Guid.NewGuid(), "p"));
             Assert.True(await harness.Consumed.Any<SaveRequested>());
             Assert.True(await consumerHarness.Consumed.Any<SaveRequested>());
             Assert.Single(repository.Audits);


### PR DESCRIPTION
## Summary
- add payload to SaveRequested and update SaveValidated
- rewrite SaveValidationConsumer to only publish validation result
- introduce SaveCommitConsumer to persist audits
- adjust entity events and integration tests

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688bf3ac489c8330b1d03a3a71068cb1