### PR TITLE
Add test verifying published payload from repository

### DIFF
--- a/Validation.Tests/EventPublishingRepositoryTests.cs
+++ b/Validation.Tests/EventPublishingRepositoryTests.cs
@@ -1,6 +1,9 @@
+using MassTransit;
 using MassTransit.Testing;
+using Microsoft.Extensions.DependencyInjection;
 using Validation.Domain.Entities;
 using Validation.Domain.Events;
+using Validation.Domain.Repositories;
 using Validation.Infrastructure.Repositories;
 
 namespace Validation.Tests;
@@ -38,6 +41,33 @@ public class EventPublishingRepositoryTests
             var id = Guid.NewGuid();
             await repository.DeleteAsync(id);
             Assert.True(await harness.Published.Any<DeleteRequested>());
+        }
+        finally
+        {
+            await harness.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task SaveAsync_publishes_event_with_payload()
+    {
+        var services = new ServiceCollection();
+        services.AddMassTransitTestHarness();
+        services.AddScoped<IEntityRepository<Item>, EventPublishingRepository<Item>>();
+
+        var provider = services.BuildServiceProvider(true);
+        var harness = provider.GetRequiredService<ITestHarness>();
+        await harness.Start();
+        try
+        {
+            using var scope = provider.CreateScope();
+            var repository = scope.ServiceProvider.GetRequiredService<IEntityRepository<Item>>();
+            var item = new Item(5);
+            await repository.SaveAsync(item);
+
+            Assert.True(await harness.Published.Any<SaveRequested<Item>>(x =>
+                x.Context.Message.Entity.Id == item.Id &&
+                x.Context.Message.Entity.Metric == item.Metric));
         }
         finally
         {


### PR DESCRIPTION
## Summary
- extend `EventPublishingRepositoryTests` with a new test to verify the published `SaveRequested<Item>` payload

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688c14b24c688330b6036d5ad0d939fc