### PR TITLE
Add harness test for MassTransit repository

### DIFF
--- a/Validation.Tests/EventPublishingRepositoryHarnessTests.cs
+++ b/Validation.Tests/EventPublishingRepositoryHarnessTests.cs
@@ -1,0 +1,38 @@
+using System.Threading.Tasks;
+using MassTransit;
+using MassTransit.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Validation.Domain.Entities;
+using Validation.Domain.Events;
+using Validation.Infrastructure.Repositories;
+using Xunit;
+
+namespace Validation.Tests;
+
+public class EventPublishingRepositoryHarnessTests
+{
+    [Fact]
+    public async Task SaveAsync_publishes_event_with_matching_payload()
+    {
+        var services = new ServiceCollection();
+        services.AddMassTransitTestHarness();
+        services.AddScoped<EventPublishingRepository<Item>>();
+        var provider = services.BuildServiceProvider(true);
+        var harness = provider.GetRequiredService<ITestHarness>();
+        await harness.Start();
+        try
+        {
+            using var scope = provider.CreateScope();
+            var repo = scope.ServiceProvider.GetRequiredService<EventPublishingRepository<Item>>();
+            var item = new Item(10);
+            await repo.SaveAsync(item);
+            var published = await harness.Published.SelectAsync<SaveRequested<Item>>().First();
+            Assert.Equal(item.Id, published.Context.Message.Entity.Id);
+            Assert.Same(item, published.Context.Message.Entity);
+        }
+        finally
+        {
+            await harness.Stop();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a MassTransit `ITestHarness` test verifying `EventPublishingRepository<T>` publishes a `SaveRequested<T>` message with the correct entity

## Testing
- `dotnet test --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_688c14b24c688330b6036d5ad0d939fc