### PR TITLE
Add basic UnitOfWork validation example

### DIFF
--- a/Validation.Domain/Entities/YourEntity.cs
+++ b/Validation.Domain/Entities/YourEntity.cs
@@ -1,0 +1,22 @@
+using Validation.Domain.Events;
+
+namespace Validation.Domain.Entities;
+
+public class YourEntity : EntityWithEvents
+{
+    public Guid Id { get; private set; } = Guid.NewGuid();
+    public decimal Metric { get; private set; }
+    public bool Validated { get; set; }
+
+    public YourEntity(decimal metric)
+    {
+        Metric = metric;
+        AddEvent(new SaveRequested(Id));
+    }
+
+    public void UpdateMetric(decimal metric)
+    {
+        Metric = metric;
+        AddEvent(new SaveRequested(Id));
+    }
+}

--- a/Validation.Domain/Validation/EntityValidationRuleSet.cs
+++ b/Validation.Domain/Validation/EntityValidationRuleSet.cs
@@ -1,0 +1,13 @@
+namespace Validation.Domain.Validation;
+
+public class EntityValidationRuleSet<T>
+{
+    public Func<T, decimal> MetricSelector { get; }
+    public IReadOnlyList<IValidationRule> Rules { get; }
+
+    public EntityValidationRuleSet(Func<T, decimal> metricSelector, params IValidationRule[] rules)
+    {
+        MetricSelector = metricSelector;
+        Rules = rules;
+    }
+}

--- a/Validation.Infrastructure/UnitOfWork.cs
+++ b/Validation.Infrastructure/UnitOfWork.cs
@@ -1,0 +1,32 @@
+using Validation.Domain.Validation;
+
+namespace Validation.Infrastructure;
+
+public class UnitOfWork<T>
+{
+    private readonly List<T> _items = new();
+    private readonly SummarisationValidator _validator = new();
+    private decimal? _lastMetric;
+
+    public Task AddAsync(T item)
+    {
+        _items.Add(item);
+        return Task.CompletedTask;
+    }
+
+    public Task SaveChangesAsync(EntityValidationRuleSet<T> ruleSet)
+    {
+        foreach (var item in _items)
+        {
+            var metric = ruleSet.MetricSelector(item);
+            var prev = _lastMetric ?? metric;
+            var valid = _validator.Validate(prev, metric, ruleSet.Rules);
+            var prop = item!.GetType().GetProperty("Validated");
+            if (prop != null && prop.PropertyType == typeof(bool))
+                prop.SetValue(item, valid);
+            _lastMetric = metric;
+        }
+        _items.Clear();
+        return Task.CompletedTask;
+    }
+}

--- a/Validation.Tests/UnitOfWorkTests.cs
+++ b/Validation.Tests/UnitOfWorkTests.cs
@@ -1,0 +1,28 @@
+using Xunit;
+using System;
+using System.Threading.Tasks;
+using Validation.Domain.Entities;
+using Validation.Domain.Validation;
+using Validation.Infrastructure;
+
+namespace Validation.Tests;
+
+public class UnitOfWorkTests
+{
+    [Fact]
+    public async Task SaveChanges_marks_entity_validated()
+    {
+        var uow = new UnitOfWork<YourEntity>();
+        var entity = new YourEntity(105m);
+        await uow.AddAsync(entity);
+
+        var ruleSet = new EntityValidationRuleSet<YourEntity>(e => e.Metric,
+            new PercentChangeRule(10m),
+            new RawDifferenceRule(5m));
+
+        await uow.SaveChangesAsync(ruleSet);
+
+        Console.WriteLine($"Entity validated: {entity.Validated}");
+        Assert.True(entity.Validated);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `EntityValidationRuleSet<T>` and `UnitOfWork<T>` for validating entities
- add new entity `YourEntity` with `Validated` flag
- add test demonstrating `UnitOfWork` validation workflow

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_688c14a6dc288330b1fd83010c464f61