### PR TITLE
Add UnitOfWork validation example

### DIFF
--- a/Validation.Domain/Entities/YourEntity.cs
+++ b/Validation.Domain/Entities/YourEntity.cs
@@ -1,0 +1,8 @@
+namespace Validation.Domain.Entities;
+
+public class YourEntity
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public decimal Metric { get; set; }
+    public bool Validated { get; set; }
+}

--- a/Validation.Infrastructure/UnitOfWork.cs
+++ b/Validation.Infrastructure/UnitOfWork.cs
@@ -1,0 +1,36 @@
+using Validation.Domain.Entities;
+using Validation.Domain.Validation;
+
+namespace Validation.Infrastructure;
+
+public class UnitOfWork
+{
+    private decimal _previousMetric;
+    private YourEntity? _pending;
+    private readonly SummarisationValidator _validator = new();
+
+    public UnitOfWork(decimal initialMetric = 0m)
+    {
+        _previousMetric = initialMetric;
+    }
+
+    public void Add(YourEntity entity)
+    {
+        _pending = entity;
+    }
+
+    public bool Validated { get; private set; }
+
+    public async Task SaveChangesAsync(ValidationPlan ruleSet)
+    {
+        if (_pending == null) return;
+        Validated = _validator.Validate(_previousMetric, _pending.Metric, ruleSet);
+        _pending.Validated = Validated;
+        if (Validated)
+        {
+            _previousMetric = _pending.Metric;
+        }
+        _pending = null;
+        await Task.CompletedTask;
+    }
+}

--- a/Validation.Tests/UnitOfWorkTests.cs
+++ b/Validation.Tests/UnitOfWorkTests.cs
@@ -1,0 +1,23 @@
+using Validation.Domain.Entities;
+using Validation.Domain.Validation;
+using Validation.Infrastructure;
+
+namespace Validation.Tests;
+
+public class UnitOfWorkTests
+{
+    [Fact]
+    public async Task SaveChangesAsync_marks_entity_validated_based_on_rules()
+    {
+        var uow = new UnitOfWork(100m);
+        var entity = new YourEntity { Metric = 100.09m };
+        var ruleSet = new ValidationPlan(new IValidationRule[]
+        {
+            new PercentChangeRule(0.1m),
+            new RawDifferenceRule(5m)
+        });
+        uow.Add(entity);
+        await uow.SaveChangesAsync(ruleSet);
+        Assert.True(entity.Validated);
+    }
+}


### PR DESCRIPTION
## Summary
- implement simple `UnitOfWork` that validates the latest entity
- add `YourEntity` type used by the new UnitOfWork
- show UnitOfWork usage in `UnitOfWorkTests`

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688c14a6dc288330b1fd83010c464f61