### PR TITLE
Add UnitOfWork and validation example

### DIFF
--- a/Validation.Domain/Entities/IValidatableEntity.cs
+++ b/Validation.Domain/Entities/IValidatableEntity.cs
@@ -1,0 +1,7 @@
+namespace Validation.Domain.Entities;
+
+public interface IValidatableEntity
+{
+    decimal Metric { get; }
+    bool Validated { get; set; }
+}

--- a/Validation.Domain/Entities/Measurement.cs
+++ b/Validation.Domain/Entities/Measurement.cs
@@ -1,0 +1,22 @@
+using Validation.Domain.Events;
+
+namespace Validation.Domain.Entities;
+
+public class Measurement : EntityWithEvents, IValidatableEntity
+{
+    public Guid Id { get; private set; } = Guid.NewGuid();
+    public decimal Metric { get; private set; }
+    public bool Validated { get; set; }
+
+    public Measurement(decimal metric)
+    {
+        Metric = metric;
+        AddEvent(new SaveRequested(Id));
+    }
+
+    public void UpdateMetric(decimal metric)
+    {
+        Metric = metric;
+        AddEvent(new SaveRequested(Id));
+    }
+}

--- a/Validation.Infrastructure/UnitOfWork.cs
+++ b/Validation.Infrastructure/UnitOfWork.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+using Validation.Domain.Entities;
+using Validation.Domain.Validation;
+
+namespace Validation.Infrastructure;
+
+public class UnitOfWork
+{
+    private readonly DbContext _context;
+    private readonly SummarisationValidator _validator;
+    private decimal _previousMetric;
+
+    public UnitOfWork(DbContext context, SummarisationValidator validator)
+    {
+        _context = context;
+        _validator = validator;
+    }
+
+    public async Task SaveChangesAsync<T>(ValidationPlan ruleSet, CancellationToken ct = default)
+        where T : class, IValidatableEntity
+    {
+        foreach (var entry in _context.ChangeTracker.Entries<T>())
+        {
+            var entity = entry.Entity;
+            var isValid = _validator.Validate(_previousMetric, entity.Metric, ruleSet);
+            entity.Validated = isValid;
+            _previousMetric = entity.Metric;
+        }
+
+        await _context.SaveChangesAsync(ct);
+    }
+}

--- a/Validation.Tests/TestDbContext.cs
+++ b/Validation.Tests/TestDbContext.cs
@@ -11,4 +11,5 @@ public class TestDbContext : DbContext
 
     public DbSet<SaveAudit> SaveAudits => Set<SaveAudit>();
     public DbSet<Validation.Domain.Entities.Item> Items => Set<Validation.Domain.Entities.Item>();
+    public DbSet<Validation.Domain.Entities.Measurement> Measurements => Set<Validation.Domain.Entities.Measurement>();
 }

--- a/Validation.Tests/UnitOfWorkTests.cs
+++ b/Validation.Tests/UnitOfWorkTests.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore;
+using Validation.Domain.Entities;
+using Validation.Domain.Validation;
+using Validation.Infrastructure;
+
+namespace Validation.Tests;
+
+public class UnitOfWorkTests
+{
+    [Fact]
+    public async Task SaveChangesAsync_marks_entity_validated()
+    {
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseInMemoryDatabase("uowtest")
+            .Options;
+        using var context = new TestDbContext(options);
+        var validator = new SummarisationValidator();
+        var uow = new UnitOfWork(context, validator);
+
+        var entity = new Measurement(3m);
+        context.Measurements.Add(entity);
+
+        var ruleSet = new ValidationPlan(new IValidationRule[]
+        {
+            new PercentChangeRule(0.1m),
+            new RawDifferenceRule(5m)
+        });
+
+        await uow.SaveChangesAsync<Measurement>(ruleSet);
+
+        Assert.True(entity.Validated);
+    }
+}


### PR DESCRIPTION
## Summary
- add a `Measurement` entity and `IValidatableEntity` interface
- implement `UnitOfWork` for validating entities using `ValidationPlan`
- extend `TestDbContext` with a new `Measurements` set
- test that `UnitOfWork.SaveChangesAsync` marks an entity as validated

## Testing
- `dotnet test --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_688c14a6dc288330b1fd83010c464f61