### PR TITLE
Add unit of work example

### DIFF
--- a/Validation.Domain/Entities/YourEntity.cs
+++ b/Validation.Domain/Entities/YourEntity.cs
@@ -1,0 +1,6 @@
+namespace Validation.Domain.Entities;
+
+public class YourEntity
+{
+    public int Id { get; set; }
+}

--- a/Validation.Domain/Validation.Domain.csproj
+++ b/Validation.Domain/Validation.Domain.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Validation.Infrastructure/Repositories/EfUnitOfWork.cs
+++ b/Validation.Infrastructure/Repositories/EfUnitOfWork.cs
@@ -1,0 +1,35 @@
+using Microsoft.EntityFrameworkCore;
+using Validation.Domain.Validation;
+
+namespace Validation.Infrastructure.Repositories;
+
+public interface IUnitOfWork : IDisposable
+{
+    IGenericRepository<TEntity> Repository<TEntity>() where TEntity : class;
+    Task SaveChangesWithPlanAsync<TEntity>(CancellationToken ct = default) where TEntity : class;
+}
+
+public class EfUnitOfWork : IUnitOfWork
+{
+    private readonly DbContext _context;
+    private readonly IValidationPlanProvider _planProvider;
+    private readonly SummarisationValidator _validator;
+
+    public EfUnitOfWork(DbContext context, IValidationPlanProvider planProvider, SummarisationValidator validator)
+    {
+        _context = context;
+        _planProvider = planProvider;
+        _validator = validator;
+    }
+
+    public IGenericRepository<TEntity> Repository<TEntity>() where TEntity : class
+        => new EfGenericRepository<TEntity>(_context, _planProvider, _validator);
+
+    public async Task SaveChangesWithPlanAsync<TEntity>(CancellationToken ct = default) where TEntity : class
+    {
+        var repo = new EfGenericRepository<TEntity>(_context, _planProvider, _validator);
+        await repo.SaveChangesWithPlanAsync(ct);
+    }
+
+    public void Dispose() => _context.Dispose();
+}

--- a/Validation.Infrastructure/Validation.Infrastructure.csproj
+++ b/Validation.Infrastructure/Validation.Infrastructure.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Validation.Tests/UnitOfWorkExampleTests.cs
+++ b/Validation.Tests/UnitOfWorkExampleTests.cs
@@ -1,0 +1,36 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Validation.Domain.Entities;
+using Validation.Domain.Validation;
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Tests;
+
+public class UnitOfWorkExampleTests
+{
+    [Fact]
+    public async Task UnitOfWork_usage_example()
+    {
+        var services = new ServiceCollection();
+        services.AddDbContext<YourDbContext>(o => o.UseInMemoryDatabase("uowtest"));
+        services.AddScoped<DbContext>(sp => sp.GetRequiredService<YourDbContext>());
+        services.AddSingleton<IValidationPlanProvider, InMemoryValidationPlanProvider>();
+        services.AddScoped<SummarisationValidator>();
+        services.AddScoped<IUnitOfWork, EfUnitOfWork>();
+
+        var provider = services.BuildServiceProvider();
+        var planProvider = provider.GetRequiredService<IValidationPlanProvider>();
+        planProvider.AddPlan<YourEntity>(
+            new ValidationPlan(e => ((YourEntity)e).Id, ThresholdType.RawDifference, 5));
+
+        using var scope = provider.CreateScope();
+        var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+        var repo = uow.Repository<YourEntity>();
+        await repo.AddAsync(new YourEntity { Id = 50 });
+        await uow.SaveChangesWithPlanAsync<YourEntity>();
+
+        var context = scope.ServiceProvider.GetRequiredService<YourDbContext>();
+        var count = context.YourEntities.Count();
+        Assert.Equal(1, count);
+    }
+}

--- a/Validation.Tests/Validation.Tests.csproj
+++ b/Validation.Tests/Validation.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/Validation.Tests/YourDbContext.cs
+++ b/Validation.Tests/YourDbContext.cs
@@ -1,0 +1,15 @@
+using Microsoft.EntityFrameworkCore;
+using Validation.Infrastructure;
+using Validation.Domain.Entities;
+
+namespace Validation.Tests;
+
+public class YourDbContext : DbContext
+{
+    public YourDbContext(DbContextOptions<YourDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<SaveAudit> SaveAudits => Set<SaveAudit>();
+    public DbSet<YourEntity> YourEntities => Set<YourEntity>();
+}

--- a/ValidationFlow.Messages/ValidationFlow.Messages.csproj
+++ b/ValidationFlow.Messages/ValidationFlow.Messages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
- target .NET 9 for all projects
- add `YourEntity` sample entity
- implement `EfUnitOfWork` for repository access
- add DbContext and integration test showing how to use the unit of work

## Testing
- `dotnet test Validation.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_688c147bb2348330b825de3df79033cf