### PR TITLE
Add UnitOfWork usage sample and tests

### DIFF
--- a/Validation.Infrastructure/UnitOfWork.cs
+++ b/Validation.Infrastructure/UnitOfWork.cs
@@ -1,0 +1,36 @@
+using Microsoft.EntityFrameworkCore;
+using Validation.Infrastructure.Repositories;
+using Validation.Domain.Validation;
+
+namespace Validation.Infrastructure;
+
+public class UnitOfWork
+{
+    private readonly DbContext _context;
+    private readonly IValidationPlanProvider _planProvider;
+    private readonly SummarisationValidator _validator;
+    private readonly Dictionary<Type, object> _repos = new();
+
+    public UnitOfWork(DbContext context, IValidationPlanProvider planProvider, SummarisationValidator validator)
+    {
+        _context = context;
+        _planProvider = planProvider;
+        _validator = validator;
+    }
+
+    public IGenericRepository<T> Repository<T>() where T : class
+    {
+        if (!_repos.TryGetValue(typeof(T), out var repo))
+        {
+            repo = new EfGenericRepository<T>(_context, _planProvider, _validator);
+            _repos[typeof(T)] = repo;
+        }
+        return (IGenericRepository<T>)repo;
+    }
+
+    public async Task<int> SaveChangesWithPlanAsync<T>(CancellationToken ct = default) where T : class
+    {
+        await Repository<T>().SaveChangesWithPlanAsync(ct);
+        return await _context.Set<T>().CountAsync(ct);
+    }
+}

--- a/Validation.Tests/UnitOfWorkExampleTests.cs
+++ b/Validation.Tests/UnitOfWorkExampleTests.cs
@@ -1,0 +1,45 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Validation.Domain.Validation;
+using Validation.Infrastructure;
+
+namespace Validation.Tests;
+
+public class UnitOfWorkExampleTests
+{
+    private class YourEntity
+    {
+        public int Id { get; set; }
+    }
+
+    private class ExampleDbContext : DbContext
+    {
+        public ExampleDbContext(DbContextOptions<ExampleDbContext> options) : base(options) { }
+        public DbSet<SaveAudit> SaveAudits => Set<SaveAudit>();
+        public DbSet<YourEntity> Entities => Set<YourEntity>();
+    }
+
+    [Fact]
+    public async Task UnitOfWork_usage_example()
+    {
+        var services = new ServiceCollection();
+        services.AddDbContext<ExampleDbContext>(o => o.UseInMemoryDatabase("uowexample"));
+        services.AddScoped<DbContext>(sp => sp.GetRequiredService<ExampleDbContext>());
+        services.AddSingleton<IValidationPlanProvider, InMemoryValidationPlanProvider>();
+        services.AddSingleton<SummarisationValidator>();
+        services.AddScoped<UnitOfWork>();
+
+        var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        var planProvider = scope.ServiceProvider.GetRequiredService<IValidationPlanProvider>();
+        planProvider.AddPlan<YourEntity>(new ValidationPlan(e => ((YourEntity)e).Id, ThresholdType.RawDifference, 5));
+
+        var uow = scope.ServiceProvider.GetRequiredService<UnitOfWork>();
+        await uow.Repository<YourEntity>().AddAsync(new YourEntity { Id = 50 });
+        var count = await uow.SaveChangesWithPlanAsync<YourEntity>();
+
+        var ctx = scope.ServiceProvider.GetRequiredService<ExampleDbContext>();
+        Assert.Equal(1, ctx.Entities.Count());
+        Assert.Equal(1, count);
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold `UnitOfWork` for repository access
- demonstrate DI and UnitOfWork usage with new test

## Testing
- `dotnet test Validation.sln`

------
https://chatgpt.com/codex/tasks/task_e_688c147bb2348330b825de3df79033cf