### PR TITLE
Add manual validator runtime addition test

### DIFF
--- a/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
+++ b/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
@@ -54,6 +54,12 @@ public static class ServiceCollectionExtensions
 
         return services;
     }
+    public static IServiceCollection AddValidatorService(this IServiceCollection services)
+    {
+        services.AddSingleton<IManualValidatorService, ManualValidatorService>();
+        return services;
+    }
+
 
     public static IServiceCollection AddValidatorRule<T>(this IServiceCollection services, Func<T, bool> rule)
     {

--- a/Validation.Tests/ManualValidatorServiceTests.cs
+++ b/Validation.Tests/ManualValidatorServiceTests.cs
@@ -17,4 +17,20 @@ public class ManualValidatorServiceTests
         Assert.True(svc.Validate("hello"));
         Assert.False(svc.Validate("hi"));
     }
+    private class MyEntity
+    {
+        public int Id { get; set; }
+    }
+
+    [Fact]
+    public void Runtime_rule_addition_works()
+    {
+        var services = new ServiceCollection();
+        services.AddValidatorService()
+                .AddValidatorRule<MyEntity>(e => e.Id % 2 == 0);
+        var provider = services.BuildServiceProvider();
+        var svc = provider.GetRequiredService<IManualValidatorService>();
+        Assert.True(svc.Validate(new MyEntity { Id = 4 }));
+        Assert.False(svc.Validate(new MyEntity { Id = 3 }));
+    }
 }


### PR DESCRIPTION
## Summary
- support registering manual validator service directly
- add MyEntity unit test for runtime rule addition

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688c13ff68008330a0c05462f364b419