### PR TITLE
Add runtime rule test

### DIFF
--- a/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
+++ b/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
@@ -55,6 +55,15 @@ public static class ServiceCollectionExtensions
         return services;
     }
 
+    public static IServiceCollection AddValidatorService(this IServiceCollection services)
+    {
+        if (!services.Any(d => d.ServiceType == typeof(IManualValidatorService)))
+        {
+            services.AddSingleton<IManualValidatorService, ManualValidatorService>();
+        }
+        return services;
+    }
+
     public static IServiceCollection AddValidatorRule<T>(this IServiceCollection services, Func<T, bool> rule)
     {
         var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(IManualValidatorService));

--- a/Validation.Tests/ManualValidatorServiceTests.cs
+++ b/Validation.Tests/ManualValidatorServiceTests.cs
@@ -17,4 +17,23 @@ public class ManualValidatorServiceTests
         Assert.True(svc.Validate("hello"));
         Assert.False(svc.Validate("hi"));
     }
+
+    private class YourEntity
+    {
+        public int Id { get; set; }
+    }
+
+    [Fact]
+    public void Manual_rules_can_be_added_at_runtime()
+    {
+        var services = new ServiceCollection();
+        services.AddValidatorService()
+                .AddValidatorRule<YourEntity>(e => e.Id % 2 == 0);
+
+        var provider = services.BuildServiceProvider();
+        var svc = provider.GetRequiredService<IManualValidatorService>();
+
+        Assert.True(svc.Validate(new YourEntity { Id = 4 }));
+        Assert.False(svc.Validate(new YourEntity { Id = 3 }));
+    }
 }


### PR DESCRIPTION
## Summary
- allow registering manual validation service via `AddValidatorService`
- demonstrate adding runtime rules in `ManualValidatorServiceTests`

## Testing
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_688c13ff68008330a0c05462f364b419