### PR TITLE
Add AddValidatorService method and unit test

### DIFF
--- a/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
+++ b/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
@@ -55,6 +55,15 @@ public static class ServiceCollectionExtensions
         return services;
     }
 
+    public static IServiceCollection AddValidatorService(this IServiceCollection services)
+    {
+        if (!services.Any(d => d.ServiceType == typeof(IManualValidatorService)))
+        {
+            services.AddSingleton<IManualValidatorService, ManualValidatorService>();
+        }
+        return services;
+    }
+
     public static IServiceCollection AddValidatorRule<T>(this IServiceCollection services, Func<T, bool> rule)
     {
         var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(IManualValidatorService));

--- a/Validation.Tests/AddValidatorServiceTests.cs
+++ b/Validation.Tests/AddValidatorServiceTests.cs
@@ -1,0 +1,25 @@
+using Microsoft.Extensions.DependencyInjection;
+using Validation.Domain.Validation;
+using Validation.Infrastructure.DI;
+using Xunit;
+
+namespace Validation.Tests;
+
+public class AddValidatorServiceTests
+{
+    private class TestEntity
+    {
+        public int Id { get; set; }
+    }
+
+    [Fact]
+    public void Manual_rule_can_be_added_at_runtime()
+    {
+        var services = new ServiceCollection();
+        services.AddValidatorService().AddValidatorRule<TestEntity>(e => e.Id % 2 == 0);
+        var provider = services.BuildServiceProvider();
+        var svc = provider.GetRequiredService<IManualValidatorService>();
+        Assert.True(svc.Validate(new TestEntity { Id = 4 }));
+        Assert.False(svc.Validate(new TestEntity { Id = 3 }));
+    }
+}


### PR DESCRIPTION
## Summary
- add `AddValidatorService` extension for manual validator service registration
- test runtime rule addition using `AddValidatorService().AddValidatorRule`

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_688c13ff68008330a0c05462f364b419