### PR TITLE
Add runtime manual validation rule test

### DIFF
--- a/Validation.Tests/ManualValidatorServiceRuntimeTests.cs
+++ b/Validation.Tests/ManualValidatorServiceRuntimeTests.cs
@@ -1,0 +1,22 @@
+using Microsoft.Extensions.DependencyInjection;
+using Validation.Domain.Validation;
+using Validation.Infrastructure.DI;
+using Xunit;
+
+namespace Validation.Tests;
+
+public class ManualValidatorServiceRuntimeTests
+{
+    private class TestEntity { public int Id { get; set; } }
+
+    [Fact]
+    public void Manual_rule_added_at_runtime_is_invoked()
+    {
+        var services = new ServiceCollection();
+        services.AddValidatorService().AddValidatorRule<TestEntity>(e => e.Id % 2 == 0);
+        var provider = services.BuildServiceProvider();
+        var svc = provider.GetRequiredService<IManualValidatorService>();
+        Assert.True(svc.Validate(new TestEntity { Id = 4 }));
+        Assert.False(svc.Validate(new TestEntity { Id = 3 }));
+    }
+}


### PR DESCRIPTION
## Summary
- provide extension method `AddValidatorService` and refactor rule registration
- ensure validator services are registered in infrastructure setup
- add unit test for runtime manual rule addition

## Testing
- `dotnet test Validation.sln --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_688c13ff68008330a0c05462f364b419