### PR TITLE
Add validation flow configuration loader

### DIFF
--- a/Validation.Infrastructure/DI/ValidationFlowConfig.cs
+++ b/Validation.Infrastructure/DI/ValidationFlowConfig.cs
@@ -1,0 +1,13 @@
+using Validation.Domain.Validation;
+
+namespace Validation.Infrastructure.DI;
+
+public class ValidationFlowConfig
+{
+    public string Type { get; set; } = string.Empty;
+    public bool SaveValidation { get; set; }
+    public bool SaveCommit { get; set; }
+    public string MetricProperty { get; set; } = string.Empty;
+    public ThresholdType ThresholdType { get; set; }
+    public decimal ThresholdValue { get; set; }
+}

--- a/Validation.Tests/AddValidationFlowsTests.cs
+++ b/Validation.Tests/AddValidationFlowsTests.cs
@@ -1,0 +1,28 @@
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Validation.Domain.Entities;
+using Validation.Infrastructure.DI;
+using Validation.Infrastructure.Messaging;
+
+namespace Validation.Tests;
+
+public class AddValidationFlowsTests
+{
+    [Fact]
+    public void Configuration_registers_consumers()
+    {
+        var json = "[\n  {\n    \"Type\":\"Validation.Domain.Entities.Item, Validation.Domain\",\n    \"SaveValidation\":true,\n    \"SaveCommit\":true,\n    \"MetricProperty\":\"Metric\",\n    \"ThresholdType\":\"PercentChange\",\n    \"ThresholdValue\":0.2\n  }\n]";
+        var opts = new JsonSerializerOptions();
+        opts.Converters.Add(new System.Text.Json.Serialization.JsonStringEnumConverter());
+        var configs = JsonSerializer.Deserialize<List<ValidationFlowConfig>>(json, opts)!;
+
+        var services = new ServiceCollection();
+        services.AddValidationFlows(configs);
+
+        var hasValidation = services.Any(d => d.ServiceType == typeof(SaveValidationConsumer<Item>));
+        var hasCommit = services.Any(d => d.ServiceType == typeof(SaveCommitConsumer<Item>));
+
+        Assert.True(hasValidation);
+        Assert.True(hasCommit);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `AddValidationFlows` extension to load config and register consumers
- add `ValidationFlowConfig` to represent JSON configuration
- test configuration loading and consumer registration

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688c149f254c8330b489d2426f9c81bb