### PR TITLE
Add validation flow config support

### DIFF
--- a/Validation.Infrastructure/DI/AddValidationFlowsExtensions.cs
+++ b/Validation.Infrastructure/DI/AddValidationFlowsExtensions.cs
@@ -1,0 +1,54 @@
+using System.Linq.Expressions;
+using MassTransit;
+using Microsoft.Extensions.DependencyInjection;
+using Serilog;
+using Validation.Domain.Validation;
+using Validation.Infrastructure.Messaging;
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Infrastructure.DI;
+
+public static class AddValidationFlowsExtensions
+{
+    public static IServiceCollection AddValidationFlows(
+        this IServiceCollection services,
+        IEnumerable<ValidationFlowConfig> configs)
+    {
+        services.AddValidationInfrastructure(cfg =>
+        {
+            foreach (var flow in configs)
+            {
+                var type = Type.GetType(flow.Type, true)!;
+                if (flow.SaveValidation)
+                    cfg.AddConsumer(typeof(SaveValidationConsumer<>).MakeGenericType(type));
+                if (flow.SaveCommit)
+                    cfg.AddConsumer(typeof(SaveCommitConsumer<>).MakeGenericType(type));
+            }
+        });
+
+        services.AddSingleton<IValidationPlanProvider>(_ =>
+        {
+            var provider = new InMemoryValidationPlanProvider();
+            foreach (var flow in configs)
+            {
+                if (flow.MetricProperty != null && flow.ThresholdType.HasValue && flow.ThresholdValue.HasValue)
+                {
+                    var type = Type.GetType(flow.Type, true)!;
+                    var param = Expression.Parameter(typeof(object), "o");
+                    var cast = Expression.Convert(param, type);
+                    var prop = Expression.Property(cast, flow.MetricProperty);
+                    var conv = Expression.Convert(prop, typeof(decimal));
+                    var lambda = Expression.Lambda<Func<object, decimal>>(conv, param).Compile();
+                    var plan = new ValidationPlan(lambda, flow.ThresholdType.Value, flow.ThresholdValue.Value);
+                    typeof(InMemoryValidationPlanProvider).GetMethod("AddPlan")!
+                        .MakeGenericMethod(type)
+                        .Invoke(provider, new object[] { plan });
+                }
+            }
+            return provider;
+        });
+
+        services.AddScoped<SummarisationValidator>();
+        return services;
+    }
+}

--- a/Validation.Infrastructure/DI/ValidationFlowConfig.cs
+++ b/Validation.Infrastructure/DI/ValidationFlowConfig.cs
@@ -1,0 +1,13 @@
+using Validation.Domain.Validation;
+
+namespace Validation.Infrastructure.DI;
+
+public class ValidationFlowConfig
+{
+    public string Type { get; set; } = string.Empty;
+    public bool SaveValidation { get; set; }
+    public bool SaveCommit { get; set; }
+    public string? MetricProperty { get; set; }
+    public ThresholdType? ThresholdType { get; set; }
+    public decimal? ThresholdValue { get; set; }
+}

--- a/Validation.Tests/AddValidationFlowsTests.cs
+++ b/Validation.Tests/AddValidationFlowsTests.cs
@@ -1,0 +1,54 @@
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.EntityFrameworkCore;
+using Validation.Tests;
+using Validation.Domain.Entities;
+using Validation.Infrastructure.DI;
+using Validation.Infrastructure.Messaging;
+using Validation.Domain.Validation;
+using Xunit;
+
+namespace Validation.Tests;
+
+public class AddValidationFlowsTests
+{
+    [Fact]
+    public void AddValidationFlows_registers_consumers_from_json()
+    {
+        const string json = "[{" +
+            "\"Type\":\"Validation.Domain.Entities.Item, Validation.Domain\"," +
+            "\"SaveValidation\":true," +
+            "\"SaveCommit\":true," +
+            "\"MetricProperty\":\"Metric\"," +
+            "\"ThresholdType\":1," +
+            "\"ThresholdValue\":0.2" +
+            "}]";
+        using var doc = JsonDocument.Parse(json);
+        var configs = new List<ValidationFlowConfig>();
+        foreach (var el in doc.RootElement.EnumerateArray())
+        {
+            el.TryGetProperty("ThresholdType", out var tt);
+            el.TryGetProperty("ThresholdValue", out var tv);
+            configs.Add(new ValidationFlowConfig
+            {
+                Type = el.GetProperty("Type").GetString()!,
+                SaveValidation = el.GetProperty("SaveValidation").GetBoolean(),
+                SaveCommit = el.GetProperty("SaveCommit").GetBoolean(),
+                MetricProperty = el.GetProperty("MetricProperty").GetString(),
+                ThresholdType = tt.ValueKind == JsonValueKind.Number ? (ThresholdType?)tt.GetInt32() : tt.ValueKind == JsonValueKind.String ? Enum.Parse<ThresholdType>(tt.GetString()!, true) : null,
+                ThresholdValue = tv.ValueKind == JsonValueKind.Number ? tv.GetDecimal() : null
+            });
+        }
+
+        var services = new ServiceCollection();
+        services.AddDbContext<TestDbContext>(o => o.UseInMemoryDatabase("cfg"));
+        services.AddScoped<DbContext>(sp => sp.GetRequiredService<TestDbContext>());
+        services.AddValidationFlows(configs);
+
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        Assert.NotNull(scope.ServiceProvider.GetService<SaveValidationConsumer<Item>>());
+        Assert.NotNull(scope.ServiceProvider.GetService<SaveCommitConsumer<Item>>());
+    }
+}
+


### PR DESCRIPTION
## Summary
- load validation flows from a JSON configuration
- register SaveValidationConsumer and SaveCommitConsumer dynamically
- test configuration-driven consumer registration

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688c149f254c8330b489d2426f9c81bb