### PR TITLE
Implement SetupValidation builder extensions

### DIFF
--- a/Validation.Infrastructure/DI/SetupValidationBuilder.cs
+++ b/Validation.Infrastructure/DI/SetupValidationBuilder.cs
@@ -1,0 +1,42 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Driver;
+using Validation.Domain.Validation;
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Infrastructure.DI;
+
+public class SetupValidationBuilder
+{
+    private Action<IServiceCollection>? _configure;
+
+    public bool UseMongoDatabase { get; private set; }
+
+    public void UseEntityFramework<TContext>(string connectionString) where TContext : DbContext
+    {
+        _configure += services =>
+        {
+            services.AddDbContext<TContext>(o => o.UseInMemoryDatabase(connectionString));
+            services.AddScoped<DbContext>(sp => sp.GetRequiredService<TContext>());
+        };
+    }
+
+    public void UseMongo(string connectionString, string dbName)
+    {
+        UseMongoDatabase = true;
+        _configure += services =>
+        {
+            var client = new MongoClient(connectionString);
+            var database = client.GetDatabase(dbName);
+            services.AddSingleton(database);
+        };
+    }
+
+    public IServiceCollection Apply(IServiceCollection services)
+    {
+        _configure?.Invoke(services);
+        services.AddSingleton<IValidationPlanProvider, InMemoryValidationPlanProvider>();
+        services.AddScoped<SummarisationValidator>();
+        return services;
+    }
+}

--- a/Validation.Infrastructure/DI/SetupValidationExtensions.cs
+++ b/Validation.Infrastructure/DI/SetupValidationExtensions.cs
@@ -1,0 +1,49 @@
+using Microsoft.Extensions.DependencyInjection;
+using Validation.Domain.Validation;
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Infrastructure.DI;
+
+public static class SetupValidationExtensions
+{
+    public static IServiceCollection SetupValidation(this IServiceCollection services, Action<SetupValidationBuilder> configure)
+    {
+        var builder = new SetupValidationBuilder();
+        configure(builder);
+        builder.Apply(services);
+        return services;
+    }
+
+    public static IServiceCollection AddSaveValidation<T>(this IServiceCollection services,
+        Func<T, decimal>? metricSelector = null,
+        ThresholdType thresholdType = ThresholdType.PercentChange,
+        decimal thresholdValue = 0.1m) where T : class
+    {
+        services.AddSingleton<IValidationPlanProvider>(sp =>
+        {
+            var provider = new InMemoryValidationPlanProvider();
+            Func<object, decimal> selector = metricSelector != null ? o => metricSelector((T)o) : _ => 0m;
+            var plan = new ValidationPlan(selector, thresholdType, thresholdValue);
+            provider.AddPlan<T>(plan);
+            return provider;
+        });
+        return services;
+    }
+
+    public static IServiceCollection AddSetupValidation<T>(this IServiceCollection services,
+        Action<SetupValidationBuilder> configure,
+        Func<T, decimal>? metricSelector = null,
+        ThresholdType thresholdType = ThresholdType.PercentChange,
+        decimal thresholdValue = 0.1m) where T : class
+    {
+        var builder = new SetupValidationBuilder();
+        configure(builder);
+        services.SetupValidation(configure);
+        services.AddSaveValidation<T>(metricSelector, thresholdType, thresholdValue);
+        if (builder.UseMongoDatabase)
+            services.AddScoped<ISaveAuditRepository, MongoSaveAuditRepository>();
+        else
+            services.AddScoped<ISaveAuditRepository, EfCoreSaveAuditRepository>();
+        return services;
+    }
+}

--- a/Validation.Tests/SetupValidationExtensionsTests.cs
+++ b/Validation.Tests/SetupValidationExtensionsTests.cs
@@ -1,0 +1,38 @@
+using Microsoft.Extensions.DependencyInjection;
+using Validation.Domain.Entities;
+using Validation.Domain.Validation;
+using Validation.Infrastructure.DI;
+using Validation.Infrastructure.Repositories;
+using MongoDB.Driver;
+
+namespace Validation.Tests;
+
+public class SetupValidationExtensionsTests
+{
+    [Fact]
+    public void AddSetupValidation_registers_ef_repository_and_plan()
+    {
+        var services = new ServiceCollection();
+        services.AddSetupValidation<Item>(b => b.UseEntityFramework<TestDbContext>("test"), i => i.Metric);
+
+        using var provider = services.BuildServiceProvider();
+        var repo = provider.GetRequiredService<ISaveAuditRepository>();
+        Assert.IsType<EfCoreSaveAuditRepository>(repo);
+
+        var planProvider = provider.GetRequiredService<IValidationPlanProvider>();
+        var plan = planProvider.GetPlan(typeof(Item));
+        Assert.Equal(ThresholdType.PercentChange, plan.ThresholdType);
+        Assert.Equal(0.1m, plan.ThresholdValue);
+    }
+
+    [Fact]
+    public void AddSetupValidation_registers_mongo_repository()
+    {
+        var services = new ServiceCollection();
+        services.AddSetupValidation<Item>(b => b.UseMongo("mongodb://localhost:27017", "db"), i => i.Metric);
+
+        using var provider = services.BuildServiceProvider();
+        var repo = provider.GetRequiredService<ISaveAuditRepository>();
+        Assert.IsType<MongoSaveAuditRepository>(repo);
+    }
+}


### PR DESCRIPTION
## Summary
- add `SetupValidationBuilder` for configuring EF or Mongo storage
- introduce `SetupValidation` and `AddSetupValidation` extension methods
- allow creating default validation plans via `AddSaveValidation`
- tests for the new extensions

## Testing
- `dotnet test Validation.Tests/Validation.Tests.csproj --no-build`

------
https://chatgpt.com/codex/tasks/task_e_688c226be0d08330a79b36c575965fc8