### PR TITLE
Add SetupValidation extensions and tests

### DIFF
--- a/Validation.Infrastructure/DI/SetupValidationBuilder.cs
+++ b/Validation.Infrastructure/DI/SetupValidationBuilder.cs
@@ -1,0 +1,49 @@
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Driver;
+using OpenTelemetry.Trace;
+using Serilog;
+using Validation.Domain.Validation;
+
+namespace Validation.Infrastructure.DI;
+
+public class SetupValidationBuilder
+{
+    private readonly IServiceCollection _services;
+    private Action<IBusRegistrationConfigurator>? _configureBus;
+    internal bool UseMongo { get; private set; }
+
+    public SetupValidationBuilder(IServiceCollection services)
+    {
+        _services = services;
+    }
+
+    public void ConfigureBus(Action<IBusRegistrationConfigurator> configure)
+    {
+        _configureBus = configure;
+    }
+
+    public void SetupDatabase<TContext>(string connectionString) where TContext : DbContext
+    {
+        _services.AddDbContext<TContext>(o => o.UseInMemoryDatabase(connectionString));
+        _services.AddScoped<DbContext>(sp => sp.GetRequiredService<TContext>());
+    }
+
+    public void SetupMongoDatabase(string connectionString, string dbName)
+    {
+        var client = new MongoClient(connectionString);
+        var database = client.GetDatabase(dbName);
+        _services.AddSingleton(database);
+        UseMongo = true;
+    }
+
+    internal void Apply(IServiceCollection services)
+    {
+        services.AddSingleton<IValidationPlanProvider, InMemoryValidationPlanProvider>();
+        services.AddSingleton<IManualValidatorService, ManualValidatorService>();
+        services.AddMassTransit(x => { _configureBus?.Invoke(x); });
+        services.AddLogging(b => b.AddSerilog());
+        services.AddOpenTelemetry().WithTracing(b => b.AddAspNetCoreInstrumentation());
+    }
+}

--- a/Validation.Infrastructure/DI/SetupValidationExtensions.cs
+++ b/Validation.Infrastructure/DI/SetupValidationExtensions.cs
@@ -1,0 +1,66 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using MassTransit;
+using Validation.Domain.Validation;
+using Validation.Infrastructure.Messaging;
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Infrastructure.DI;
+
+public static class SetupValidationExtensions
+{
+    public static IServiceCollection SetupValidation(this IServiceCollection services, Action<SetupValidationBuilder> configure)
+    {
+        var builder = new SetupValidationBuilder(services);
+        configure(builder);
+        builder.Apply(services);
+        return services;
+    }
+
+    public static IServiceCollection AddSaveValidation<T>(this IServiceCollection services,
+        Func<T, decimal>? metricSelector = null,
+        ThresholdType thresholdType = ThresholdType.PercentChange,
+        decimal thresholdValue = 0.1m) where T : class
+    {
+        services.RemoveAll<IValidationPlanProvider>();
+        var provider = new InMemoryValidationPlanProvider();
+        if (metricSelector != null)
+        {
+            Func<object, decimal> selector = o => metricSelector((T)o);
+            var plan = new ValidationPlan(selector, thresholdType, thresholdValue);
+            provider.AddPlan<T>(plan);
+        }
+        else
+        {
+            provider.AddPlan<T>(new ValidationPlan(Array.Empty<IValidationRule>()));
+        }
+        services.AddSingleton<IValidationPlanProvider>(provider);
+        services.AddScoped<SummarisationValidator>();
+        services.AddMassTransitTestHarness(x =>
+        {
+            x.AddConsumer<SaveValidationConsumer<T>>();
+            x.AddConsumer<SaveCommitConsumer<T>>();
+            x.UsingInMemory((context, cfg) => cfg.ConfigureEndpoints(context));
+        });
+        return services;
+    }
+
+    public static IServiceCollection AddSetupValidation<T>(this IServiceCollection services,
+        Action<SetupValidationBuilder> configure,
+        Func<T, decimal>? metricSelector = null,
+        ThresholdType thresholdType = ThresholdType.PercentChange,
+        decimal thresholdValue = 0.1m) where T : class
+    {
+        var capture = new SetupValidationBuilder(new ServiceCollection());
+        configure(capture);
+        services.SetupValidation(configure);
+
+        if (capture.UseMongo)
+            services.AddScoped<ISaveAuditRepository, MongoSaveAuditRepository>();
+        else
+            services.AddScoped<ISaveAuditRepository, EfCoreSaveAuditRepository>();
+
+        services.AddSaveValidation(metricSelector, thresholdType, thresholdValue);
+        return services;
+    }
+}

--- a/Validation.Tests/SetupValidationExtensionsTests.cs
+++ b/Validation.Tests/SetupValidationExtensionsTests.cs
@@ -1,0 +1,49 @@
+using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Driver;
+using Microsoft.EntityFrameworkCore;
+using Validation.Domain.Entities;
+using Validation.Domain.Validation;
+using Validation.Infrastructure.DI;
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Tests;
+
+public class SetupValidationExtensionsTests
+{
+    [Fact]
+    public void AddSetupValidation_registers_plan_and_ef_repository()
+    {
+        var services = new ServiceCollection();
+        services.AddDbContext<TestDbContext>(o => o.UseInMemoryDatabase("test"));
+        services.AddScoped<DbContext>(sp => sp.GetRequiredService<TestDbContext>());
+
+        services.AddSetupValidation<Item>(builder =>
+        {
+            builder.SetupDatabase<TestDbContext>("test");
+        }, i => i.Metric, ThresholdType.RawDifference, 5m);
+
+        using var provider = services.BuildServiceProvider();
+        var repo = provider.GetRequiredService<ISaveAuditRepository>();
+        Assert.IsType<EfCoreSaveAuditRepository>(repo);
+
+        var planProvider = provider.GetRequiredService<IValidationPlanProvider>();
+        var plan = planProvider.GetPlan(typeof(Item));
+        Assert.Equal(ThresholdType.RawDifference, plan.ThresholdType);
+        Assert.Equal(5m, plan.ThresholdValue);
+        Assert.NotNull(plan.MetricSelector);
+    }
+
+    [Fact]
+    public void AddSetupValidation_mongo_registers_mongo_repository()
+    {
+        var services = new ServiceCollection();
+        services.AddSetupValidation<Item>(builder =>
+        {
+            builder.SetupMongoDatabase("mongodb://localhost:27017", "db");
+        }, i => i.Metric);
+
+        using var provider = services.BuildServiceProvider();
+        var repo = provider.GetRequiredService<ISaveAuditRepository>();
+        Assert.IsType<MongoSaveAuditRepository>(repo);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `SetupValidationBuilder` for configuring validation
- add `SetupValidation`, `AddSaveValidation`, and `AddSetupValidation` extension methods
- add tests covering new extensions

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_688c226be0d08330a79b36c575965fc8