### PR TITLE
Add commit/delete validation flow options

### DIFF
--- a/Validation.Domain/Events/DeleteCommitFault.cs
+++ b/Validation.Domain/Events/DeleteCommitFault.cs
@@ -1,0 +1,3 @@
+namespace Validation.Domain.Events;
+
+public record DeleteCommitFault<T>(Guid EntityId, string Error);

--- a/Validation.Domain/Events/DeleteValidated.Generic.cs
+++ b/Validation.Domain/Events/DeleteValidated.Generic.cs
@@ -1,0 +1,3 @@
+namespace Validation.Domain.Events;
+
+public record DeleteValidated<T>(Guid EntityId);

--- a/Validation.Infrastructure/DI/ValidationFlowConfig.cs
+++ b/Validation.Infrastructure/DI/ValidationFlowConfig.cs
@@ -7,6 +7,8 @@ public class ValidationFlowConfig
     public string Type { get; set; } = string.Empty;
     public bool SaveValidation { get; set; }
     public bool SaveCommit { get; set; }
+    public bool DeleteValidation { get; set; }
+    public bool DeleteCommit { get; set; }
     public string? MetricProperty { get; set; }
     public ThresholdType? ThresholdType { get; set; }
     public decimal? ThresholdValue { get; set; }

--- a/Validation.Infrastructure/Messaging/DeleteCommitConsumer.cs
+++ b/Validation.Infrastructure/Messaging/DeleteCommitConsumer.cs
@@ -1,0 +1,27 @@
+using MassTransit;
+using Validation.Domain.Events;
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Infrastructure.Messaging;
+
+public class DeleteCommitConsumer<T> : IConsumer<DeleteValidated<T>>
+{
+    private readonly ISaveAuditRepository _repository;
+
+    public DeleteCommitConsumer(ISaveAuditRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task Consume(ConsumeContext<DeleteValidated<T>> context)
+    {
+        try
+        {
+            await _repository.DeleteAsync(context.Message.EntityId, context.CancellationToken);
+        }
+        catch (Exception ex)
+        {
+            await context.Publish(new DeleteCommitFault<T>(context.Message.EntityId, ex.Message));
+        }
+    }
+}

--- a/Validation.Tests/AddValidationFlowsTests.cs
+++ b/Validation.Tests/AddValidationFlowsTests.cs
@@ -18,6 +18,8 @@ public class AddValidationFlowsTests
                 "Type": "Validation.Domain.Entities.Item, Validation.Domain",
                 "SaveValidation": true,
                 "SaveCommit": true,
+                "DeleteValidation": true,
+                "DeleteCommit": true,
                 "MetricProperty": "Metric",
                 "ThresholdType": 1,
                 "ThresholdValue": 0.2
@@ -36,6 +38,8 @@ public class AddValidationFlowsTests
                 Type = element.GetProperty("Type").GetString()!,
                 SaveValidation = element.GetProperty("SaveValidation").GetBoolean(),
                 SaveCommit = element.GetProperty("SaveCommit").GetBoolean(),
+                DeleteValidation = element.GetProperty("DeleteValidation").GetBoolean(),
+                DeleteCommit = element.GetProperty("DeleteCommit").GetBoolean(),
                 MetricProperty = element.GetProperty("MetricProperty").GetString(),
                 ThresholdType = thresholdTypeElement.ValueKind == JsonValueKind.Number 
                     ? (ThresholdType?)thresholdTypeElement.GetInt32() 
@@ -57,6 +61,8 @@ public class AddValidationFlowsTests
         // Verify that the consumers were registered
         Assert.NotNull(scope.ServiceProvider.GetService<SaveValidationConsumer<Item>>());
         Assert.NotNull(scope.ServiceProvider.GetService<SaveCommitConsumer<Item>>());
+        Assert.NotNull(scope.ServiceProvider.GetService<DeleteValidationConsumer<Item>>());
+        Assert.NotNull(scope.ServiceProvider.GetService<DeleteCommitConsumer<Item>>());
         
         // Verify that validation plan provider was configured
         var planProvider = scope.ServiceProvider.GetRequiredService<IValidationPlanProvider>();
@@ -73,6 +79,8 @@ public class AddValidationFlowsTests
                 Type = "Validation.Domain.Entities.Item, Validation.Domain",
                 SaveValidation = true,
                 SaveCommit = false,
+                DeleteValidation = false,
+                DeleteCommit = false,
                 // No MetricProperty, ThresholdType, or ThresholdValue
             }
         };
@@ -88,6 +96,8 @@ public class AddValidationFlowsTests
         // Verify that only SaveValidationConsumer was registered
         Assert.NotNull(scope.ServiceProvider.GetService<SaveValidationConsumer<Item>>());
         Assert.Null(scope.ServiceProvider.GetService<SaveCommitConsumer<Item>>());
+        Assert.Null(scope.ServiceProvider.GetService<DeleteValidationConsumer<Item>>());
+        Assert.Null(scope.ServiceProvider.GetService<DeleteCommitConsumer<Item>>());
         
         // Verify that validation plan provider was still configured
         var planProvider = scope.ServiceProvider.GetRequiredService<IValidationPlanProvider>();


### PR DESCRIPTION
## Summary
- support delete commit workflow with DeleteCommitConsumer
- add DeleteCommitFault and DeleteValidated events
- expose `AddSaveValidation`, `AddSaveCommit`, `AddDeleteValidation`, `AddDeleteCommit` methods
- load flow options using reflection to call helper methods
- update tests for new JSON validation flow config

## Testing
- `dotnet test Validation.sln --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_688c22d865e08330b0e9caa68b569d7c