### PR TITLE
Add rule inspection and duplicate detection

### DIFF
--- a/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
+++ b/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
@@ -69,7 +69,14 @@ public static class ServiceCollectionExtensions
             svc = new ManualValidatorService();
             services.AddSingleton<IManualValidatorService>(svc);
         }
-        svc.AddRule(rule);
+        try
+        {
+            svc.AddRule(rule);
+        }
+        catch (InvalidOperationException ex)
+        {
+            throw new InvalidOperationException($"A validation rule for type '{typeof(T).Name}' with the same signature already exists.", ex);
+        }
         return services;
     }
 

--- a/Validation.Infrastructure/ManualValidatorService.cs
+++ b/Validation.Infrastructure/ManualValidatorService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Linq;
 using Validation.Domain.Validation;
 
 namespace Validation.Infrastructure;
@@ -6,11 +7,31 @@ namespace Validation.Infrastructure;
 public class ManualValidatorService : IManualValidatorService
 {
     private readonly ConcurrentDictionary<Type, List<Func<object, bool>>> _rules = new();
+    private readonly ConcurrentDictionary<Type, List<Delegate>> _typedRules = new();
 
     public void AddRule<T>(Func<T, bool> rule)
     {
-        var list = _rules.GetOrAdd(typeof(T), _ => new List<Func<object, bool>>());
+        var type = typeof(T);
+        var typedList = _typedRules.GetOrAdd(type, _ => new List<Delegate>());
+        if (typedList.Any(d => d.Equals(rule)))
+            throw new InvalidOperationException($"A rule for type '{type.Name}' with the same signature already exists.");
+        typedList.Add(rule);
+
+        var list = _rules.GetOrAdd(type, _ => new List<Func<object, bool>>());
         list.Add(o => rule((T)o));
+    }
+
+    public IEnumerable<Func<object, bool>> GetRules(Type type)
+    {
+        if (type == null) throw new ArgumentNullException(nameof(type));
+        return _rules.TryGetValue(type, out var list) ? list.ToArray() : Enumerable.Empty<Func<object, bool>>();
+    }
+
+    public void RemoveRules(Type type)
+    {
+        if (type == null) throw new ArgumentNullException(nameof(type));
+        _rules.TryRemove(type, out _);
+        _typedRules.TryRemove(type, out _);
     }
 
     public bool Validate(object instance)

--- a/Validation.Tests/AddValidatorServiceTests.cs
+++ b/Validation.Tests/AddValidatorServiceTests.cs
@@ -73,4 +73,16 @@ public class AddValidatorServiceTests
         var validEntity = new TestEntity { Id = 1, Name = "Hello" };
         Assert.True(validatorService.Validate(validEntity));
     }
+
+    [Fact]
+    public void AddValidatorRule_throws_when_duplicate_rule_added()
+    {
+        var services = new ServiceCollection();
+        Func<TestEntity, bool> rule = e => e.Id > 0;
+
+        services.AddValidatorRule<TestEntity>(rule);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => services.AddValidatorRule<TestEntity>(rule));
+        Assert.Contains("already", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/Validation.Tests/ManualValidatorServiceTests.cs
+++ b/Validation.Tests/ManualValidatorServiceTests.cs
@@ -2,6 +2,7 @@ using Xunit;
 using Microsoft.Extensions.DependencyInjection;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.DI;
+using Validation.Infrastructure;
 
 namespace Validation.Tests;
 
@@ -16,5 +17,17 @@ public class ManualValidatorServiceTests
         var svc = provider.GetRequiredService<IManualValidatorService>();
         Assert.True(svc.Validate("hello"));
         Assert.False(svc.Validate("hi"));
+    }
+
+    [Fact]
+    public void Multiple_rules_for_same_type_are_all_enforced()
+    {
+        var svc = new ManualValidatorService();
+        svc.AddRule<string>(s => s.Length > 3);
+        svc.AddRule<string>(s => s.StartsWith("h"));
+
+        Assert.True(svc.Validate("hello"));
+        Assert.False(svc.Validate("hi"));
+        Assert.False(svc.Validate("world"));
     }
 }


### PR DESCRIPTION
## Summary
- extend `ManualValidatorService` with rule management helpers
- prevent duplicate manual validator rules from being registered
- verify duplicate behavior with tests

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688c230018f08330bde451333d6c1b82