### PR TITLE
Extend manual validation service

### DIFF
--- a/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
+++ b/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
@@ -69,6 +69,8 @@ public static class ServiceCollectionExtensions
             svc = new ManualValidatorService();
             services.AddSingleton<IManualValidatorService>(svc);
         }
+        if (svc.ContainsRule(rule))
+            throw new InvalidOperationException($"A validation rule for {typeof(T).Name} with the same signature already exists.");
         svc.AddRule(rule);
         return services;
     }

--- a/Validation.Infrastructure/ManualValidatorService.cs
+++ b/Validation.Infrastructure/ManualValidatorService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Linq;
 using Validation.Domain.Validation;
 
 namespace Validation.Infrastructure;
@@ -6,11 +7,31 @@ namespace Validation.Infrastructure;
 public class ManualValidatorService : IManualValidatorService
 {
     private readonly ConcurrentDictionary<Type, List<Func<object, bool>>> _rules = new();
+    private readonly ConcurrentDictionary<Type, List<Delegate>> _typedRules = new();
 
     public void AddRule<T>(Func<T, bool> rule)
     {
         var list = _rules.GetOrAdd(typeof(T), _ => new List<Func<object, bool>>());
         list.Add(o => rule((T)o));
+
+        var typed = _typedRules.GetOrAdd(typeof(T), _ => new List<Delegate>());
+        typed.Add(rule);
+    }
+
+    internal bool ContainsRule<T>(Func<T, bool> rule)
+    {
+        return _typedRules.TryGetValue(typeof(T), out var list) && list.Contains(rule);
+    }
+
+    public IEnumerable<Func<object, bool>> GetRules(Type type)
+    {
+        return _rules.TryGetValue(type, out var list) ? list : Enumerable.Empty<Func<object, bool>>();
+    }
+
+    public void RemoveRules(Type type)
+    {
+        _rules.TryRemove(type, out _);
+        _typedRules.TryRemove(type, out _);
     }
 
     public bool Validate(object instance)

--- a/Validation.Tests/AddValidatorServiceTests.cs
+++ b/Validation.Tests/AddValidatorServiceTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.DI;
+using Validation.Infrastructure;
 
 namespace Validation.Tests;
 
@@ -72,5 +73,21 @@ public class AddValidatorServiceTests
         // Test entity that passes both rules
         var validEntity = new TestEntity { Id = 1, Name = "Hello" };
         Assert.True(validatorService.Validate(validEntity));
+
+        var svcImpl = Assert.IsType<ManualValidatorService>(validatorService);
+        Assert.Equal(2, svcImpl.GetRules(typeof(TestEntity)).Count());
+    }
+
+    [Fact]
+    public void AddValidatorRule_throws_when_rule_is_duplicate()
+    {
+        var services = new ServiceCollection();
+        Func<TestEntity, bool> rule = e => e.Id > 0;
+
+        services.AddValidatorRule(rule);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => services.AddValidatorRule(rule));
+
+        Assert.Contains("same signature", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/Validation.Tests/ManualValidatorServiceTests.cs
+++ b/Validation.Tests/ManualValidatorServiceTests.cs
@@ -2,6 +2,7 @@ using Xunit;
 using Microsoft.Extensions.DependencyInjection;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.DI;
+using Validation.Infrastructure;
 
 namespace Validation.Tests;
 
@@ -16,5 +17,19 @@ public class ManualValidatorServiceTests
         var svc = provider.GetRequiredService<IManualValidatorService>();
         Assert.True(svc.Validate("hello"));
         Assert.False(svc.Validate("hi"));
+    }
+
+    [Fact]
+    public void GetRules_returns_added_rules_and_RemoveRules_clears_them()
+    {
+        var service = new ManualValidatorService();
+        service.AddRule<string>(s => s.Length > 1);
+        service.AddRule<string>(s => s.StartsWith("A"));
+
+        Assert.Equal(2, service.GetRules(typeof(string)).Count());
+
+        service.RemoveRules(typeof(string));
+
+        Assert.Empty(service.GetRules(typeof(string)));
     }
 }


### PR DESCRIPTION
## Summary
- allow retrieval and removal of validation rules
- prevent duplicate validator rules
- add tests for manual validation rules

## Testing
- `dotnet build --no-incremental`
- `dotnet test --no-build --logger "console;verbosity=normal"`

------
https://chatgpt.com/codex/tasks/task_e_688c230018f08330bde451333d6c1b82