### PR TITLE
Improve manual validation services

### DIFF
--- a/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
+++ b/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using MassTransit;
+using System;
 using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore;
@@ -68,6 +69,10 @@ public static class ServiceCollectionExtensions
         {
             svc = new ManualValidatorService();
             services.AddSingleton<IManualValidatorService>(svc);
+        }
+        if (svc.GetTypedRules(typeof(T)).Any(r => r.Equals(rule)))
+        {
+            throw new InvalidOperationException($"A duplicate validator rule for {typeof(T).Name} is already registered.");
         }
         svc.AddRule(rule);
         return services;

--- a/Validation.Infrastructure/ManualValidatorService.cs
+++ b/Validation.Infrastructure/ManualValidatorService.cs
@@ -1,4 +1,7 @@
+using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
 using Validation.Domain.Validation;
 
 namespace Validation.Infrastructure;
@@ -6,11 +9,14 @@ namespace Validation.Infrastructure;
 public class ManualValidatorService : IManualValidatorService
 {
     private readonly ConcurrentDictionary<Type, List<Func<object, bool>>> _rules = new();
+    private readonly ConcurrentDictionary<Type, List<Delegate>> _typedRules = new();
 
     public void AddRule<T>(Func<T, bool> rule)
     {
-        var list = _rules.GetOrAdd(typeof(T), _ => new List<Func<object, bool>>());
-        list.Add(o => rule((T)o));
+        var objList = _rules.GetOrAdd(typeof(T), _ => new List<Func<object, bool>>());
+        var typedList = _typedRules.GetOrAdd(typeof(T), _ => new List<Delegate>());
+        objList.Add(o => rule((T)o));
+        typedList.Add(rule);
     }
 
     public bool Validate(object instance)
@@ -20,5 +26,21 @@ public class ManualValidatorService : IManualValidatorService
         if (!_rules.TryGetValue(type, out var list) || list.Count == 0)
             return true;
         return list.All(r => r(instance));
+    }
+
+    public IEnumerable<Func<object, bool>> GetRules(Type type)
+    {
+        return _rules.TryGetValue(type, out var list) ? list.ToList() : Enumerable.Empty<Func<object, bool>>();
+    }
+
+    public void RemoveRules(Type type)
+    {
+        _rules.TryRemove(type, out _);
+        _typedRules.TryRemove(type, out _);
+    }
+
+    internal IEnumerable<Delegate> GetTypedRules(Type type)
+    {
+        return _typedRules.TryGetValue(type, out var list) ? list.ToList() : Enumerable.Empty<Delegate>();
     }
 }

--- a/Validation.Tests/AddValidatorServiceTests.cs
+++ b/Validation.Tests/AddValidatorServiceTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Extensions.DependencyInjection;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.DI;
@@ -72,5 +73,17 @@ public class AddValidatorServiceTests
         // Test entity that passes both rules
         var validEntity = new TestEntity { Id = 1, Name = "Hello" };
         Assert.True(validatorService.Validate(validEntity));
+    }
+
+    [Fact]
+    public void AddValidatorRule_throws_when_rule_is_duplicate()
+    {
+        var services = new ServiceCollection();
+        Func<TestEntity, bool> rule = e => e.Id > 0;
+
+        services.AddValidatorRule(rule);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => services.AddValidatorRule(rule));
+        Assert.Contains("duplicate", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 }


### PR DESCRIPTION
## Summary
- extend manual validator service with rule retrieval and removal
- prevent adding duplicate validator rules
- test duplicate rule rejection

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_688c230018f08330bde451333d6c1b82