### PR TITLE
Add MassTransit reliability features

### DIFF
--- a/Validation.Infrastructure/Observers/SerilogReceiveObserver.cs
+++ b/Validation.Infrastructure/Observers/SerilogReceiveObserver.cs
@@ -1,0 +1,32 @@
+using MassTransit;
+using Serilog;
+
+namespace Validation.Infrastructure.Observers;
+
+public class SerilogReceiveObserver : IReceiveObserver
+{
+    private readonly ILogger _logger;
+
+    public SerilogReceiveObserver(ILogger logger)
+    {
+        _logger = logger;
+    }
+
+    public Task PreReceive(ReceiveContext context) => Task.CompletedTask;
+
+    public Task PostReceive(ReceiveContext context) => Task.CompletedTask;
+
+    public Task PostConsume<T>(ConsumeContext<T> context, TimeSpan duration, string consumerType) where T : class => Task.CompletedTask;
+
+    public Task ConsumeFault<T>(ConsumeContext<T> context, TimeSpan duration, string consumerType, Exception exception) where T : class
+    {
+        _logger.Error(exception, "Message consumption failed for {MessageType}", typeof(T).Name);
+        return Task.CompletedTask;
+    }
+
+    public Task ReceiveFault(ReceiveContext context, Exception exception)
+    {
+        _logger.Error(exception, "Message receive fault");
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary
- add reliability configuration to MassTransit setup
- log failed messages via SerilogReceiveObserver
- enable MassTransit OpenTelemetry tracing

## Testing
- `dotnet test Validation.Tests/Validation.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_688c2299a780833089ceb71ff092891f