### PR TITLE
Add MassTransit reliability features

### DIFF
--- a/Validation.Infrastructure/SerilogReceiveObserver.cs
+++ b/Validation.Infrastructure/SerilogReceiveObserver.cs
@@ -1,0 +1,27 @@
+using MassTransit;
+using Serilog;
+
+namespace Validation.Infrastructure;
+
+/// <summary>
+/// Logs message receive faults using Serilog.
+/// </summary>
+public class SerilogReceiveObserver : IReceiveObserver
+{
+    private readonly ILogger _logger;
+
+    public SerilogReceiveObserver(ILogger logger)
+    {
+        _logger = logger;
+    }
+
+    public Task PreReceive(ReceiveContext context) => Task.CompletedTask;
+    public Task PostReceive(ReceiveContext context) => Task.CompletedTask;
+    public Task PostConsume<T>(ConsumeContext<T> context, TimeSpan duration, string consumerType) where T : class => Task.CompletedTask;
+    public Task ConsumeFault<T>(ConsumeContext<T> context, TimeSpan elapsed, string consumerType, Exception exception) where T : class => Task.CompletedTask;
+    public Task ReceiveFault(ReceiveContext context, Exception exception)
+    {
+        _logger.Error(exception, "Message receive fault for {InputAddress}", context.InputAddress);
+        return Task.CompletedTask;
+    }
+}

--- a/Validation.Tests/AddValidationInfrastructureTests.cs
+++ b/Validation.Tests/AddValidationInfrastructureTests.cs
@@ -1,0 +1,75 @@
+using MassTransit;
+using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Driver;
+using Validation.Infrastructure.DI;
+using Xunit;
+
+namespace Validation.Tests;
+
+public class AddValidationInfrastructureTests
+{
+    public record RetryMessage;
+
+    class FailingConsumer : IConsumer<RetryMessage>
+    {
+        public static int Attempts;
+        public Task Consume(ConsumeContext<RetryMessage> context)
+        {
+            Attempts++;
+            throw new Exception("fail");
+        }
+    }
+
+    [Fact]
+    public async Task AddValidationInfrastructure_retries_failed_messages()
+    {
+        FailingConsumer.Attempts = 0;
+        var services = new ServiceCollection();
+        services.AddValidationInfrastructure(x =>
+        {
+            x.AddConsumer<FailingConsumer>();
+        });
+        await using var provider = services.BuildServiceProvider();
+        var busControl = provider.GetRequiredService<IBusControl>();
+
+        await busControl.StartAsync();
+        try
+        {
+            var bus = provider.GetRequiredService<IBus>();
+            await bus.Publish(new RetryMessage());
+            await Task.Delay(1000);
+            Assert.Equal(4, FailingConsumer.Attempts);
+        }
+        finally
+        {
+            await busControl.StopAsync();
+        }
+    }
+
+    [Fact]
+    public async Task AddMongoValidationInfrastructure_retries_failed_messages()
+    {
+        FailingConsumer.Attempts = 0;
+        var services = new ServiceCollection();
+        var database = new MongoClient("mongodb://localhost:27017").GetDatabase("test");
+        services.AddMongoValidationInfrastructure(database, x =>
+        {
+            x.AddConsumer<FailingConsumer>();
+        });
+        await using var provider = services.BuildServiceProvider();
+        var busControl = provider.GetRequiredService<IBusControl>();
+
+        await busControl.StartAsync();
+        try
+        {
+            var bus = provider.GetRequiredService<IBus>();
+            await bus.Publish(new RetryMessage());
+            await Task.Delay(1000);
+            Assert.Equal(4, FailingConsumer.Attempts);
+        }
+        finally
+        {
+            await busControl.StopAsync();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement reliability features for MassTransit configuration
- add receive observer for Serilog
- record new tests for message retry logic

## Testing
- `DOTNET_ROOT=/usr/lib/dotnet /usr/lib/dotnet/dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_688c2299a780833089ceb71ff092891f