### PR TITLE
Add MassTransit reliability features

### DIFF
--- a/Validation.Infrastructure/Messaging/SerilogReceiveObserver.cs
+++ b/Validation.Infrastructure/Messaging/SerilogReceiveObserver.cs
@@ -1,0 +1,35 @@
+using MassTransit;
+using Serilog;
+
+namespace Validation.Infrastructure.Messaging;
+
+/// <summary>
+/// Logs failed message consumption using Serilog.
+/// </summary>
+public class SerilogReceiveObserver : IReceiveObserver
+{
+    private readonly ILogger _logger;
+
+    public SerilogReceiveObserver(ILogger logger)
+    {
+        _logger = logger;
+    }
+
+    public Task PreReceive(ReceiveContext context) => Task.CompletedTask;
+
+    public Task PostReceive(ReceiveContext context) => Task.CompletedTask;
+
+    public Task PostConsume<T>(ConsumeContext<T> context, TimeSpan duration, string consumerType) where T : class => Task.CompletedTask;
+
+    public Task ConsumeFault<T>(ConsumeContext<T> context, TimeSpan duration, string consumerType, Exception exception) where T : class
+    {
+        _logger.Error(exception, "Error consuming {MessageType}", typeof(T).Name);
+        return Task.CompletedTask;
+    }
+
+    public Task ReceiveFault(ReceiveContext context, Exception exception)
+    {
+        _logger.Error(exception, "Receive fault");
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary
- add MassTransit reliability features to service configuration
- log failed messages via new `SerilogReceiveObserver`
- enable MassTransit tracing with OpenTelemetry

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688c2299a780833089ceb71ff092891f