### PR TITLE
Add nanny record auditing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # validation
+
+This project demonstrates a validation pipeline with audit logging. A new entity
+`NannyRecord` tracks the last summarised metric for each saved entity. These
+records allow auditing and troubleshooting of metric calculations across runs.

--- a/Validation.Domain/NannyRecord.cs
+++ b/Validation.Domain/NannyRecord.cs
@@ -1,0 +1,11 @@
+namespace Validation.Domain;
+
+public class NannyRecord
+{
+    public Guid Id { get; set; }
+    public Guid EntityId { get; set; }
+    public decimal LastMetric { get; set; }
+    public string ProgramName { get; set; } = string.Empty;
+    public string RuntimeIdentifier { get; set; } = string.Empty;
+    public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+}

--- a/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
+++ b/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
@@ -20,6 +20,7 @@ public static class ServiceCollectionExtensions
         Action<IBusRegistrationConfigurator>? configureBus = null)
     {
         services.AddScoped<ISaveAuditRepository, EfCoreSaveAuditRepository>();
+        services.AddScoped<INannyRecordRepository, EfNannyRecordRepository>();
         services.AddSingleton<IValidationPlanProvider, InMemoryValidationPlanProvider>();
         services.AddSingleton<IManualValidatorService, ManualValidatorService>();
 
@@ -41,6 +42,7 @@ public static class ServiceCollectionExtensions
     {
         services.AddSingleton(database);
         services.AddScoped<ISaveAuditRepository, MongoSaveAuditRepository>();
+        services.AddScoped<INannyRecordRepository, MongoNannyRecordRepository>();
         services.AddSingleton<IValidationPlanProvider, InMemoryValidationPlanProvider>();
         services.AddSingleton<IManualValidatorService, ManualValidatorService>();
 
@@ -107,6 +109,7 @@ public static class ServiceCollectionExtensions
 
         // Register dependencies for consumers
         services.AddScoped<ISaveAuditRepository, EfCoreSaveAuditRepository>();
+        services.AddScoped<INannyRecordRepository, EfNannyRecordRepository>();
         services.AddSingleton<IManualValidatorService, ManualValidatorService>();
         services.AddScoped<SummarisationValidator>();
 
@@ -154,6 +157,7 @@ public static class ValidationFlowServiceCollectionExtensions
         options.Services.AddDbContext<TContext>(o => o.UseInMemoryDatabase(connectionString));
         options.Services.AddScoped<DbContext>(sp => sp.GetRequiredService<TContext>());
         options.Services.AddScoped<ISaveAuditRepository, EfCoreSaveAuditRepository>();
+        options.Services.AddScoped<INannyRecordRepository, EfNannyRecordRepository>();
         return options.Services;
     }
 
@@ -163,6 +167,7 @@ public static class ValidationFlowServiceCollectionExtensions
         var database = client.GetDatabase(dbName);
         options.Services.AddSingleton(database);
         options.Services.AddScoped<ISaveAuditRepository, MongoSaveAuditRepository>();
+        options.Services.AddScoped<INannyRecordRepository, MongoNannyRecordRepository>();
         return options.Services;
     }
 

--- a/Validation.Infrastructure/Repositories/EfNannyRecordRepository.cs
+++ b/Validation.Infrastructure/Repositories/EfNannyRecordRepository.cs
@@ -1,0 +1,48 @@
+using Microsoft.EntityFrameworkCore;
+using Validation.Domain;
+
+namespace Validation.Infrastructure.Repositories;
+
+public class EfNannyRecordRepository : INannyRecordRepository
+{
+    private readonly DbContext _context;
+    private readonly DbSet<NannyRecord> _set;
+
+    public EfNannyRecordRepository(DbContext context)
+    {
+        _context = context;
+        _set = context.Set<NannyRecord>();
+    }
+
+    public async Task AddAsync(NannyRecord entity, CancellationToken ct = default)
+    {
+        await _set.AddAsync(entity, ct);
+        await _context.SaveChangesAsync(ct);
+    }
+
+    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
+    {
+        var entity = await _set.FindAsync(new object?[] { id }, ct);
+        if (entity != null)
+        {
+            _set.Remove(entity);
+            await _context.SaveChangesAsync(ct);
+        }
+    }
+
+    public async Task<NannyRecord?> GetAsync(Guid id, CancellationToken ct = default)
+    {
+        return await _set.FindAsync(new object?[] { id }, ct);
+    }
+
+    public async Task UpdateAsync(NannyRecord entity, CancellationToken ct = default)
+    {
+        _set.Update(entity);
+        await _context.SaveChangesAsync(ct);
+    }
+
+    public async Task<NannyRecord?> GetByEntityIdAsync(Guid entityId, CancellationToken ct = default)
+    {
+        return await _set.FirstOrDefaultAsync(n => n.EntityId == entityId, ct);
+    }
+}

--- a/Validation.Infrastructure/Repositories/INannyRecordRepository.cs
+++ b/Validation.Infrastructure/Repositories/INannyRecordRepository.cs
@@ -1,0 +1,6 @@
+namespace Validation.Infrastructure.Repositories;
+
+public interface INannyRecordRepository : IRepository<Validation.Domain.NannyRecord>
+{
+    Task<Validation.Domain.NannyRecord?> GetByEntityIdAsync(Guid entityId, CancellationToken ct = default);
+}

--- a/Validation.Infrastructure/Repositories/MongoNannyRecordRepository.cs
+++ b/Validation.Infrastructure/Repositories/MongoNannyRecordRepository.cs
@@ -1,0 +1,39 @@
+using MongoDB.Driver;
+using Validation.Domain;
+
+namespace Validation.Infrastructure.Repositories;
+
+public class MongoNannyRecordRepository : INannyRecordRepository
+{
+    private readonly IMongoCollection<NannyRecord> _collection;
+
+    public MongoNannyRecordRepository(IMongoDatabase database)
+    {
+        _collection = database.GetCollection<NannyRecord>("nannyRecords");
+    }
+
+    public async Task AddAsync(NannyRecord entity, CancellationToken ct = default)
+    {
+        await _collection.InsertOneAsync(entity, null, ct);
+    }
+
+    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
+    {
+        await _collection.DeleteOneAsync(x => x.Id == id, ct);
+    }
+
+    public async Task<NannyRecord?> GetAsync(Guid id, CancellationToken ct = default)
+    {
+        return await _collection.Find(x => x.Id == id).FirstOrDefaultAsync(ct);
+    }
+
+    public async Task UpdateAsync(NannyRecord entity, CancellationToken ct = default)
+    {
+        await _collection.ReplaceOneAsync(x => x.Id == entity.Id, entity, cancellationToken: ct);
+    }
+
+    public async Task<NannyRecord?> GetByEntityIdAsync(Guid entityId, CancellationToken ct = default)
+    {
+        return await _collection.Find(x => x.EntityId == entityId).FirstOrDefaultAsync(ct);
+    }
+}

--- a/Validation.Infrastructure/UnitOfWork.cs
+++ b/Validation.Infrastructure/UnitOfWork.cs
@@ -1,6 +1,10 @@
 using Microsoft.EntityFrameworkCore;
-using Validation.Infrastructure.Repositories;
+using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Validation.Domain;
 using Validation.Domain.Validation;
+using Validation.Infrastructure.Repositories;
 
 namespace Validation.Infrastructure;
 
@@ -9,13 +13,15 @@ public class UnitOfWork
     private readonly DbContext _context;
     private readonly IValidationPlanProvider _planProvider;
     private readonly SummarisationValidator _validator;
+    private readonly INannyRecordRepository _nannyRepo;
     private readonly Dictionary<Type, object> _repos = new();
 
-    public UnitOfWork(DbContext context, IValidationPlanProvider planProvider, SummarisationValidator validator)
+    public UnitOfWork(DbContext context, IValidationPlanProvider planProvider, SummarisationValidator validator, INannyRecordRepository nannyRepo)
     {
         _context = context;
         _planProvider = planProvider;
         _validator = validator;
+        _nannyRepo = nannyRepo;
     }
 
     public IGenericRepository<T> Repository<T>() where T : class
@@ -31,6 +37,36 @@ public class UnitOfWork
     public async Task<int> SaveChangesWithPlanAsync<T>(CancellationToken ct = default) where T : class
     {
         await Repository<T>().SaveChangesWithPlanAsync(ct);
+
+        var plan = _planProvider.GetPlan(typeof(T));
+        if (plan.MetricSelector != null)
+        {
+            var entries = await _context.Set<T>().ToListAsync(ct);
+
+            foreach (var entity in entries)
+            {
+                var idProp = entity!.GetType().GetProperty("Id");
+                if (idProp == null || idProp.PropertyType != typeof(Guid))
+                    continue;
+
+                var entityId = (Guid)(idProp.GetValue(entity) ?? Guid.Empty);
+                var metric = plan.MetricSelector(entity);
+
+                var existing = await _nannyRepo.GetByEntityIdAsync(entityId, ct);
+                var record = existing ?? new NannyRecord { Id = Guid.NewGuid(), EntityId = entityId };
+
+                record.LastMetric = metric;
+                record.ProgramName = AppDomain.CurrentDomain.FriendlyName;
+                record.RuntimeIdentifier = System.Runtime.InteropServices.RuntimeInformation.RuntimeIdentifier;
+                record.Timestamp = DateTime.UtcNow;
+
+                if (existing == null)
+                    await _nannyRepo.AddAsync(record, ct);
+                else
+                    await _nannyRepo.UpdateAsync(record, ct);
+            }
+        }
+
         return await _context.Set<T>().CountAsync(ct);
     }
 }

--- a/Validation.Tests/AddValidationInfrastructureTests.cs
+++ b/Validation.Tests/AddValidationInfrastructureTests.cs
@@ -1,0 +1,38 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.EntityFrameworkCore;
+using MongoDB.Driver;
+using Validation.Infrastructure.DI;
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Tests;
+
+public class AddValidationInfrastructureTests
+{
+    [Fact]
+    public void AddValidationInfrastructure_registers_nanny_repository()
+    {
+        var services = new ServiceCollection();
+        services.AddDbContext<TestDbContext>(o => o.UseInMemoryDatabase("nanny-di"));
+        services.AddScoped<DbContext>(sp => sp.GetRequiredService<TestDbContext>());
+        services.AddValidationInfrastructure();
+
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        var repo = scope.ServiceProvider.GetService<INannyRecordRepository>();
+        Assert.NotNull(repo);
+    }
+
+    [Fact]
+    public void AddMongoValidationInfrastructure_registers_nanny_repository()
+    {
+        var client = new MongoClient("mongodb://localhost:27017");
+        var db = client.GetDatabase("testdb");
+        var services = new ServiceCollection();
+        services.AddMongoValidationInfrastructure(db);
+
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        var repo = scope.ServiceProvider.GetService<INannyRecordRepository>();
+        Assert.NotNull(repo);
+    }
+}

--- a/Validation.Tests/InMemoryNannyRecordRepository.cs
+++ b/Validation.Tests/InMemoryNannyRecordRepository.cs
@@ -1,0 +1,38 @@
+using Validation.Domain;
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Tests;
+
+public class InMemoryNannyRecordRepository : INannyRecordRepository
+{
+    public List<NannyRecord> Records { get; } = new();
+
+    public Task AddAsync(NannyRecord entity, CancellationToken ct = default)
+    {
+        Records.Add(entity);
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteAsync(Guid id, CancellationToken ct = default)
+    {
+        Records.RemoveAll(r => r.Id == id);
+        return Task.CompletedTask;
+    }
+
+    public Task<NannyRecord?> GetAsync(Guid id, CancellationToken ct = default)
+    {
+        return Task.FromResult<NannyRecord?>(Records.FirstOrDefault(r => r.Id == id));
+    }
+
+    public Task UpdateAsync(NannyRecord entity, CancellationToken ct = default)
+    {
+        var index = Records.FindIndex(r => r.Id == entity.Id);
+        if (index >= 0) Records[index] = entity;
+        return Task.CompletedTask;
+    }
+
+    public Task<NannyRecord?> GetByEntityIdAsync(Guid entityId, CancellationToken ct = default)
+    {
+        return Task.FromResult<NannyRecord?>(Records.FirstOrDefault(r => r.EntityId == entityId));
+    }
+}

--- a/Validation.Tests/UnitOfWorkExampleTests.cs
+++ b/Validation.Tests/UnitOfWorkExampleTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Validation.Domain.Validation;
+using Validation.Infrastructure.Repositories;
 using Validation.Infrastructure;
 
 namespace Validation.Tests;
@@ -27,6 +28,7 @@ public class UnitOfWorkExampleTests
         services.AddScoped<DbContext>(sp => sp.GetRequiredService<ExampleDbContext>());
         services.AddSingleton<IValidationPlanProvider, InMemoryValidationPlanProvider>();
         services.AddScoped<SummarisationValidator>();
+        services.AddScoped<INannyRecordRepository, InMemoryNannyRecordRepository>();
         services.AddScoped<UnitOfWork>();
 
         var provider = services.BuildServiceProvider();


### PR DESCRIPTION
## Summary
- introduce `NannyRecord` entity and repository implementations
- persist nanny metrics in `UnitOfWork`
- register new repositories in DI helpers
- add tests verifying nanny repo registration
- document nanny record purpose

## Testing
- `dotnet clean`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688c22c76ba083308c4a6bb5c6f10a2c