### PR TITLE
Add metrics pipeline orchestrator

### DIFF
--- a/Validation.Infrastructure/Pipeline/CommitService.cs
+++ b/Validation.Infrastructure/Pipeline/CommitService.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Validation.Infrastructure.Repositories;
+using Validation.Domain.Events;
+
+namespace Validation.Infrastructure.Pipeline;
+
+/// <summary>
+/// Persists successful metrics and publishes an event.
+/// </summary>
+public class CommitService
+{
+    private readonly ISaveAuditRepository _repository;
+    private readonly IEventPublisher _publisher;
+
+    public CommitService(ISaveAuditRepository repository, IEventPublisher publisher)
+    {
+        _repository = repository;
+        _publisher = publisher;
+    }
+
+    /// <summary>
+    /// Persist the summary and notify observers.
+    /// </summary>
+    public virtual async Task CommitAsync(decimal summary, bool valid, CancellationToken ct)
+    {
+        var audit = new SaveAudit
+        {
+            Id = Guid.NewGuid(),
+            EntityId = Guid.Empty,
+            Metric = summary,
+            IsValid = valid
+        };
+        await _repository.AddAsync(audit, ct);
+        await _publisher.PublishAsync(new SaveValidated<decimal>(audit.EntityId, audit.Id), ct);
+    }
+}

--- a/Validation.Infrastructure/Pipeline/DiscardHandler.cs
+++ b/Validation.Infrastructure/Pipeline/DiscardHandler.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Validation.Domain.Events;
+
+namespace Validation.Infrastructure.Pipeline;
+
+/// <summary>
+/// Handles metrics that fail validation by logging and publishing a fault event.
+/// </summary>
+public class DiscardHandler
+{
+    private readonly ILogger<DiscardHandler> _logger;
+    private readonly IEventPublisher _publisher;
+
+    public DiscardHandler(ILogger<DiscardHandler> logger, IEventPublisher publisher)
+    {
+        _logger = logger;
+        _publisher = publisher;
+    }
+
+    /// <summary>
+    /// Process invalid metric summaries.
+    /// </summary>
+    public virtual async Task HandleAsync(decimal summary, CancellationToken ct)
+    {
+        _logger.LogWarning("Discarding metric summary {Summary}", summary);
+        await _publisher.PublishAsync(new SaveCommitFault<decimal>(Guid.Empty, Guid.Empty, "Validation failed"), ct);
+    }
+}

--- a/Validation.Infrastructure/Pipeline/IEventPublisher.cs
+++ b/Validation.Infrastructure/Pipeline/IEventPublisher.cs
@@ -1,0 +1,23 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Validation.Infrastructure.Pipeline;
+
+/// <summary>
+/// Abstraction over the event publishing mechanism used by the pipeline.
+/// </summary>
+public interface IEventPublisher
+{
+    /// <summary>
+    /// Publish an event message.
+    /// </summary>
+    Task PublishAsync<T>(T message, CancellationToken ct = default);
+}
+
+/// <summary>
+/// No-op publisher used when none is configured.
+/// </summary>
+public sealed class NullEventPublisher : IEventPublisher
+{
+    public Task PublishAsync<T>(T message, CancellationToken ct = default) => Task.CompletedTask;
+}

--- a/Validation.Infrastructure/Pipeline/IGatherService.cs
+++ b/Validation.Infrastructure/Pipeline/IGatherService.cs
@@ -1,0 +1,12 @@
+namespace Validation.Infrastructure.Pipeline;
+
+/// <summary>
+/// Service responsible for gathering raw metric values from any source.
+/// </summary>
+public interface IGatherService
+{
+    /// <summary>
+    /// Retrieve a collection of metric values.
+    /// </summary>
+    Task<IEnumerable<decimal>> GatherAsync(CancellationToken ct);
+}

--- a/Validation.Infrastructure/Pipeline/IValidationService.cs
+++ b/Validation.Infrastructure/Pipeline/IValidationService.cs
@@ -1,0 +1,12 @@
+namespace Validation.Infrastructure.Pipeline;
+
+/// <summary>
+/// Validates a computed metric summary before it is committed.
+/// </summary>
+public interface IValidationService
+{
+    /// <summary>
+    /// Returns true if the summary value is valid.
+    /// </summary>
+    Task<bool> ValidateAsync(decimal summary, CancellationToken ct);
+}

--- a/Validation.Infrastructure/Pipeline/InMemoryGatherService.cs
+++ b/Validation.Infrastructure/Pipeline/InMemoryGatherService.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Threading;
+
+namespace Validation.Infrastructure.Pipeline;
+
+/// <summary>
+/// Simple gatherer that returns a set of random data for testing purposes.
+/// </summary>
+public class InMemoryGatherService : IGatherService
+{
+    private readonly Random _random = new();
+
+    public Task<IEnumerable<decimal>> GatherAsync(CancellationToken ct)
+    {
+        var data = Enumerable.Range(0, 5).Select(_ => (decimal)_random.Next(0, 100)).ToArray();
+        return Task.FromResult<IEnumerable<decimal>>(data);
+    }
+}

--- a/Validation.Infrastructure/Pipeline/PipelineOrchestrator.cs
+++ b/Validation.Infrastructure/Pipeline/PipelineOrchestrator.cs
@@ -1,0 +1,46 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Validation.Domain.Validation;
+
+namespace Validation.Infrastructure.Pipeline;
+
+/// <summary>
+/// Coordinates each step of the metrics pipeline from gathering through committing or discarding.
+/// </summary>
+public class PipelineOrchestrator<T> : IHostedService
+{
+    private readonly IGatherService _gather;
+    private readonly SummarizationService _summarizer;
+    private readonly IValidationService _validator;
+    private readonly CommitService _commit;
+    private readonly DiscardHandler _discard;
+
+    public PipelineOrchestrator(IGatherService gather, SummarizationService summarizer, IValidationService validator, CommitService commit, DiscardHandler discard)
+    {
+        _gather = gather;
+        _summarizer = summarizer;
+        _validator = validator;
+        _commit = commit;
+        _discard = discard;
+    }
+
+    /// <summary>
+    /// Runs the full gather-&gt;summarize-&gt;validate flow for <typeparamref name="T"/>.
+    /// </summary>
+    public async Task ExecuteAsync(CancellationToken ct)
+    {
+        var metrics = await _gather.GatherAsync(ct);
+        var summary = await _summarizer.SummarizeAsync(metrics, ValidationStrategy.Sum, ct);
+        var valid = await _validator.ValidateAsync(summary, ct);
+
+        if (valid)
+            await _commit.CommitAsync(summary, valid, ct);
+        else
+            await _discard.HandleAsync(summary, ct);
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken) => ExecuteAsync(cancellationToken);
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/Validation.Infrastructure/Pipeline/SummarizationService.cs
+++ b/Validation.Infrastructure/Pipeline/SummarizationService.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Validation.Domain.Validation;
+
+namespace Validation.Infrastructure.Pipeline;
+
+/// <summary>
+/// Aggregates a collection of metric values into a single summary value.
+/// </summary>
+public class SummarizationService
+{
+    private readonly IValidationService _validationService;
+
+    /// <summary>
+    /// Creates the service with the validation component used later in the pipeline.
+    /// </summary>
+    public SummarizationService(IValidationService validationService)
+    {
+        _validationService = validationService;
+    }
+
+    /// <summary>
+    /// Compute the summary value using the supplied strategy.
+    /// </summary>
+    public Task<decimal> SummarizeAsync(IEnumerable<decimal> metrics, ValidationStrategy strategy, CancellationToken ct = default)
+    {
+        var list = metrics.ToList();
+        decimal result = strategy switch
+        {
+            ValidationStrategy.Sum => list.Sum(),
+            ValidationStrategy.Average => list.Count == 0 ? 0m : list.Average(),
+            ValidationStrategy.Count => list.Count,
+            ValidationStrategy.Variance => ComputeVariance(list),
+            _ => throw new ArgumentOutOfRangeException(nameof(strategy))
+        };
+        return Task.FromResult(result);
+    }
+
+    private static decimal ComputeVariance(IReadOnlyList<decimal> values)
+    {
+        if (values.Count == 0)
+            return 0m;
+        var avg = values.Average();
+        var diff = values.Select(v => Math.Pow((double)(v - avg), 2)).Average();
+        return (decimal)diff;
+    }
+}

--- a/Validation.Infrastructure/Pipeline/ValidationService.cs
+++ b/Validation.Infrastructure/Pipeline/ValidationService.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Validation.Domain.Validation;
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Infrastructure.Pipeline;
+
+/// <summary>
+/// Uses configured validation plans to determine if a new summary value should be committed.
+/// </summary>
+public class ValidationService : IValidationService
+{
+    private readonly SummarisationValidator _validator;
+    private readonly IValidationPlanProvider _planProvider;
+    private readonly ISaveAuditRepository _repository;
+
+    public ValidationService(SummarisationValidator validator, IValidationPlanProvider planProvider, ISaveAuditRepository repository)
+    {
+        _validator = validator;
+        _planProvider = planProvider;
+        _repository = repository;
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<bool> ValidateAsync(decimal summary, CancellationToken ct)
+    {
+        var last = await _repository.GetLastAsync(Guid.Empty, ct);
+        var plan = _planProvider.GetPlan(typeof(decimal));
+        return _validator.Validate(last?.Metric ?? 0m, summary, plan);
+    }
+}

--- a/Validation.Tests/MetricsPipelineTests.cs
+++ b/Validation.Tests/MetricsPipelineTests.cs
@@ -1,0 +1,108 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Validation.Domain.Validation;
+using Validation.Infrastructure;
+using Validation.Infrastructure.Pipeline;
+using Validation.Infrastructure.Repositories;
+using Xunit;
+
+namespace Validation.Tests;
+
+public class MetricsPipelineTests
+{
+    private class TestGatherer : IGatherService
+    {
+        public Task<IEnumerable<decimal>> GatherAsync(CancellationToken ct) =>
+            Task.FromResult<IEnumerable<decimal>>(new decimal[] {1m,2m,3m});
+    }
+
+    private class AlwaysValidValidationService : ValidationService
+    {
+        public AlwaysValidValidationService(ISaveAuditRepository repo)
+            : base(new SummarisationValidator(), new InMemoryValidationPlanProvider(), repo) {}
+        public bool NextResult { get; set; } = true;
+        public override async Task<bool> ValidateAsync(decimal summary, CancellationToken ct)
+        {
+            return await Task.FromResult(NextResult);
+        }
+    }
+
+    private class RecordingCommitService : CommitService
+    {
+        public decimal? Summary { get; private set; }
+        public bool? Valid { get; private set; }
+        public RecordingCommitService(ISaveAuditRepository repo)
+            : base(repo, new NullEventPublisher()) {}
+        public override Task CommitAsync(decimal summary, bool valid, CancellationToken ct)
+        {
+            Summary = summary; Valid = valid; return Task.CompletedTask;
+        }
+    }
+
+    private class RecordingDiscardHandler : DiscardHandler
+    {
+        public decimal? Summary { get; private set; }
+        public RecordingDiscardHandler() : base(NullLogger<DiscardHandler>.Instance, new NullEventPublisher()) {}
+        public override Task HandleAsync(decimal summary, CancellationToken ct)
+        {
+            Summary = summary; return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task Orchestrator_commits_when_valid()
+    {
+        var repo = new InMemorySaveAuditRepository();
+        var validator = new AlwaysValidValidationService(repo) { NextResult = true };
+        var commit = new RecordingCommitService(repo);
+        var discard = new RecordingDiscardHandler();
+        var summarizer = new SummarizationService(validator);
+        var orchestrator = new PipelineOrchestrator<decimal>(new TestGatherer(), summarizer, validator, commit, discard);
+
+        await orchestrator.ExecuteAsync(CancellationToken.None);
+
+        Assert.Equal(6m, commit.Summary);
+        Assert.True(commit.Valid);
+        Assert.Null(discard.Summary);
+    }
+
+    [Fact]
+    public async Task Orchestrator_discards_when_invalid()
+    {
+        var repo = new InMemorySaveAuditRepository();
+        var validator = new AlwaysValidValidationService(repo) { NextResult = false };
+        var commit = new RecordingCommitService(repo);
+        var discard = new RecordingDiscardHandler();
+        var summarizer = new SummarizationService(validator);
+        var orchestrator = new PipelineOrchestrator<decimal>(new TestGatherer(), summarizer, validator, commit, discard);
+
+        await orchestrator.ExecuteAsync(CancellationToken.None);
+
+        Assert.Equal(6m, discard.Summary);
+        Assert.Null(commit.Summary);
+    }
+}
+
+public class SummarizationServiceTests
+{
+    private class DummyValidationService : ValidationService
+    {
+        public DummyValidationService() : base(new SummarisationValidator(), new InMemoryValidationPlanProvider(), new InMemorySaveAuditRepository()) {}
+        public override Task<bool> ValidateAsync(decimal summary, CancellationToken ct) => Task.FromResult(true);
+    }
+
+    [Theory]
+    [InlineData(ValidationStrategy.Sum, 6)]
+    [InlineData(ValidationStrategy.Average, 2)]
+    [InlineData(ValidationStrategy.Count, 3)]
+    public async Task Computes_expected_summary(ValidationStrategy strategy, decimal expected)
+    {
+        var svc = new SummarizationService(new DummyValidationService());
+        var result = await svc.SummarizeAsync(new decimal[]{1m,2m,3m}, strategy, CancellationToken.None);
+        Assert.Equal(expected, result);
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement pipeline services for metrics gathering, summarisation, validation and commit
- register pipeline via `AddMetricsPipeline`
- provide default in-memory gatherer
- orchestrate flow via `PipelineOrchestrator`
- add unit tests for summarisation and orchestrator

## Testing
- `dotnet build Validation.sln -v minimal`
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_688c22a8c0a8833083f07e7ad7ef005c