### PR TITLE
Implement metrics pipeline orchestrator

### DIFF
--- a/Validation.Infrastructure/Pipeline/CommitService.cs
+++ b/Validation.Infrastructure/Pipeline/CommitService.cs
@@ -1,0 +1,36 @@
+using MassTransit;
+using Validation.Domain.Events;
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Infrastructure.Pipeline;
+
+/// <summary>
+/// Persists audits and notifies interested consumers when validation succeeds.
+/// </summary>
+public class CommitService
+{
+    private readonly ISaveAuditRepository _repository;
+    private readonly IPublishEndpoint _publisher;
+
+    public CommitService(ISaveAuditRepository repository, IPublishEndpoint publisher)
+    {
+        _repository = repository;
+        _publisher = publisher;
+    }
+
+    /// <summary>
+    /// Store the audit and publish a <see cref="SaveValidated{T}"/> event.
+    /// </summary>
+    public async Task CommitAsync<T>(Guid entityId, decimal metric, bool valid, CancellationToken ct = default)
+    {
+        var audit = new SaveAudit
+        {
+            Id = Guid.NewGuid(),
+            EntityId = entityId,
+            IsValid = valid,
+            Metric = metric
+        };
+        await _repository.AddAsync(audit, ct);
+        await _publisher.Publish(new SaveValidated<T>(entityId, audit.Id), ct);
+    }
+}

--- a/Validation.Infrastructure/Pipeline/DiscardHandler.cs
+++ b/Validation.Infrastructure/Pipeline/DiscardHandler.cs
@@ -1,0 +1,29 @@
+using MassTransit;
+using Microsoft.Extensions.Logging;
+using Validation.Domain.Events;
+
+namespace Validation.Infrastructure.Pipeline;
+
+/// <summary>
+/// Handles metrics that failed validation.
+/// </summary>
+public class DiscardHandler
+{
+    private readonly ILogger<DiscardHandler> _logger;
+    private readonly IPublishEndpoint _publisher;
+
+    public DiscardHandler(ILogger<DiscardHandler> logger, IPublishEndpoint publisher)
+    {
+        _logger = logger;
+        _publisher = publisher;
+    }
+
+    /// <summary>
+    /// Log discarded metrics and publish a fault event.
+    /// </summary>
+    public async Task HandleAsync<T>(IEnumerable<decimal> metrics, CancellationToken ct = default)
+    {
+        _logger.LogWarning("Discarding {Count} metrics", metrics.Count());
+        await _publisher.Publish(new SaveCommitFault<T>(Guid.Empty, Guid.Empty, "Validation failed"), ct);
+    }
+}

--- a/Validation.Infrastructure/Pipeline/IGatherService.cs
+++ b/Validation.Infrastructure/Pipeline/IGatherService.cs
@@ -1,0 +1,12 @@
+namespace Validation.Infrastructure.Pipeline;
+
+/// <summary>
+/// Service that gathers raw metric values from a data source.
+/// </summary>
+public interface IGatherService
+{
+    /// <summary>
+    /// Gather a collection of metric values.
+    /// </summary>
+    Task<IEnumerable<decimal>> GatherAsync(CancellationToken ct);
+}

--- a/Validation.Infrastructure/Pipeline/InMemoryGatherService.cs
+++ b/Validation.Infrastructure/Pipeline/InMemoryGatherService.cs
@@ -1,0 +1,12 @@
+namespace Validation.Infrastructure.Pipeline;
+
+internal class InMemoryGatherService : IGatherService
+{
+    private static readonly Random _rand = new();
+
+    public Task<IEnumerable<decimal>> GatherAsync(CancellationToken ct)
+    {
+        var data = Enumerable.Range(0, 5).Select(_ => (decimal)_rand.NextDouble() * 100);
+        return Task.FromResult(data);
+    }
+}

--- a/Validation.Infrastructure/Pipeline/PipelineOrchestrator.cs
+++ b/Validation.Infrastructure/Pipeline/PipelineOrchestrator.cs
@@ -1,0 +1,52 @@
+using Microsoft.Extensions.Hosting;
+
+namespace Validation.Infrastructure.Pipeline;
+
+/// <summary>
+/// Coordinates the metric processing pipeline from gathering through commit or discard.
+/// </summary>
+public class PipelineOrchestrator<T> : IHostedService
+{
+    private readonly IGatherService _gather;
+    private readonly SummarizationService _summarizer;
+    private readonly ValidationService _validator;
+    private readonly CommitService _commit;
+    private readonly DiscardHandler _discard;
+
+    public PipelineOrchestrator(
+        IGatherService gather,
+        SummarizationService summarizer,
+        ValidationService validator,
+        CommitService commit,
+        DiscardHandler discard)
+    {
+        _gather = gather;
+        _summarizer = summarizer;
+        _validator = validator;
+        _commit = commit;
+        _discard = discard;
+    }
+
+    /// <summary>
+    /// Execute the pipeline once.
+    /// </summary>
+    public async Task ExecuteAsync(CancellationToken ct)
+    {
+        var metrics = await _gather.GatherAsync(ct);
+        var summary = await _summarizer.SummarizeAsync(metrics, ct);
+        var entityId = Guid.NewGuid();
+        var valid = await _validator.ValidateAsync<T>(entityId, summary, ct);
+        if (valid)
+        {
+            await _commit.CommitAsync<T>(entityId, summary, valid, ct);
+        }
+        else
+        {
+            await _discard.HandleAsync<T>(metrics, ct);
+        }
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken) => ExecuteAsync(cancellationToken);
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/Validation.Infrastructure/Pipeline/SummarizationService.cs
+++ b/Validation.Infrastructure/Pipeline/SummarizationService.cs
@@ -1,0 +1,41 @@
+using Validation.Domain.Validation;
+
+namespace Validation.Infrastructure.Pipeline;
+
+/// <summary>
+/// Calculates a summary metric from a sequence of values.
+/// </summary>
+public class SummarizationService
+{
+    private readonly ValidationStrategy _strategy;
+
+    public SummarizationService(ValidationStrategy strategy = ValidationStrategy.Average)
+    {
+        _strategy = strategy;
+    }
+
+    /// <summary>
+    /// Reduce the provided metrics to a single value using the configured strategy.
+    /// </summary>
+    public Task<decimal> SummarizeAsync(IEnumerable<decimal> metrics, CancellationToken ct = default)
+    {
+        var data = metrics.ToArray();
+        decimal result = _strategy switch
+        {
+            ValidationStrategy.Sum => data.Sum(),
+            ValidationStrategy.Average => data.Average(),
+            ValidationStrategy.Count => data.Length,
+            ValidationStrategy.Variance => CalculateVariance(data),
+            _ => 0m
+        };
+        return Task.FromResult(result);
+    }
+
+    private static decimal CalculateVariance(decimal[] values)
+    {
+        if (values.Length == 0) return 0m;
+        var avg = values.Average();
+        var variance = values.Select(v => (double)(v - avg) * (double)(v - avg)).Average();
+        return (decimal)variance;
+    }
+}

--- a/Validation.Infrastructure/Pipeline/ValidationService.cs
+++ b/Validation.Infrastructure/Pipeline/ValidationService.cs
@@ -1,0 +1,33 @@
+using Validation.Domain.Validation;
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Infrastructure.Pipeline;
+
+/// <summary>
+/// Validates a summary value against previously persisted audits using the
+/// configured validation plan.
+/// </summary>
+public class ValidationService
+{
+    private readonly ISaveAuditRepository _repository;
+    private readonly IValidationPlanProvider _planProvider;
+    private readonly SummarisationValidator _validator;
+
+    public ValidationService(ISaveAuditRepository repository, IValidationPlanProvider planProvider, SummarisationValidator validator)
+    {
+        _repository = repository;
+        _planProvider = planProvider;
+        _validator = validator;
+    }
+
+    /// <summary>
+    /// Validate the provided summary for <typeparamref name="T"/>.
+    /// </summary>
+    public async Task<bool> ValidateAsync<T>(Guid entityId, decimal summary, CancellationToken ct = default)
+    {
+        var last = await _repository.GetLastAsync(entityId, ct);
+        var previous = last?.Metric ?? 0m;
+        var plan = _planProvider.GetPlan(typeof(T));
+        return _validator.Validate(previous, summary, plan);
+    }
+}

--- a/Validation.Tests/AddMetricsPipelineTests.cs
+++ b/Validation.Tests/AddMetricsPipelineTests.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Validation.Infrastructure.DI;
+using Validation.Infrastructure.Pipeline;
+using Validation.Infrastructure.Repositories;
+using Validation.Domain.Validation;
+using MassTransit;
+using Microsoft.Extensions.Logging;
+
+namespace Validation.Tests;
+
+public class AddMetricsPipelineTests
+{
+    [Fact]
+    public void AddMetricsPipeline_registers_pipeline_services()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ISaveAuditRepository, InMemorySaveAuditRepository>();
+        services.AddSingleton<IValidationPlanProvider, InMemoryValidationPlanProvider>();
+        services.AddSingleton<IPublishEndpoint>(sp => new MassTransit.Testing.InMemoryTestHarness().Bus);
+        services.AddSingleton<ILoggerFactory, Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory>();
+        services.AddLogging();
+        services.AddMetricsPipeline<object>();
+
+        using var provider = services.BuildServiceProvider();
+        Assert.NotNull(provider.GetService<SummarizationService>());
+        Assert.NotNull(provider.GetService<ValidationService>());
+        Assert.NotNull(provider.GetService<CommitService>());
+        Assert.NotNull(provider.GetService<DiscardHandler>());
+        var hosted = provider.GetServices<IHostedService>().OfType<PipelineOrchestrator<object>>().FirstOrDefault();
+        Assert.NotNull(hosted);
+    }
+}

--- a/Validation.Tests/PipelineOrchestratorTests.cs
+++ b/Validation.Tests/PipelineOrchestratorTests.cs
@@ -1,0 +1,82 @@
+using System.Collections.Generic;
+using MassTransit.Testing;
+using Microsoft.Extensions.Logging.Abstractions;
+using Validation.Domain.Events;
+using Validation.Domain.Validation;
+using Validation.Infrastructure;
+using Validation.Infrastructure.Pipeline;
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Tests;
+
+public class PipelineOrchestratorTests
+{
+    private class FixedGatherer : IGatherService
+    {
+        private readonly IEnumerable<decimal> _data;
+        public FixedGatherer(IEnumerable<decimal> data) => _data = data;
+        public Task<IEnumerable<decimal>> GatherAsync(CancellationToken ct) => Task.FromResult(_data);
+    }
+
+    private class PassingPlanProvider : IValidationPlanProvider
+    {
+        public IEnumerable<IValidationRule> GetRules<T>() => Array.Empty<IValidationRule>();
+        public ValidationPlan GetPlan(Type t) => new ValidationPlan(_ => 0m, ThresholdType.RawDifference, 1000m);
+        public void AddPlan<T>(ValidationPlan plan) { }
+    }
+
+    private class FailingPlanProvider : IValidationPlanProvider
+    {
+        public IEnumerable<IValidationRule> GetRules<T>() => Array.Empty<IValidationRule>();
+        public ValidationPlan GetPlan(Type t) => new ValidationPlan(_ => 0m, ThresholdType.RawDifference, 0m);
+        public void AddPlan<T>(ValidationPlan plan) { }
+    }
+
+    [Fact]
+    public async Task Orchestrator_commits_when_valid()
+    {
+        var gather = new FixedGatherer(new[] { 1m, 2m, 3m });
+        var summarizer = new SummarizationService(ValidationStrategy.Sum);
+        var repo = new InMemorySaveAuditRepository();
+        var validation = new ValidationService(repo, new PassingPlanProvider(), new SummarisationValidator());
+        var harness = new InMemoryTestHarness();
+        await harness.Start();
+        var commit = new CommitService(repo, harness.Bus);
+        var discard = new DiscardHandler(NullLogger<DiscardHandler>.Instance, harness.Bus);
+        var orchestrator = new PipelineOrchestrator<object>(gather, summarizer, validation, commit, discard);
+        try
+        {
+            await orchestrator.ExecuteAsync(CancellationToken.None);
+            Assert.Single(repo.Audits);
+            Assert.True(await harness.Published.Any<SaveValidated<object>>());
+        }
+        finally
+        {
+            await harness.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task Orchestrator_discards_when_invalid()
+    {
+        var gather = new FixedGatherer(new[] { 1m, 2m, 3m });
+        var summarizer = new SummarizationService(ValidationStrategy.Sum);
+        var repo = new InMemorySaveAuditRepository();
+        var validation = new ValidationService(repo, new FailingPlanProvider(), new SummarisationValidator());
+        var harness = new InMemoryTestHarness();
+        await harness.Start();
+        var commit = new CommitService(repo, harness.Bus);
+        var discard = new DiscardHandler(NullLogger<DiscardHandler>.Instance, harness.Bus);
+        var orchestrator = new PipelineOrchestrator<object>(gather, summarizer, validation, commit, discard);
+        try
+        {
+            await orchestrator.ExecuteAsync(CancellationToken.None);
+            Assert.Empty(repo.Audits);
+            Assert.True(await harness.Published.Any<SaveCommitFault<object>>());
+        }
+        finally
+        {
+            await harness.Stop();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add pipeline services and orchestrator to Validation.Infrastructure
- support metrics pipeline registration via `AddMetricsPipeline`
- add unit tests for orchestrator and DI registration

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688c22a8c0a8833083f07e7ad7ef005c