### PR TITLE
Add Serilog and OpenTelemetry logging for consumers

### DIFF
--- a/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
+++ b/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using MongoDB.Driver;
 using OpenTelemetry.Trace;
 using Serilog;
+using System.Diagnostics;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.Messaging;
 using Validation.Infrastructure.Repositories;
@@ -30,7 +31,13 @@ public static class ServiceCollectionExtensions
 
         services.AddLogging(loggingBuilder => loggingBuilder.AddSerilog());
 
-        services.AddOpenTelemetry().WithTracing(builder => builder.AddAspNetCoreInstrumentation());
+        var source = new ActivitySource("Validation.Infrastructure");
+        services.AddSingleton(source);
+
+        services.AddOpenTelemetry()
+            .WithTracing(builder => builder
+                .AddSource("Validation.Infrastructure")
+                .AddAspNetCoreInstrumentation());
 
         return services;
     }
@@ -51,7 +58,13 @@ public static class ServiceCollectionExtensions
 
         services.AddLogging(loggingBuilder => loggingBuilder.AddSerilog());
 
-        services.AddOpenTelemetry().WithTracing(builder => builder.AddAspNetCoreInstrumentation());
+        var source = new ActivitySource("Validation.Infrastructure");
+        services.AddSingleton(source);
+
+        services.AddOpenTelemetry()
+            .WithTracing(builder => builder
+                .AddSource("Validation.Infrastructure")
+                .AddAspNetCoreInstrumentation());
 
         return services;
     }
@@ -131,7 +144,10 @@ public static class ServiceCollectionExtensions
         });
 
         services.AddLogging(b => b.AddSerilog());
-        services.AddOpenTelemetry().WithTracing(b => b.AddAspNetCoreInstrumentation());
+        var source = new ActivitySource("Validation.Infrastructure");
+        services.AddSingleton(source);
+        services.AddOpenTelemetry()
+            .WithTracing(b => b.AddSource("Validation.Infrastructure").AddAspNetCoreInstrumentation());
 
         return services;
     }
@@ -179,7 +195,9 @@ public static class ValidationFlowServiceCollectionExtensions
             x.UsingInMemory((context, cfg) => cfg.ConfigureEndpoints(context));
         });
         services.AddLogging(b => b.AddSerilog());
-        services.AddOpenTelemetry().WithTracing(b => b.AddAspNetCoreInstrumentation());
+        var source = new ActivitySource("Validation.Infrastructure");
+        services.AddSingleton(source);
+        services.AddOpenTelemetry().WithTracing(b => b.AddSource("Validation.Infrastructure").AddAspNetCoreInstrumentation());
         var options = new ValidationFlowOptions(services);
         configure?.Invoke(options);
         return services;

--- a/Validation.Infrastructure/Messaging/DeleteValidationConsumer.cs
+++ b/Validation.Infrastructure/Messaging/DeleteValidationConsumer.cs
@@ -2,25 +2,37 @@ using MassTransit;
 using Validation.Domain.Events;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.Repositories;
+using Microsoft.Extensions.Logging;
+using System.Diagnostics;
 
 namespace Validation.Infrastructure.Messaging;
 
+/// <summary>
+/// Validates a delete request. Logging and tracing provide visibility into
+/// manual rule execution for delete operations.
+/// </summary>
 public class DeleteValidationConsumer<T> : IConsumer<DeleteRequested>
 {
     private readonly IValidationPlanProvider _planProvider;
     private readonly SummarisationValidator _validator;
+    private readonly ILogger<DeleteValidationConsumer<T>> _logger;
+    private readonly ActivitySource _activitySource;
 
-    public DeleteValidationConsumer(IValidationPlanProvider planProvider, SummarisationValidator validator)
+    public DeleteValidationConsumer(IValidationPlanProvider planProvider, SummarisationValidator validator, ILogger<DeleteValidationConsumer<T>> logger, ActivitySource activitySource)
     {
         _planProvider = planProvider;
         _validator = validator;
+        _logger = logger;
+        _activitySource = activitySource;
     }
 
     public Task Consume(ConsumeContext<DeleteRequested> context)
     {
+        using var activity = _activitySource.StartActivity("Consume DeleteRequested");
         var rules = _planProvider.GetRules<T>();
         // execute manual rules with zero metrics since delete; actual logic omitted
         _validator.Validate(0, 0, rules);
+        _logger.LogInformation("Delete validated for {Id}", context.Message.Id);
         return Task.CompletedTask;
     }
 }

--- a/Validation.Infrastructure/Messaging/SaveCommitConsumer.cs
+++ b/Validation.Infrastructure/Messaging/SaveCommitConsumer.cs
@@ -1,30 +1,43 @@
 using MassTransit;
 using Validation.Domain.Events;
 using Validation.Infrastructure.Repositories;
+using Microsoft.Extensions.Logging;
+using System.Diagnostics;
 
 namespace Validation.Infrastructure.Messaging;
 
+/// <summary>
+/// Finalises a save operation and records success or failure. Serilog logs and
+/// OpenTelemetry spans emitted here make it easier to trace persistence issues.
+/// </summary>
 public class SaveCommitConsumer<T> : IConsumer<SaveValidated<T>>
 {
     private readonly ISaveAuditRepository _repository;
+    private readonly ILogger<SaveCommitConsumer<T>> _logger;
+    private readonly ActivitySource _activitySource;
 
-    public SaveCommitConsumer(ISaveAuditRepository repository)
+    public SaveCommitConsumer(ISaveAuditRepository repository, ILogger<SaveCommitConsumer<T>> logger, ActivitySource activitySource)
     {
         _repository = repository;
+        _logger = logger;
+        _activitySource = activitySource;
     }
 
     public async Task Consume(ConsumeContext<SaveValidated<T>> context)
     {
+        using var activity = _activitySource.StartActivity("Consume SaveValidated");
         try
         {
             var audit = await _repository.GetAsync(context.Message.AuditId, context.CancellationToken);
             if (audit != null)
             {
                 await _repository.UpdateAsync(audit, context.CancellationToken);
+                _logger.LogInformation("Audit {AuditId} updated", audit.Id);
             }
         }
         catch (Exception ex)
         {
+            _logger.LogError(ex, "Failed to update audit {AuditId}", context.Message.AuditId);
             await context.Publish(new SaveCommitFault<T>(context.Message.EntityId, context.Message.AuditId, ex.Message));
         }
     }

--- a/Validation.Infrastructure/Messaging/SaveRequestedConsumer.cs
+++ b/Validation.Infrastructure/Messaging/SaveRequestedConsumer.cs
@@ -3,25 +3,39 @@ using Validation.Domain.Events;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.Repositories;
 using Validation.Infrastructure;
+using Microsoft.Extensions.Logging;
+using System.Diagnostics;
 
 namespace Validation.Infrastructure.Messaging;
 
+/// <summary>
+/// Validates incoming save requests using a single rule.
+/// Logging of metrics and spans help pinpoint validation errors.
+/// </summary>
 public class SaveRequestedConsumer : IConsumer<SaveRequested>
 {
     private readonly ISaveAuditRepository _repository;
     private readonly IValidationRule _rule;
     private decimal _previousMetric;
+    private readonly ILogger<SaveRequestedConsumer> _logger;
+    private readonly ActivitySource _activitySource;
 
-    public SaveRequestedConsumer(ISaveAuditRepository repository, IValidationRule rule)
+    public SaveRequestedConsumer(ISaveAuditRepository repository, IValidationRule rule, ILogger<SaveRequestedConsumer> logger, ActivitySource activitySource)
     {
         _repository = repository;
         _rule = rule;
+        _logger = logger;
+        _activitySource = activitySource;
     }
 
     public async Task Consume(ConsumeContext<SaveRequested> context)
     {
+        using var activity = _activitySource.StartActivity("Consume SaveRequested(single)");
         var metric = new Random().Next(0, 100); // simulate metric
         var isValid = _rule.Validate(_previousMetric, metric);
+        _logger.LogInformation(
+            "Save requested for {Id}: previous={Prev} new={Metric} valid={Valid}",
+            context.Message.Id, _previousMetric, metric, isValid);
         _previousMetric = metric;
         var audit = new SaveAudit
         {

--- a/Validation.Infrastructure/Messaging/SaveValidationConsumer.cs
+++ b/Validation.Infrastructure/Messaging/SaveValidationConsumer.cs
@@ -2,28 +2,43 @@ using MassTransit;
 using Validation.Domain.Events;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.Repositories;
+using Microsoft.Extensions.Logging;
+using System.Diagnostics;
 
 namespace Validation.Infrastructure.Messaging;
 
+/// <summary>
+/// Consumes <see cref="SaveRequested"/> messages and logs validation results.
+/// The emitted Serilog entries and OpenTelemetry spans help trace message flow
+/// and diagnose failures during validation.
+/// </summary>
 public class SaveValidationConsumer<T> : IConsumer<SaveRequested>
 {
     private readonly IValidationPlanProvider _planProvider;
     private readonly ISaveAuditRepository _repository;
     private readonly SummarisationValidator _validator;
+    private readonly ILogger<SaveValidationConsumer<T>> _logger;
+    private readonly ActivitySource _activitySource;
 
-    public SaveValidationConsumer(IValidationPlanProvider planProvider, ISaveAuditRepository repository, SummarisationValidator validator)
+    public SaveValidationConsumer(IValidationPlanProvider planProvider, ISaveAuditRepository repository, SummarisationValidator validator, ILogger<SaveValidationConsumer<T>> logger, ActivitySource activitySource)
     {
         _planProvider = planProvider;
         _repository = repository;
         _validator = validator;
+        _logger = logger;
+        _activitySource = activitySource;
     }
 
     public async Task Consume(ConsumeContext<SaveRequested> context)
     {
+        using var activity = _activitySource.StartActivity("Consume SaveRequested");
         var last = await _repository.GetLastAsync(context.Message.Id, context.CancellationToken);
         var metric = new Random().Next(0, 100);
         var rules = _planProvider.GetRules<T>();
         var isValid = _validator.Validate(last?.Metric ?? 0m, metric, rules);
+
+        _logger.LogInformation("Validation for {Id}: previous={PrevMetric} new={Metric} valid={Valid}",
+            context.Message.Id, last?.Metric, metric, isValid);
 
         var audit = new SaveAudit
         {

--- a/Validation.Tests/SavePipelineTests.cs
+++ b/Validation.Tests/SavePipelineTests.cs
@@ -6,6 +6,8 @@ using Validation.Domain.Validation;
 using Validation.Infrastructure.Messaging;
 using Validation.Infrastructure.Repositories;
 using Validation.Infrastructure;
+using Microsoft.Extensions.Logging;
+using System.Diagnostics;
 
 namespace Validation.Tests;
 
@@ -62,8 +64,8 @@ public class SavePipelineTests
     {
         var repo = new InMemorySaveAuditRepository();
         var harness = new InMemoryTestHarness();
-        harness.Consumer(() => new SaveValidationConsumer<Item>(new TestPlanProvider(), repo, new SummarisationValidator()));
-        harness.Consumer(() => new SaveCommitConsumer<Item>(repo));
+        harness.Consumer(() => new SaveValidationConsumer<Item>(new TestPlanProvider(), repo, new SummarisationValidator(), new TestLogger<SaveValidationConsumer<Item>>(), new ActivitySource("p1")));
+        harness.Consumer(() => new SaveCommitConsumer<Item>(repo, new TestLogger<SaveCommitConsumer<Item>>(), new ActivitySource("p2")));
 
         await harness.Start();
         try
@@ -84,8 +86,8 @@ public class SavePipelineTests
     {
         var repo = new FailingRepository();
         var harness = new InMemoryTestHarness();
-        harness.Consumer(() => new SaveValidationConsumer<Item>(new TestPlanProvider(), repo, new SummarisationValidator()));
-        harness.Consumer(() => new SaveCommitConsumer<Item>(repo));
+        harness.Consumer(() => new SaveValidationConsumer<Item>(new TestPlanProvider(), repo, new SummarisationValidator(), new TestLogger<SaveValidationConsumer<Item>>(), new ActivitySource("p3")));
+        harness.Consumer(() => new SaveCommitConsumer<Item>(repo, new TestLogger<SaveCommitConsumer<Item>>(), new ActivitySource("p4")));
 
         await harness.Start();
         try
@@ -105,7 +107,7 @@ public class SavePipelineTests
     {
         var repo = new InMemorySaveAuditRepository();
         var harness = new InMemoryTestHarness();
-        var validationConsumer = harness.Consumer(() => new SaveValidationConsumer<Item>(new TestPlanProvider(), repo, new SummarisationValidator()));
+        var validationConsumer = harness.Consumer(() => new SaveValidationConsumer<Item>(new TestPlanProvider(), repo, new SummarisationValidator(), new TestLogger<SaveValidationConsumer<Item>>(), new ActivitySource("p5")));
 
         await harness.Start();
         try

--- a/Validation.Tests/SaveValidationConsumerTests.cs
+++ b/Validation.Tests/SaveValidationConsumerTests.cs
@@ -4,6 +4,8 @@ using Validation.Domain.Events;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.Messaging;
 using Validation.Domain.Entities;
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
 
 namespace Validation.Tests;
 
@@ -20,7 +22,9 @@ public class SaveValidationConsumerTests
     public async Task Publish_SaveValidated_after_processing()
     {
         var repository = new InMemorySaveAuditRepository();
-        var consumer = new SaveValidationConsumer<Item>(new TestPlanProvider(), repository, new SummarisationValidator());
+        var logger = new TestLogger<SaveValidationConsumer<Item>>();
+        var source = new ActivitySource("test");
+        var consumer = new SaveValidationConsumer<Item>(new TestPlanProvider(), repository, new SummarisationValidator(), logger, source);
 
         var harness = new InMemoryTestHarness();
         harness.Consumer(() => consumer);
@@ -31,6 +35,41 @@ public class SaveValidationConsumerTests
             await harness.InputQueueSendEndpoint.Send(new SaveRequested(Guid.NewGuid()));
 
             Assert.True(await harness.Published.Any<SaveValidated<Item>>());
+        }
+        finally
+        {
+            await harness.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task Logs_validation_information()
+    {
+        var repository = new InMemorySaveAuditRepository();
+        var logger = new TestLogger<SaveValidationConsumer<Item>>();
+        var source = new ActivitySource("logtest");
+        var consumer = new SaveValidationConsumer<Item>(new TestPlanProvider(), repository, new SummarisationValidator(), logger, source);
+
+        var harness = new InMemoryTestHarness();
+        harness.Consumer(() => consumer);
+
+        var activities = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = s => true,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStarted = a => activities.Add(a)
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        await harness.Start();
+        try
+        {
+            var id = Guid.NewGuid();
+            await harness.InputQueueSendEndpoint.Send(new SaveRequested(id));
+
+            Assert.True(logger.Messages.Any());
+            Assert.True(activities.Any());
         }
         finally
         {

--- a/Validation.Tests/TestLogger.cs
+++ b/Validation.Tests/TestLogger.cs
@@ -1,0 +1,15 @@
+using Microsoft.Extensions.Logging;
+using System.Collections.Concurrent;
+
+namespace Validation.Tests;
+
+public class TestLogger<T> : ILogger<T>
+{
+    private class NullScope : IDisposable { public void Dispose() { } }
+    public ConcurrentBag<string> Messages { get; } = new();
+
+    public IDisposable BeginScope<TState>(TState state) => new NullScope();
+    public bool IsEnabled(LogLevel logLevel) => true;
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        => Messages.Add(formatter(state, exception));
+}

--- a/Validation.Tests/ValidationFlowIntegrationTests.cs
+++ b/Validation.Tests/ValidationFlowIntegrationTests.cs
@@ -5,6 +5,8 @@ using Validation.Infrastructure.Messaging;
 using MassTransit;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.DI;
+using Microsoft.Extensions.Logging;
+using System.Diagnostics;
 
 namespace Validation.Tests;
 

--- a/Validation.Tests/ValidationWorkflowTests.cs
+++ b/Validation.Tests/ValidationWorkflowTests.cs
@@ -3,6 +3,8 @@ using MassTransit.Testing;
 using Validation.Domain.Events;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.Messaging;
+using Microsoft.Extensions.Logging;
+using System.Diagnostics;
 
 namespace Validation.Tests;
 
@@ -13,7 +15,9 @@ public class ValidationWorkflowTests
     {
         var repository = new InMemorySaveAuditRepository();
         var rule = new RawDifferenceRule(100); // always valid
-        var consumer = new SaveRequestedConsumer(repository, rule);
+        var logger = new TestLogger<SaveRequestedConsumer>();
+        var src = new ActivitySource("workflow");
+        var consumer = new SaveRequestedConsumer(repository, rule, logger, src);
 
         var harness = new InMemoryTestHarness();
         var consumerHarness = harness.Consumer(() => consumer);


### PR DESCRIPTION
## Summary
- log validation operations and results in all consumers
- create spans with `ActivitySource` for every consume operation
- register `ActivitySource` in validation infrastructure
- capture consumer logging and tracing in tests

## Testing
- `dotnet test Validation.sln`

------
https://chatgpt.com/codex/tasks/task_e_688c23106200833092a329edd778f03b