### PR TITLE
Add Serilog logging and OpenTelemetry spans

### DIFF
--- a/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
+++ b/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using MongoDB.Driver;
 using OpenTelemetry.Trace;
 using Serilog;
+using System.Diagnostics;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.Messaging;
 using Validation.Infrastructure.Repositories;
@@ -30,7 +31,11 @@ public static class ServiceCollectionExtensions
 
         services.AddLogging(loggingBuilder => loggingBuilder.AddSerilog());
 
-        services.AddOpenTelemetry().WithTracing(builder => builder.AddAspNetCoreInstrumentation());
+        services.AddSingleton(_ => new ActivitySource("Validation.Infrastructure"));
+
+        services.AddOpenTelemetry().WithTracing(builder =>
+            builder.AddAspNetCoreInstrumentation()
+                   .AddSource("Validation.Infrastructure"));
 
         return services;
     }
@@ -51,7 +56,11 @@ public static class ServiceCollectionExtensions
 
         services.AddLogging(loggingBuilder => loggingBuilder.AddSerilog());
 
-        services.AddOpenTelemetry().WithTracing(builder => builder.AddAspNetCoreInstrumentation());
+        services.AddSingleton(_ => new ActivitySource("Validation.Infrastructure"));
+
+        services.AddOpenTelemetry().WithTracing(builder =>
+            builder.AddAspNetCoreInstrumentation()
+                   .AddSource("Validation.Infrastructure"));
 
         return services;
     }
@@ -131,7 +140,9 @@ public static class ServiceCollectionExtensions
         });
 
         services.AddLogging(b => b.AddSerilog());
-        services.AddOpenTelemetry().WithTracing(b => b.AddAspNetCoreInstrumentation());
+        services.AddSingleton(_ => new ActivitySource("Validation.Infrastructure"));
+        services.AddOpenTelemetry().WithTracing(b => b.AddAspNetCoreInstrumentation()
+            .AddSource("Validation.Infrastructure"));
 
         return services;
     }
@@ -179,7 +190,9 @@ public static class ValidationFlowServiceCollectionExtensions
             x.UsingInMemory((context, cfg) => cfg.ConfigureEndpoints(context));
         });
         services.AddLogging(b => b.AddSerilog());
-        services.AddOpenTelemetry().WithTracing(b => b.AddAspNetCoreInstrumentation());
+        services.AddSingleton(_ => new ActivitySource("Validation.Infrastructure"));
+        services.AddOpenTelemetry().WithTracing(b => b.AddAspNetCoreInstrumentation()
+            .AddSource("Validation.Infrastructure"));
         var options = new ValidationFlowOptions(services);
         configure?.Invoke(options);
         return services;

--- a/Validation.Infrastructure/Messaging/DeleteValidationConsumer.cs
+++ b/Validation.Infrastructure/Messaging/DeleteValidationConsumer.cs
@@ -2,25 +2,40 @@ using MassTransit;
 using Validation.Domain.Events;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.Repositories;
+using Microsoft.Extensions.Logging;
+using System.Diagnostics;
 
 namespace Validation.Infrastructure.Messaging;
 
+/// <summary>
+/// Validates delete requests and emits logs and tracing spans to track
+/// processing progress.
+/// </summary>
 public class DeleteValidationConsumer<T> : IConsumer<DeleteRequested>
 {
     private readonly IValidationPlanProvider _planProvider;
     private readonly SummarisationValidator _validator;
+    private readonly ILogger<DeleteValidationConsumer<T>> _logger;
+    private readonly ActivitySource _activitySource;
 
-    public DeleteValidationConsumer(IValidationPlanProvider planProvider, SummarisationValidator validator)
+    public DeleteValidationConsumer(IValidationPlanProvider planProvider, SummarisationValidator validator, ILogger<DeleteValidationConsumer<T>> logger, ActivitySource activitySource)
     {
         _planProvider = planProvider;
         _validator = validator;
+        _logger = logger;
+        _activitySource = activitySource;
     }
 
+    /// <summary>
+    /// Executes validation of delete requests while producing log records and a tracing span.
+    /// </summary>
     public Task Consume(ConsumeContext<DeleteRequested> context)
     {
+        using var activity = _activitySource.StartActivity("DeleteValidationConsumer.Consume");
         var rules = _planProvider.GetRules<T>();
         // execute manual rules with zero metrics since delete; actual logic omitted
         _validator.Validate(0, 0, rules);
+        _logger.LogInformation("Validated delete for entity {EntityId}", context.Message.Id);
         return Task.CompletedTask;
     }
 }

--- a/Validation.Infrastructure/Messaging/SaveCommitConsumer.cs
+++ b/Validation.Infrastructure/Messaging/SaveCommitConsumer.cs
@@ -1,31 +1,47 @@
 using MassTransit;
 using Validation.Domain.Events;
 using Validation.Infrastructure.Repositories;
+using Microsoft.Extensions.Logging;
+using System.Diagnostics;
 
 namespace Validation.Infrastructure.Messaging;
 
+/// <summary>
+/// Commits validated save audits while logging successes and failures.
+/// Each consume operation creates an OpenTelemetry span to aid troubleshooting.
+/// </summary>
 public class SaveCommitConsumer<T> : IConsumer<SaveValidated<T>>
 {
     private readonly ISaveAuditRepository _repository;
+    private readonly ILogger<SaveCommitConsumer<T>> _logger;
+    private readonly ActivitySource _activitySource;
 
-    public SaveCommitConsumer(ISaveAuditRepository repository)
+    public SaveCommitConsumer(ISaveAuditRepository repository, ILogger<SaveCommitConsumer<T>> logger, ActivitySource activitySource)
     {
         _repository = repository;
+        _logger = logger;
+        _activitySource = activitySource;
     }
 
+    /// <summary>
+    /// Applies the commit and records success or failure with logs and traces.
+    /// </summary>
     public async Task Consume(ConsumeContext<SaveValidated<T>> context)
     {
+        using var activity = _activitySource.StartActivity("SaveCommitConsumer.Consume");
         try
         {
             var audit = await _repository.GetAsync(context.Message.AuditId, context.CancellationToken);
             if (audit != null)
             {
                 await _repository.UpdateAsync(audit, context.CancellationToken);
+                _logger.LogInformation("Committed audit {AuditId} for entity {EntityId}", audit.Id, audit.EntityId);
             }
         }
         catch (Exception ex)
         {
             await context.Publish(new SaveCommitFault<T>(context.Message.EntityId, context.Message.AuditId, ex.Message));
+            _logger.LogError(ex, "Failed to commit audit {AuditId} for entity {EntityId}", context.Message.AuditId, context.Message.EntityId);
         }
     }
 }

--- a/Validation.Infrastructure/Messaging/SaveRequestedConsumer.cs
+++ b/Validation.Infrastructure/Messaging/SaveRequestedConsumer.cs
@@ -3,26 +3,41 @@ using Validation.Domain.Events;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.Repositories;
 using Validation.Infrastructure;
+using Microsoft.Extensions.Logging;
+using System.Diagnostics;
 
 namespace Validation.Infrastructure.Messaging;
 
+/// <summary>
+/// Validates manual save requests while logging and tracing the message lifecycle.
+/// </summary>
 public class SaveRequestedConsumer : IConsumer<SaveRequested>
 {
     private readonly ISaveAuditRepository _repository;
     private readonly IValidationRule _rule;
     private decimal _previousMetric;
+    private readonly ILogger<SaveRequestedConsumer> _logger;
+    private readonly ActivitySource _activitySource;
 
-    public SaveRequestedConsumer(ISaveAuditRepository repository, IValidationRule rule)
+    public SaveRequestedConsumer(ISaveAuditRepository repository, IValidationRule rule, ILogger<SaveRequestedConsumer> logger, ActivitySource activitySource)
     {
         _repository = repository;
         _rule = rule;
+        _logger = logger;
+        _activitySource = activitySource;
     }
 
+    /// <summary>
+    /// Validates the incoming save request and publishes the outcome while capturing logs and a span.
+    /// </summary>
     public async Task Consume(ConsumeContext<SaveRequested> context)
     {
+        using var activity = _activitySource.StartActivity("SaveRequestedConsumer.Consume");
         var metric = new Random().Next(0, 100); // simulate metric
-        var isValid = _rule.Validate(_previousMetric, metric);
+        var previous = _previousMetric;
+        var isValid = _rule.Validate(previous, metric);
         _previousMetric = metric;
+        _logger.LogInformation("Validating save request for {EntityId}. Previous {Prev} New {Metric} Result {Result}", context.Message.Id, previous, metric, isValid);
         var audit = new SaveAudit
         {
             Id = Guid.NewGuid(),
@@ -32,5 +47,6 @@ public class SaveRequestedConsumer : IConsumer<SaveRequested>
         };
         await _repository.AddAsync(audit, context.CancellationToken);
         await context.Publish(new SaveValidated(context.Message.Id, isValid, metric), context.CancellationToken);
+        _logger.LogInformation("Published SaveValidated for {EntityId} with audit {AuditId}", context.Message.Id, audit.Id);
     }
 }

--- a/Validation.Infrastructure/Messaging/SaveValidationConsumer.cs
+++ b/Validation.Infrastructure/Messaging/SaveValidationConsumer.cs
@@ -2,28 +2,47 @@ using MassTransit;
 using Validation.Domain.Events;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.Repositories;
+using Microsoft.Extensions.Logging;
+using System.Diagnostics;
 
 namespace Validation.Infrastructure.Messaging;
 
+/// <summary>
+/// Consumes <see cref="SaveRequested"/> messages and validates the payload.
+/// Logs metrics and validation result and starts an OpenTelemetry span for the
+/// operation to diagnose message flow and failures.
+/// </summary>
 public class SaveValidationConsumer<T> : IConsumer<SaveRequested>
 {
     private readonly IValidationPlanProvider _planProvider;
     private readonly ISaveAuditRepository _repository;
     private readonly SummarisationValidator _validator;
+    private readonly ILogger<SaveValidationConsumer<T>> _logger;
+    private readonly ActivitySource _activitySource;
 
-    public SaveValidationConsumer(IValidationPlanProvider planProvider, ISaveAuditRepository repository, SummarisationValidator validator)
+    public SaveValidationConsumer(IValidationPlanProvider planProvider, ISaveAuditRepository repository, SummarisationValidator validator, ILogger<SaveValidationConsumer<T>> logger, ActivitySource activitySource)
     {
         _planProvider = planProvider;
         _repository = repository;
         _validator = validator;
+        _logger = logger;
+        _activitySource = activitySource;
     }
 
+    /// <summary>
+    /// Handles the save request while emitting logs and a tracing span so that
+    /// message processing can be correlated across services.
+    /// </summary>
     public async Task Consume(ConsumeContext<SaveRequested> context)
     {
+        using var activity = _activitySource.StartActivity("SaveValidationConsumer.Consume");
         var last = await _repository.GetLastAsync(context.Message.Id, context.CancellationToken);
         var metric = new Random().Next(0, 100);
         var rules = _planProvider.GetRules<T>();
         var isValid = _validator.Validate(last?.Metric ?? 0m, metric, rules);
+
+        _logger.LogInformation("Validating entity {EntityId}. Previous {PreviousMetric} New {Metric} Result {Result}",
+            context.Message.Id, last?.Metric, metric, isValid);
 
         var audit = new SaveAudit
         {
@@ -35,5 +54,6 @@ public class SaveValidationConsumer<T> : IConsumer<SaveRequested>
 
         await _repository.AddAsync(audit, context.CancellationToken);
         await context.Publish(new SaveValidated<T>(context.Message.Id, audit.Id));
+        _logger.LogInformation("Published SaveValidated for {EntityId} with audit {AuditId}", context.Message.Id, audit.Id);
     }
 }

--- a/Validation.Tests/SavePipelineTests.cs
+++ b/Validation.Tests/SavePipelineTests.cs
@@ -6,6 +6,8 @@ using Validation.Domain.Validation;
 using Validation.Infrastructure.Messaging;
 using Validation.Infrastructure.Repositories;
 using Validation.Infrastructure;
+using Microsoft.Extensions.Logging;
+using System.Diagnostics;
 
 namespace Validation.Tests;
 
@@ -62,8 +64,8 @@ public class SavePipelineTests
     {
         var repo = new InMemorySaveAuditRepository();
         var harness = new InMemoryTestHarness();
-        harness.Consumer(() => new SaveValidationConsumer<Item>(new TestPlanProvider(), repo, new SummarisationValidator()));
-        harness.Consumer(() => new SaveCommitConsumer<Item>(repo));
+        harness.Consumer(() => new SaveValidationConsumer<Item>(new TestPlanProvider(), repo, new SummarisationValidator(), new LoggerFactory().CreateLogger<SaveValidationConsumer<Item>>(), new ActivitySource("pipeline")));
+        harness.Consumer(() => new SaveCommitConsumer<Item>(repo, new LoggerFactory().CreateLogger<SaveCommitConsumer<Item>>(), new ActivitySource("pipeline")));
 
         await harness.Start();
         try
@@ -84,8 +86,8 @@ public class SavePipelineTests
     {
         var repo = new FailingRepository();
         var harness = new InMemoryTestHarness();
-        harness.Consumer(() => new SaveValidationConsumer<Item>(new TestPlanProvider(), repo, new SummarisationValidator()));
-        harness.Consumer(() => new SaveCommitConsumer<Item>(repo));
+        harness.Consumer(() => new SaveValidationConsumer<Item>(new TestPlanProvider(), repo, new SummarisationValidator(), new LoggerFactory().CreateLogger<SaveValidationConsumer<Item>>(), new ActivitySource("pipeline")));
+        harness.Consumer(() => new SaveCommitConsumer<Item>(repo, new LoggerFactory().CreateLogger<SaveCommitConsumer<Item>>(), new ActivitySource("pipeline")));
 
         await harness.Start();
         try
@@ -105,7 +107,7 @@ public class SavePipelineTests
     {
         var repo = new InMemorySaveAuditRepository();
         var harness = new InMemoryTestHarness();
-        var validationConsumer = harness.Consumer(() => new SaveValidationConsumer<Item>(new TestPlanProvider(), repo, new SummarisationValidator()));
+        var validationConsumer = harness.Consumer(() => new SaveValidationConsumer<Item>(new TestPlanProvider(), repo, new SummarisationValidator(), new LoggerFactory().CreateLogger<SaveValidationConsumer<Item>>(), new ActivitySource("pipeline")));
 
         await harness.Start();
         try

--- a/Validation.Tests/SaveValidationConsumerTests.cs
+++ b/Validation.Tests/SaveValidationConsumerTests.cs
@@ -2,6 +2,9 @@ using MassTransit;
 using MassTransit.Testing;
 using Validation.Domain.Events;
 using Validation.Domain.Validation;
+using Serilog;
+using Microsoft.Extensions.Logging;
+using System.Diagnostics;
 using Validation.Infrastructure.Messaging;
 using Validation.Domain.Entities;
 
@@ -20,7 +23,22 @@ public class SaveValidationConsumerTests
     public async Task Publish_SaveValidated_after_processing()
     {
         var repository = new InMemorySaveAuditRepository();
-        var consumer = new SaveValidationConsumer<Item>(new TestPlanProvider(), repository, new SummarisationValidator());
+        var sink = new TestSink();
+        var serilogger = new LoggerConfiguration().WriteTo.Sink(sink).CreateLogger();
+        using var factory = LoggerFactory.Create(b => b.AddSerilog(serilogger));
+        var logger = factory.CreateLogger<SaveValidationConsumer<Item>>();
+        using var source = new ActivitySource("test-validation");
+        var activities = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = s => s.Name == "test-validation",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStarted = a => activities.Add(a),
+            ActivityStopped = _ => { }
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var consumer = new SaveValidationConsumer<Item>(new TestPlanProvider(), repository, new SummarisationValidator(), logger, source);
 
         var harness = new InMemoryTestHarness();
         harness.Consumer(() => consumer);
@@ -31,6 +49,8 @@ public class SaveValidationConsumerTests
             await harness.InputQueueSendEndpoint.Send(new SaveRequested(Guid.NewGuid()));
 
             Assert.True(await harness.Published.Any<SaveValidated<Item>>());
+            Assert.NotEmpty(sink.Events);
+            Assert.NotEmpty(activities);
         }
         finally
         {

--- a/Validation.Tests/TestSink.cs
+++ b/Validation.Tests/TestSink.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Validation.Tests;
+
+public class TestSink : ILogEventSink
+{
+    public List<LogEvent> Events { get; } = new();
+    public void Emit(LogEvent logEvent)
+    {
+        Events.Add(logEvent);
+    }
+}

--- a/Validation.Tests/Validation.Tests.csproj
+++ b/Validation.Tests/Validation.Tests.csproj
@@ -13,6 +13,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Validation.Tests/ValidationWorkflowTests.cs
+++ b/Validation.Tests/ValidationWorkflowTests.cs
@@ -3,6 +3,8 @@ using MassTransit.Testing;
 using Validation.Domain.Events;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.Messaging;
+using Microsoft.Extensions.Logging;
+using System.Diagnostics;
 
 namespace Validation.Tests;
 
@@ -13,7 +15,7 @@ public class ValidationWorkflowTests
     {
         var repository = new InMemorySaveAuditRepository();
         var rule = new RawDifferenceRule(100); // always valid
-        var consumer = new SaveRequestedConsumer(repository, rule);
+        var consumer = new SaveRequestedConsumer(repository, rule, new LoggerFactory().CreateLogger<SaveRequestedConsumer>(), new ActivitySource("workflow"));
 
         var harness = new InMemoryTestHarness();
         var consumerHarness = harness.Consumer(() => consumer);


### PR DESCRIPTION
## Summary
- inject ILogger and ActivitySource into consumers
- log validation and commit results
- create spans for each consume operation
- register ActivitySource in validation DI
- test logging and tracing in consumers

## Testing
- `dotnet test Validation.sln`

------
https://chatgpt.com/codex/tasks/task_e_688c23106200833092a329edd778f03b