### PR TITLE
Add Serilog and OpenTelemetry logging to consumers

### DIFF
--- a/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
+++ b/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using MongoDB.Driver;
 using OpenTelemetry.Trace;
+using System.Diagnostics;
 using Serilog;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.Messaging;
@@ -30,7 +31,12 @@ public static class ServiceCollectionExtensions
 
         services.AddLogging(loggingBuilder => loggingBuilder.AddSerilog());
 
-        services.AddOpenTelemetry().WithTracing(builder => builder.AddAspNetCoreInstrumentation());
+        services.AddSingleton(_ => new ActivitySource("Validation.Infrastructure"));
+
+        services.AddOpenTelemetry()
+            .WithTracing(builder => builder
+                .AddSource("Validation.Infrastructure")
+                .AddAspNetCoreInstrumentation());
 
         return services;
     }
@@ -51,7 +57,12 @@ public static class ServiceCollectionExtensions
 
         services.AddLogging(loggingBuilder => loggingBuilder.AddSerilog());
 
-        services.AddOpenTelemetry().WithTracing(builder => builder.AddAspNetCoreInstrumentation());
+        services.AddSingleton(_ => new ActivitySource("Validation.Infrastructure"));
+
+        services.AddOpenTelemetry()
+            .WithTracing(builder => builder
+                .AddSource("Validation.Infrastructure")
+                .AddAspNetCoreInstrumentation());
 
         return services;
     }
@@ -131,7 +142,13 @@ public static class ServiceCollectionExtensions
         });
 
         services.AddLogging(b => b.AddSerilog());
-        services.AddOpenTelemetry().WithTracing(b => b.AddAspNetCoreInstrumentation());
+
+        services.AddSingleton(_ => new ActivitySource("Validation.Infrastructure"));
+
+        services.AddOpenTelemetry()
+            .WithTracing(b => b
+                .AddSource("Validation.Infrastructure")
+                .AddAspNetCoreInstrumentation());
 
         return services;
     }
@@ -179,7 +196,13 @@ public static class ValidationFlowServiceCollectionExtensions
             x.UsingInMemory((context, cfg) => cfg.ConfigureEndpoints(context));
         });
         services.AddLogging(b => b.AddSerilog());
-        services.AddOpenTelemetry().WithTracing(b => b.AddAspNetCoreInstrumentation());
+
+        services.AddSingleton(_ => new ActivitySource("Validation.Infrastructure"));
+
+        services.AddOpenTelemetry()
+            .WithTracing(b => b
+                .AddSource("Validation.Infrastructure")
+                .AddAspNetCoreInstrumentation());
         var options = new ValidationFlowOptions(services);
         configure?.Invoke(options);
         return services;

--- a/Validation.Infrastructure/Messaging/DeleteValidationConsumer.cs
+++ b/Validation.Infrastructure/Messaging/DeleteValidationConsumer.cs
@@ -1,26 +1,42 @@
 using MassTransit;
+using Microsoft.Extensions.Logging;
+using System.Diagnostics;
 using Validation.Domain.Events;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.Repositories;
 
 namespace Validation.Infrastructure.Messaging;
 
+/// <summary>
+/// Validates delete operations and traces the consume flow for diagnostics.
+/// </summary>
 public class DeleteValidationConsumer<T> : IConsumer<DeleteRequested>
 {
     private readonly IValidationPlanProvider _planProvider;
     private readonly SummarisationValidator _validator;
+    private readonly ILogger<DeleteValidationConsumer<T>> _logger;
+    private readonly ActivitySource _activitySource;
 
-    public DeleteValidationConsumer(IValidationPlanProvider planProvider, SummarisationValidator validator)
+    public DeleteValidationConsumer(
+        IValidationPlanProvider planProvider,
+        SummarisationValidator validator,
+        ILogger<DeleteValidationConsumer<T>> logger,
+        ActivitySource activitySource)
     {
         _planProvider = planProvider;
         _validator = validator;
+        _logger = logger;
+        _activitySource = activitySource;
     }
 
     public Task Consume(ConsumeContext<DeleteRequested> context)
     {
+        using var activity = _activitySource.StartActivity("DeleteValidation.Consume");
+
         var rules = _planProvider.GetRules<T>();
         // execute manual rules with zero metrics since delete; actual logic omitted
         _validator.Validate(0, 0, rules);
+        _logger.LogInformation("Validated delete request for entity {EntityId}", context.Message.Id);
         return Task.CompletedTask;
     }
 }

--- a/Validation.Infrastructure/Messaging/SaveCommitConsumer.cs
+++ b/Validation.Infrastructure/Messaging/SaveCommitConsumer.cs
@@ -1,30 +1,46 @@
 using MassTransit;
+using Microsoft.Extensions.Logging;
+using System.Diagnostics;
 using Validation.Domain.Events;
 using Validation.Infrastructure.Repositories;
 
 namespace Validation.Infrastructure.Messaging;
 
+/// <summary>
+/// Commits validated save audits and logs the outcome. Each consume operation
+/// is traced using an <see cref="ActivitySource"/> to diagnose commit failures.
+/// </summary>
 public class SaveCommitConsumer<T> : IConsumer<SaveValidated<T>>
 {
     private readonly ISaveAuditRepository _repository;
+    private readonly ILogger<SaveCommitConsumer<T>> _logger;
+    private readonly ActivitySource _activitySource;
 
-    public SaveCommitConsumer(ISaveAuditRepository repository)
+    public SaveCommitConsumer(
+        ISaveAuditRepository repository,
+        ILogger<SaveCommitConsumer<T>> logger,
+        ActivitySource activitySource)
     {
         _repository = repository;
+        _logger = logger;
+        _activitySource = activitySource;
     }
 
     public async Task Consume(ConsumeContext<SaveValidated<T>> context)
     {
+        using var activity = _activitySource.StartActivity("SaveCommit.Consume");
         try
         {
             var audit = await _repository.GetAsync(context.Message.AuditId, context.CancellationToken);
             if (audit != null)
             {
                 await _repository.UpdateAsync(audit, context.CancellationToken);
+                _logger.LogInformation("Committed audit {AuditId} for entity {EntityId}", context.Message.AuditId, context.Message.EntityId);
             }
         }
         catch (Exception ex)
         {
+            _logger.LogWarning(ex, "Failed to commit audit {AuditId} for entity {EntityId}", context.Message.AuditId, context.Message.EntityId);
             await context.Publish(new SaveCommitFault<T>(context.Message.EntityId, context.Message.AuditId, ex.Message));
         }
     }

--- a/Validation.Infrastructure/Messaging/SaveRequestedConsumer.cs
+++ b/Validation.Infrastructure/Messaging/SaveRequestedConsumer.cs
@@ -1,4 +1,6 @@
 using MassTransit;
+using Microsoft.Extensions.Logging;
+using System.Diagnostics;
 using Validation.Domain.Events;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.Repositories;
@@ -6,22 +8,42 @@ using Validation.Infrastructure;
 
 namespace Validation.Infrastructure.Messaging;
 
+/// <summary>
+/// Processes save requests, logging the entity metrics and emitting a span for
+/// each request to trace validation outcomes.
+/// </summary>
 public class SaveRequestedConsumer : IConsumer<SaveRequested>
 {
     private readonly ISaveAuditRepository _repository;
     private readonly IValidationRule _rule;
     private decimal _previousMetric;
+    private readonly ILogger<SaveRequestedConsumer> _logger;
+    private readonly ActivitySource _activitySource;
 
-    public SaveRequestedConsumer(ISaveAuditRepository repository, IValidationRule rule)
+    public SaveRequestedConsumer(
+        ISaveAuditRepository repository,
+        IValidationRule rule,
+        ILogger<SaveRequestedConsumer> logger,
+        ActivitySource activitySource)
     {
         _repository = repository;
         _rule = rule;
+        _logger = logger;
+        _activitySource = activitySource;
     }
 
     public async Task Consume(ConsumeContext<SaveRequested> context)
     {
+        using var activity = _activitySource.StartActivity("SaveRequested.Consume");
+
         var metric = new Random().Next(0, 100); // simulate metric
         var isValid = _rule.Validate(_previousMetric, metric);
+        _logger.LogInformation(
+            "Processing SaveRequested {EntityId} previous {PrevMetric} new {Metric} valid {Valid}",
+            context.Message.Id,
+            _previousMetric,
+            metric,
+            isValid);
         _previousMetric = metric;
         var audit = new SaveAudit
         {

--- a/Validation.Infrastructure/Messaging/SaveValidationConsumer.cs
+++ b/Validation.Infrastructure/Messaging/SaveValidationConsumer.cs
@@ -1,29 +1,54 @@
 using MassTransit;
+using Microsoft.Extensions.Logging;
+using System.Diagnostics;
 using Validation.Domain.Events;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.Repositories;
 
 namespace Validation.Infrastructure.Messaging;
 
+/// <summary>
+/// Consumes <see cref="SaveRequested"/> events and logs the metrics and
+/// validation result. A span is created for each consume operation to aid
+/// tracing message flow failures.
+/// </summary>
 public class SaveValidationConsumer<T> : IConsumer<SaveRequested>
 {
     private readonly IValidationPlanProvider _planProvider;
     private readonly ISaveAuditRepository _repository;
     private readonly SummarisationValidator _validator;
+    private readonly ILogger<SaveValidationConsumer<T>> _logger;
+    private readonly ActivitySource _activitySource;
 
-    public SaveValidationConsumer(IValidationPlanProvider planProvider, ISaveAuditRepository repository, SummarisationValidator validator)
+    public SaveValidationConsumer(
+        IValidationPlanProvider planProvider,
+        ISaveAuditRepository repository,
+        SummarisationValidator validator,
+        ILogger<SaveValidationConsumer<T>> logger,
+        ActivitySource activitySource)
     {
         _planProvider = planProvider;
         _repository = repository;
         _validator = validator;
+        _logger = logger;
+        _activitySource = activitySource;
     }
 
     public async Task Consume(ConsumeContext<SaveRequested> context)
     {
+        using var activity = _activitySource.StartActivity("SaveValidation.Consume");
+
         var last = await _repository.GetLastAsync(context.Message.Id, context.CancellationToken);
         var metric = new Random().Next(0, 100);
         var rules = _planProvider.GetRules<T>();
         var isValid = _validator.Validate(last?.Metric ?? 0m, metric, rules);
+
+        _logger.LogInformation(
+            "Validating {EntityId} previous {PreviousMetric} new {Metric} valid {Valid}",
+            context.Message.Id,
+            last?.Metric,
+            metric,
+            isValid);
 
         var audit = new SaveAudit
         {

--- a/Validation.Tests/SaveCommitConsumerTests.cs
+++ b/Validation.Tests/SaveCommitConsumerTests.cs
@@ -5,6 +5,8 @@ using Validation.Infrastructure.Messaging;
 using Validation.Infrastructure;
 using Validation.Infrastructure.Repositories;
 using Validation.Domain.Entities;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Diagnostics;
 
 namespace Validation.Tests;
 
@@ -23,7 +25,9 @@ public class SaveCommitConsumerTests
     public async Task Publish_SaveCommitFault_on_error()
     {
         var repo = new FailingRepository();
-        var consumer = new SaveCommitConsumer<Item>(repo);
+        var consumer = new SaveCommitConsumer<Item>(repo,
+            NullLogger<SaveCommitConsumer<Item>>.Instance,
+            new ActivitySource("test"));
 
         var harness = new InMemoryTestHarness();
         harness.Consumer(() => consumer);

--- a/Validation.Tests/SavePipelineTests.cs
+++ b/Validation.Tests/SavePipelineTests.cs
@@ -6,6 +6,8 @@ using Validation.Domain.Validation;
 using Validation.Infrastructure.Messaging;
 using Validation.Infrastructure.Repositories;
 using Validation.Infrastructure;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Diagnostics;
 
 namespace Validation.Tests;
 
@@ -62,8 +64,15 @@ public class SavePipelineTests
     {
         var repo = new InMemorySaveAuditRepository();
         var harness = new InMemoryTestHarness();
-        harness.Consumer(() => new SaveValidationConsumer<Item>(new TestPlanProvider(), repo, new SummarisationValidator()));
-        harness.Consumer(() => new SaveCommitConsumer<Item>(repo));
+        harness.Consumer(() => new SaveValidationConsumer<Item>(
+            new TestPlanProvider(),
+            repo,
+            new SummarisationValidator(),
+            NullLogger<SaveValidationConsumer<Item>>.Instance,
+            new ActivitySource("test")));
+        harness.Consumer(() => new SaveCommitConsumer<Item>(repo,
+            NullLogger<SaveCommitConsumer<Item>>.Instance,
+            new ActivitySource("test")));
 
         await harness.Start();
         try
@@ -84,8 +93,15 @@ public class SavePipelineTests
     {
         var repo = new FailingRepository();
         var harness = new InMemoryTestHarness();
-        harness.Consumer(() => new SaveValidationConsumer<Item>(new TestPlanProvider(), repo, new SummarisationValidator()));
-        harness.Consumer(() => new SaveCommitConsumer<Item>(repo));
+        harness.Consumer(() => new SaveValidationConsumer<Item>(
+            new TestPlanProvider(),
+            repo,
+            new SummarisationValidator(),
+            NullLogger<SaveValidationConsumer<Item>>.Instance,
+            new ActivitySource("test")));
+        harness.Consumer(() => new SaveCommitConsumer<Item>(repo,
+            NullLogger<SaveCommitConsumer<Item>>.Instance,
+            new ActivitySource("test")));
 
         await harness.Start();
         try
@@ -105,7 +121,12 @@ public class SavePipelineTests
     {
         var repo = new InMemorySaveAuditRepository();
         var harness = new InMemoryTestHarness();
-        var validationConsumer = harness.Consumer(() => new SaveValidationConsumer<Item>(new TestPlanProvider(), repo, new SummarisationValidator()));
+        var validationConsumer = harness.Consumer(() => new SaveValidationConsumer<Item>(
+            new TestPlanProvider(),
+            repo,
+            new SummarisationValidator(),
+            NullLogger<SaveValidationConsumer<Item>>.Instance,
+            new ActivitySource("test")));
 
         await harness.Start();
         try

--- a/Validation.Tests/SaveValidationConsumerTests.cs
+++ b/Validation.Tests/SaveValidationConsumerTests.cs
@@ -4,6 +4,8 @@ using Validation.Domain.Events;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.Messaging;
 using Validation.Domain.Entities;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Diagnostics;
 
 namespace Validation.Tests;
 
@@ -20,7 +22,12 @@ public class SaveValidationConsumerTests
     public async Task Publish_SaveValidated_after_processing()
     {
         var repository = new InMemorySaveAuditRepository();
-        var consumer = new SaveValidationConsumer<Item>(new TestPlanProvider(), repository, new SummarisationValidator());
+        var consumer = new SaveValidationConsumer<Item>(
+            new TestPlanProvider(),
+            repository,
+            new SummarisationValidator(),
+            NullLogger<SaveValidationConsumer<Item>>.Instance,
+            new ActivitySource("test"));
 
         var harness = new InMemoryTestHarness();
         harness.Consumer(() => consumer);

--- a/Validation.Tests/ValidationWorkflowTests.cs
+++ b/Validation.Tests/ValidationWorkflowTests.cs
@@ -3,6 +3,8 @@ using MassTransit.Testing;
 using Validation.Domain.Events;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.Messaging;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Diagnostics;
 
 namespace Validation.Tests;
 
@@ -13,7 +15,11 @@ public class ValidationWorkflowTests
     {
         var repository = new InMemorySaveAuditRepository();
         var rule = new RawDifferenceRule(100); // always valid
-        var consumer = new SaveRequestedConsumer(repository, rule);
+        var consumer = new SaveRequestedConsumer(
+            repository,
+            rule,
+            NullLogger<SaveRequestedConsumer>.Instance,
+            new ActivitySource("test"));
 
         var harness = new InMemoryTestHarness();
         var consumerHarness = harness.Consumer(() => consumer);


### PR DESCRIPTION
## Summary
- inject `ILogger` and `ActivitySource` into message consumers
- log validation metrics, commit status and delete requests
- create OpenTelemetry spans for each consume method
- register `ActivitySource` in the validation infrastructure
- adjust unit tests for new constructors

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688c23106200833092a329edd778f03b