### PR TITLE
Add delete pipeline reliability features

### DIFF
--- a/Validation.Domain/Events/DeleteCommitFault.cs
+++ b/Validation.Domain/Events/DeleteCommitFault.cs
@@ -1,0 +1,3 @@
+namespace Validation.Domain.Events;
+
+public record DeleteCommitFault<T>(Guid EntityId, string Error);

--- a/Validation.Domain/Events/DeleteValidated.Generic.cs
+++ b/Validation.Domain/Events/DeleteValidated.Generic.cs
@@ -1,0 +1,3 @@
+namespace Validation.Domain.Events;
+
+public record DeleteValidated<T>(Guid EntityId);

--- a/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
+++ b/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
@@ -26,6 +26,13 @@ public static class ServiceCollectionExtensions
         services.AddMassTransit(x =>
         {
             configureBus?.Invoke(x);
+            x.UsingInMemory((context, cfg) =>
+            {
+                cfg.UseMessageRetry(r => r.Interval(3, TimeSpan.FromSeconds(1)));
+                cfg.UseInMemoryOutbox();
+                cfg.ReceiveEndpoint("delete_requests_queue_error", _ => { });
+                cfg.ConfigureEndpoints(context);
+            });
         });
 
         services.AddLogging(loggingBuilder => loggingBuilder.AddSerilog());

--- a/Validation.Infrastructure/Messaging/DeleteCommitConsumer.cs
+++ b/Validation.Infrastructure/Messaging/DeleteCommitConsumer.cs
@@ -1,0 +1,31 @@
+using MassTransit;
+using Validation.Domain.Events;
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Infrastructure.Messaging;
+
+/// <summary>
+/// Consumes <see cref="DeleteValidated{T}"/> events and removes the associated audit record.
+/// Publishes <see cref="DeleteCommitFault{T}"/> if the repository throws.
+/// </summary>
+public class DeleteCommitConsumer<T> : IConsumer<DeleteValidated<T>>
+{
+    private readonly ISaveAuditRepository _repository;
+
+    public DeleteCommitConsumer(ISaveAuditRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task Consume(ConsumeContext<DeleteValidated<T>> context)
+    {
+        try
+        {
+            await _repository.DeleteAsync(context.Message.EntityId, context.CancellationToken);
+        }
+        catch (Exception ex)
+        {
+            await context.Publish(new DeleteCommitFault<T>(context.Message.EntityId, ex.Message));
+        }
+    }
+}

--- a/Validation.Infrastructure/Messaging/DeleteValidationConsumer.cs
+++ b/Validation.Infrastructure/Messaging/DeleteValidationConsumer.cs
@@ -5,6 +5,9 @@ using Validation.Infrastructure.Repositories;
 
 namespace Validation.Infrastructure.Messaging;
 
+/// <summary>
+/// Validates delete requests and publishes a <see cref="DeleteValidated{T}"/> event when successful.
+/// </summary>
 public class DeleteValidationConsumer<T> : IConsumer<DeleteRequested>
 {
     private readonly IValidationPlanProvider _planProvider;
@@ -16,11 +19,11 @@ public class DeleteValidationConsumer<T> : IConsumer<DeleteRequested>
         _validator = validator;
     }
 
-    public Task Consume(ConsumeContext<DeleteRequested> context)
+    public async Task Consume(ConsumeContext<DeleteRequested> context)
     {
         var rules = _planProvider.GetRules<T>();
         // execute manual rules with zero metrics since delete; actual logic omitted
         _validator.Validate(0, 0, rules);
-        return Task.CompletedTask;
+        await context.Publish(new DeleteValidated<T>(context.Message.Id));
     }
 }

--- a/Validation.Tests/DeleteCommitConsumerTests.cs
+++ b/Validation.Tests/DeleteCommitConsumerTests.cs
@@ -1,0 +1,43 @@
+using MassTransit;
+using MassTransit.Testing;
+using Validation.Domain.Events;
+using Validation.Infrastructure.Messaging;
+using Validation.Infrastructure.Repositories;
+using Validation.Infrastructure;
+using Validation.Domain.Entities;
+
+namespace Validation.Tests;
+
+public class DeleteCommitConsumerTests
+{
+    private class FailingRepository : ISaveAuditRepository
+    {
+        public Task AddAsync(SaveAudit entity, CancellationToken ct = default) => Task.CompletedTask;
+        public Task DeleteAsync(Guid id, CancellationToken ct = default) => throw new Exception("fail");
+        public Task<SaveAudit?> GetAsync(Guid id, CancellationToken ct = default) => Task.FromResult<SaveAudit?>(new SaveAudit { Id = id, EntityId = id });
+        public Task UpdateAsync(SaveAudit entity, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<SaveAudit?> GetLastAsync(Guid entityId, CancellationToken ct = default) => Task.FromResult<SaveAudit?>(null);
+    }
+
+    [Fact]
+    public async Task Publish_DeleteCommitFault_on_error()
+    {
+        var repo = new FailingRepository();
+        var consumer = new DeleteCommitConsumer<Item>(repo);
+
+        var harness = new InMemoryTestHarness();
+        harness.Consumer(() => consumer);
+
+        await harness.Start();
+        try
+        {
+            await harness.InputQueueSendEndpoint.Send(new DeleteValidated<Item>(Guid.NewGuid()));
+
+            Assert.True(await harness.Published.Any<DeleteCommitFault<Item>>());
+        }
+        finally
+        {
+            await harness.Stop();
+        }
+    }
+}

--- a/Validation.Tests/DeleteValidationConsumerTests.cs
+++ b/Validation.Tests/DeleteValidationConsumerTests.cs
@@ -1,0 +1,40 @@
+using MassTransit;
+using MassTransit.Testing;
+using Validation.Domain.Events;
+using Validation.Domain.Validation;
+using Validation.Infrastructure.Messaging;
+using Validation.Infrastructure.Repositories;
+using Validation.Domain.Entities;
+
+namespace Validation.Tests;
+
+public class DeleteValidationConsumerTests
+{
+    private class TestPlanProvider : IValidationPlanProvider
+    {
+        public IEnumerable<IValidationRule> GetRules<T>() => Array.Empty<IValidationRule>();
+        public ValidationPlan GetPlan(Type t) => new ValidationPlan(new[] { new RawDifferenceRule(100) });
+        public void AddPlan<T>(ValidationPlan plan) { }
+    }
+
+    [Fact]
+    public async Task Publish_DeleteValidated_after_processing()
+    {
+        var consumer = new DeleteValidationConsumer<Item>(new TestPlanProvider(), new SummarisationValidator());
+
+        var harness = new InMemoryTestHarness();
+        harness.Consumer(() => consumer);
+
+        await harness.Start();
+        try
+        {
+            await harness.InputQueueSendEndpoint.Send(new DeleteRequested(Guid.NewGuid()));
+
+            Assert.True(await harness.Published.Any<DeleteValidated<Item>>());
+        }
+        finally
+        {
+            await harness.Stop();
+        }
+    }
+}

--- a/ValidationFlow.Messages/SaveMessages.cs
+++ b/ValidationFlow.Messages/SaveMessages.cs
@@ -30,3 +30,9 @@ public sealed record DeleteRequested<T>(string AppName, string EntityType, Guid 
 /// </summary>
 [Serializable]
 public sealed record DeleteValidated<T>(string AppName, string EntityType, Guid EntityId);
+
+/// <summary>
+/// Notification that committing a delete request failed.
+/// </summary>
+[Serializable]
+public sealed record DeleteCommitFault<T>(string AppName, string EntityType, Guid EntityId, string ErrorMessage);


### PR DESCRIPTION
## Summary
- publish `DeleteValidated<T>` after delete validation
- add `DeleteCommitConsumer` and fault event
- retry delete endpoints and add dead-letter queue
- test delete validation and commit flows

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688c232076a483308f12658dc3edda87