### PR TITLE
Add SetupValidation support and tests

### DIFF
--- a/Validation.Infrastructure/DI/SetupValidationBuilder.cs
+++ b/Validation.Infrastructure/DI/SetupValidationBuilder.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Driver;
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Infrastructure.DI;
+
+public class SetupValidationBuilder
+{
+    public IServiceCollection Services { get; }
+
+    public SetupValidationBuilder(IServiceCollection services)
+    {
+        Services = services;
+    }
+
+    public IServiceCollection SetupDatabase<TContext>(string connectionString) where TContext : DbContext
+    {
+        Services.AddDbContext<TContext>(o => o.UseInMemoryDatabase(connectionString));
+        Services.AddScoped<DbContext>(sp => sp.GetRequiredService<TContext>());
+        Services.AddScoped<ISaveAuditRepository, EfCoreSaveAuditRepository>();
+        return Services;
+    }
+
+    public IServiceCollection SetupMongoDatabase(string connectionString, string dbName)
+    {
+        var client = new MongoClient(connectionString);
+        var database = client.GetDatabase(dbName);
+        Services.AddSingleton(database);
+        Services.AddScoped<ISaveAuditRepository, MongoSaveAuditRepository>();
+        return Services;
+    }
+}

--- a/Validation.Infrastructure/EnhancedManualValidatorService.cs
+++ b/Validation.Infrastructure/EnhancedManualValidatorService.cs
@@ -150,6 +150,7 @@ public class EnhancedManualValidatorService : IEnhancedManualValidatorService
                             _logger.LogError(ex, "Error executing named rule {RuleName} for type {Type}",
                                 kvp.Key, type.Name);
                             result.IsValid = false;
+                            result.FailedRules.Add(kvp.Key);
                             result.Errors.Add($"Rule '{kvp.Key}' execution failed: {ex.Message}");
                         }
                     }
@@ -177,6 +178,7 @@ public class EnhancedManualValidatorService : IEnhancedManualValidatorService
                             _logger.LogError(ex, "Error executing anonymous rule {Index} for type {Type}",
                                 i, type.Name);
                             result.IsValid = false;
+                            result.FailedRules.Add($"Anonymous rule {i}");
                             result.Errors.Add($"Anonymous rule {i} execution failed: {ex.Message}");
                         }
                     }

--- a/Validation.Tests/AddSetupValidationTests.cs
+++ b/Validation.Tests/AddSetupValidationTests.cs
@@ -1,0 +1,35 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.EntityFrameworkCore;
+using Validation.Domain.Entities;
+using Validation.Domain.Validation;
+using Validation.Infrastructure.DI;
+using Validation.Infrastructure.Messaging;
+
+namespace Validation.Tests;
+
+public class AddSetupValidationTests
+{
+    [Fact]
+    public void AddSetupValidation_registers_plan_and_consumers()
+    {
+        var services = new ServiceCollection();
+
+        services.AddSetupValidation<Item>(
+            opts => opts.SetupDatabase<TestDbContext>("setupvalidation") ,
+            i => i.Metric,
+            ThresholdType.RawDifference,
+            5m);
+
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+
+        var planProvider = scope.ServiceProvider.GetRequiredService<IValidationPlanProvider>();
+        var plan = planProvider.GetPlan(typeof(Item));
+
+        Assert.Equal(ThresholdType.RawDifference, plan.ThresholdType);
+        Assert.Equal(5m, plan.ThresholdValue);
+
+        Assert.NotNull(scope.ServiceProvider.GetService<SaveValidationConsumer<Item>>());
+        Assert.NotNull(scope.ServiceProvider.GetService<SaveCommitConsumer<Item>>());
+    }
+}


### PR DESCRIPTION
## Summary
- implement `SetupValidationBuilder` for configuring databases
- add `AddSetupValidation<T>` extension method
- enhance manual validator error reporting
- fix reliability policy retry logic
- test AddSetupValidation functionality

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_688c7fdb7608833088eeb53fb798a892