### PR TITLE
Add SetupValidation builder and registration helper

### DIFF
--- a/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
+++ b/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
@@ -107,6 +107,44 @@ public static class ServiceCollectionExtensions
         return services;
     }
 
+    public static IServiceCollection SetupValidation(this IServiceCollection services, Action<SetupValidationBuilder> configure)
+    {
+        var builder = new SetupValidationBuilder(services);
+        configure(builder);
+        return services;
+    }
+
+    public static IServiceCollection AddSetupValidation<T>(
+        this IServiceCollection services,
+        Action<SetupValidationBuilder> configure,
+        Func<T, decimal> metricSelector,
+        ThresholdType thresholdType,
+        decimal thresholdValue)
+    {
+        services.SetupValidation(configure);
+
+        var provider = new InMemoryValidationPlanProvider();
+        provider.AddPlan<T>(new ValidationPlan(o => metricSelector((T)o), thresholdType, thresholdValue));
+        services.AddSingleton<IValidationPlanProvider>(provider);
+
+        services.AddSingleton<IManualValidatorService, ManualValidatorService>();
+        services.AddScoped<SummarisationValidator>();
+
+        services.AddMassTransitTestHarness(x =>
+        {
+            x.AddConsumer<SaveValidationConsumer<T>>();
+            x.AddConsumer<SaveCommitConsumer<T>>();
+            x.UsingInMemory((context, cfg) => cfg.ConfigureEndpoints(context));
+        });
+        services.AddScoped<SaveValidationConsumer<T>>();
+        services.AddScoped<SaveCommitConsumer<T>>();
+
+        services.AddLogging(b => b.AddSerilog());
+        services.AddOpenTelemetry().WithTracing(b => b.AddAspNetCoreInstrumentation());
+
+        return services;
+    }
+
     public static IServiceCollection AddValidationFlows(this IServiceCollection services, IEnumerable<ValidationFlowConfig> configs)
     {
         // Set up validation plan provider with configurations

--- a/Validation.Infrastructure/DI/SetupValidationBuilder.cs
+++ b/Validation.Infrastructure/DI/SetupValidationBuilder.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Driver;
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Infrastructure.DI;
+
+public class SetupValidationBuilder
+{
+    public IServiceCollection Services { get; }
+
+    public SetupValidationBuilder(IServiceCollection services)
+    {
+        Services = services;
+    }
+
+    public IServiceCollection SetupDatabase<TContext>(string connectionString) where TContext : DbContext
+    {
+        Services.AddDbContext<TContext>(o => o.UseInMemoryDatabase(connectionString));
+        Services.AddScoped<DbContext>(sp => sp.GetRequiredService<TContext>());
+        Services.AddScoped<ISaveAuditRepository, EfCoreSaveAuditRepository>();
+        return Services;
+    }
+
+    public IServiceCollection SetupMongoDatabase(string connectionString, string dbName)
+    {
+        var client = new MongoClient(connectionString);
+        var database = client.GetDatabase(dbName);
+        Services.AddSingleton(database);
+        Services.AddScoped<ISaveAuditRepository, MongoSaveAuditRepository>();
+        return Services;
+    }
+}

--- a/Validation.Infrastructure/EnhancedManualValidatorService.cs
+++ b/Validation.Infrastructure/EnhancedManualValidatorService.cs
@@ -150,6 +150,7 @@ public class EnhancedManualValidatorService : IEnhancedManualValidatorService
                             _logger.LogError(ex, "Error executing named rule {RuleName} for type {Type}",
                                 kvp.Key, type.Name);
                             result.IsValid = false;
+                            result.FailedRules.Add(kvp.Key);
                             result.Errors.Add($"Rule '{kvp.Key}' execution failed: {ex.Message}");
                         }
                     }
@@ -177,6 +178,7 @@ public class EnhancedManualValidatorService : IEnhancedManualValidatorService
                             _logger.LogError(ex, "Error executing anonymous rule {Index} for type {Type}",
                                 i, type.Name);
                             result.IsValid = false;
+                            result.FailedRules.Add($"Anonymous rule {i}");
                             result.Errors.Add($"Anonymous rule {i} execution failed: {ex.Message}");
                         }
                     }

--- a/Validation.Infrastructure/Reliability/DeletePipelineReliabilityPolicy.cs
+++ b/Validation.Infrastructure/Reliability/DeletePipelineReliabilityPolicy.cs
@@ -38,46 +38,40 @@ public class DeletePipelineReliabilityPolicy
             try
             {
                 _logger.LogDebug("Executing delete pipeline operation. Attempt {Attempt}", attempts + 1);
-                
+
                 var result = await operation(cancellationToken);
-                
+
                 // Reset failure count on success
                 Interlocked.Exchange(ref _consecutiveFailures, 0);
                 _logger.LogDebug("Delete pipeline operation completed successfully");
-                
+
                 return result;
             }
             catch (Exception ex)
             {
                 lastException = ex;
-                attempts++;
-                
-                if (ShouldRetry(ex, attempts - 1))
+
+                if (!ShouldRetry(ex))
                 {
                     Interlocked.Increment(ref _consecutiveFailures);
                     _lastFailureTime = DateTime.UtcNow;
-
-                    _logger.LogWarning(ex, 
-                        "Delete pipeline operation failed. Attempt {Attempt} of {MaxAttempts}. Retrying in {DelayMs}ms",
-                        attempts, _options.MaxRetryAttempts, _options.RetryDelayMs);
-
-                    if (attempts < _options.MaxRetryAttempts)
-                    {
-                        await Task.Delay(_options.RetryDelayMs, cancellationToken);
-                        continue;
-                    }
-                    else
-                    {
-                        // Retryable exception but retries exhausted - this will be wrapped below
-                        break;
-                    }
-                }
-                else
-                {
-                    // Non-retryable exception - rethrow immediately
                     _logger.LogError(ex, "Delete pipeline operation failed with non-retryable exception");
                     throw;
                 }
+
+                attempts++;
+                _logger.LogWarning(ex,
+                    "Delete pipeline operation failed. Attempt {Attempt} of {MaxAttempts}. Retrying in {DelayMs}ms",
+                    attempts, _options.MaxRetryAttempts, _options.RetryDelayMs);
+
+                if (attempts == _options.MaxRetryAttempts)
+                {
+                    Interlocked.Increment(ref _consecutiveFailures);
+                    _lastFailureTime = DateTime.UtcNow;
+                    break;
+                }
+
+                await Task.Delay(_options.RetryDelayMs, cancellationToken);
             }
         }
 
@@ -99,11 +93,8 @@ public class DeletePipelineReliabilityPolicy
         }, cancellationToken);
     }
 
-    private bool ShouldRetry(Exception exception, int attempt)
+    private bool ShouldRetry(Exception exception)
     {
-        if (attempt >= _options.MaxRetryAttempts - 1)
-            return false;
-
         // Don't retry on certain exception types
         if (exception is ArgumentException or ArgumentNullException)
             return false;

--- a/Validation.Tests/AddSetupValidationTests.cs
+++ b/Validation.Tests/AddSetupValidationTests.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.EntityFrameworkCore;
+using Validation.Domain.Entities;
+using Validation.Domain.Validation;
+using Validation.Infrastructure.DI;
+using Validation.Infrastructure.Messaging;
+
+namespace Validation.Tests;
+
+public class AddSetupValidationTests
+{
+    [Fact]
+    public void AddSetupValidation_registers_plan_and_consumers()
+    {
+        var services = new ServiceCollection();
+        services.AddSetupValidation<Item>(
+            b => b.SetupDatabase<TestDbContext>("setupvalidation"),
+            i => i.Metric,
+            ThresholdType.RawDifference,
+            5m);
+
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+
+        Assert.NotNull(scope.ServiceProvider.GetService<SaveValidationConsumer<Item>>());
+        Assert.NotNull(scope.ServiceProvider.GetService<SaveCommitConsumer<Item>>());
+
+        var planProvider = scope.ServiceProvider.GetRequiredService<IValidationPlanProvider>();
+        var plan = planProvider.GetPlan(typeof(Item));
+        Assert.Equal(ThresholdType.RawDifference, plan.ThresholdType);
+        Assert.Equal(5m, plan.ThresholdValue);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `SetupValidationBuilder` for configuring database
- add `AddSetupValidation` extension to register summarisation plan and consumers
- enhance error handling in `EnhancedManualValidatorService`
- fix reliability policy logic
- test new `AddSetupValidation` helper

## Testing
- `dotnet vstest Validation.Tests/bin/Debug/net8.0/Validation.Tests.dll --logger:"console;verbosity=quiet"`

------
https://chatgpt.com/codex/tasks/task_e_688c7fdb7608833088eeb53fb798a892