### PR TITLE
Add explicit commit consumer registration

### DIFF
--- a/Validation.Domain/Events/DeleteCommitFault.cs
+++ b/Validation.Domain/Events/DeleteCommitFault.cs
@@ -1,0 +1,3 @@
+namespace Validation.Domain.Events;
+
+public record DeleteCommitFault<T>(Guid EntityId, Guid AuditId, string Error);

--- a/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
+++ b/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
@@ -107,6 +107,26 @@ public static class ServiceCollectionExtensions
         return services;
     }
 
+    public static IServiceCollection AddSaveCommit<T>(this IServiceCollection services)
+    {
+        services.AddScoped<SaveCommitConsumer<T>>();
+        services.AddMassTransit(x =>
+        {
+            x.AddConsumer<SaveCommitConsumer<T>>();
+        });
+        return services;
+    }
+
+    public static IServiceCollection AddDeleteCommit<T>(this IServiceCollection services)
+    {
+        services.AddScoped<DeleteCommitConsumer<T>>();
+        services.AddMassTransit(x =>
+        {
+            x.AddConsumer<DeleteCommitConsumer<T>>();
+        });
+        return services;
+    }
+
     public static IServiceCollection AddValidationFlows(this IServiceCollection services, IEnumerable<ValidationFlowConfig> configs)
     {
         // Set up validation plan provider with configurations

--- a/Validation.Infrastructure/Messaging/DeleteCommitConsumer.cs
+++ b/Validation.Infrastructure/Messaging/DeleteCommitConsumer.cs
@@ -1,0 +1,27 @@
+using MassTransit;
+using Validation.Domain.Events;
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Infrastructure.Messaging;
+
+public class DeleteCommitConsumer<T> : IConsumer<DeleteValidated>
+{
+    private readonly ISaveAuditRepository _repository;
+
+    public DeleteCommitConsumer(ISaveAuditRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task Consume(ConsumeContext<DeleteValidated> context)
+    {
+        try
+        {
+            await _repository.DeleteAsync(context.Message.AuditId, context.CancellationToken);
+        }
+        catch (Exception ex)
+        {
+            await context.Publish(new DeleteCommitFault<T>(context.Message.EntityId, context.Message.AuditId, ex.Message));
+        }
+    }
+}

--- a/Validation.Tests/DeleteCommitConsumerTests.cs
+++ b/Validation.Tests/DeleteCommitConsumerTests.cs
@@ -1,0 +1,42 @@
+using MassTransit;
+using MassTransit.Testing;
+using Validation.Domain.Events;
+using Validation.Infrastructure.Messaging;
+using Validation.Infrastructure.Repositories;
+using Validation.Domain.Entities;
+
+namespace Validation.Tests;
+
+public class DeleteCommitConsumerTests
+{
+    private class FailingRepository : ISaveAuditRepository
+    {
+        public Task AddAsync(SaveAudit entity, CancellationToken ct = default) => Task.CompletedTask;
+        public Task DeleteAsync(Guid id, CancellationToken ct = default) => throw new Exception("fail");
+        public Task<SaveAudit?> GetAsync(Guid id, CancellationToken ct = default) => Task.FromResult<SaveAudit?>(new SaveAudit { Id = id, EntityId = id });
+        public Task UpdateAsync(SaveAudit entity, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<SaveAudit?> GetLastAsync(Guid entityId, CancellationToken ct = default) => Task.FromResult<SaveAudit?>(null);
+    }
+
+    [Fact]
+    public async Task Publish_DeleteCommitFault_on_error()
+    {
+        var repo = new FailingRepository();
+        var consumer = new DeleteCommitConsumer<Item>(repo);
+
+        var harness = new InMemoryTestHarness();
+        harness.Consumer(() => consumer);
+
+        await harness.Start();
+        try
+        {
+            await harness.InputQueueSendEndpoint.Send(new DeleteValidated(Guid.NewGuid(), Guid.NewGuid(), typeof(Item).Name));
+
+            Assert.True(await harness.Published.Any<DeleteCommitFault<Item>>());
+        }
+        finally
+        {
+            await harness.Stop();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement DeleteCommitConsumer and related fault event
- add AddSaveCommit and AddDeleteCommit DI extensions
- test failure path for DeleteCommitConsumer

## Testing
- `dotnet test --no-build` *(fails: You must install or update .NET to run this application)*

------
https://chatgpt.com/codex/tasks/task_e_688c800d14288330b7334fa91269919b