### PR TITLE
Implement metrics pipeline orchestrator

### DIFF
--- a/Validation.Infrastructure/EnhancedManualValidatorService.cs
+++ b/Validation.Infrastructure/EnhancedManualValidatorService.cs
@@ -150,6 +150,7 @@ public class EnhancedManualValidatorService : IEnhancedManualValidatorService
                             _logger.LogError(ex, "Error executing named rule {RuleName} for type {Type}",
                                 kvp.Key, type.Name);
                             result.IsValid = false;
+                            result.FailedRules.Add(kvp.Key);
                             result.Errors.Add($"Rule '{kvp.Key}' execution failed: {ex.Message}");
                         }
                     }

--- a/Validation.Infrastructure/Pipeline/GatherServices.cs
+++ b/Validation.Infrastructure/Pipeline/GatherServices.cs
@@ -1,0 +1,28 @@
+using System.Net.Http;
+using System.Text.Json;
+
+namespace Validation.Infrastructure.Pipeline;
+
+public class InMemoryGatherService : IGatherService
+{
+    private readonly IEnumerable<object> _items;
+    public InMemoryGatherService(IEnumerable<object> items) => _items = items;
+    public Task<IEnumerable<T>> GatherAsync<T>(CancellationToken ct = default)
+        => Task.FromResult(_items.Cast<T>());
+}
+
+public class HttpGatherService : IGatherService
+{
+    private readonly HttpClient _client;
+    private readonly Uri _uri;
+    public HttpGatherService(HttpClient client, Uri uri)
+    {
+        _client = client;
+        _uri = uri;
+    }
+    public async Task<IEnumerable<T>> GatherAsync<T>(CancellationToken ct = default)
+    {
+        var json = await _client.GetStringAsync(_uri, ct);
+        return JsonSerializer.Deserialize<IEnumerable<T>>(json) ?? Array.Empty<T>();
+    }
+}

--- a/Validation.Infrastructure/Pipeline/PipelineInterfaces.cs
+++ b/Validation.Infrastructure/Pipeline/PipelineInterfaces.cs
@@ -1,0 +1,23 @@
+namespace Validation.Infrastructure.Pipeline;
+
+public interface IGatherService
+{
+    Task<IEnumerable<T>> GatherAsync<T>(CancellationToken ct = default);
+}
+
+public interface ISummarisationService
+{
+    Task<T> SummariseAsync<T>(IEnumerable<T> items, CancellationToken ct = default);
+}
+
+public interface IValidationService
+{
+    Task<bool> ValidateAsync<T>(T summary, CancellationToken ct = default);
+}
+
+public interface ICommitService
+{
+    Task CommitAsync<T>(T summary, CancellationToken ct = default);
+}
+
+public record PipelineDiscardedEvent(Type ItemType, object? Summary);

--- a/Validation.Infrastructure/Pipeline/PipelineOrchestrator.cs
+++ b/Validation.Infrastructure/Pipeline/PipelineOrchestrator.cs
@@ -1,0 +1,46 @@
+using Microsoft.Extensions.Logging;
+
+namespace Validation.Infrastructure.Pipeline;
+
+public class PipelineOrchestrator
+{
+    private readonly IGatherService _gather;
+    private readonly ISummarisationService _summarise;
+    private readonly IValidationService _validate;
+    private readonly ICommitService _commit;
+    private readonly ILogger<PipelineOrchestrator> _logger;
+
+    public event EventHandler<PipelineDiscardedEvent>? Discarded;
+
+    public PipelineOrchestrator(
+        IGatherService gather,
+        ISummarisationService summarise,
+        IValidationService validate,
+        ICommitService commit,
+        ILogger<PipelineOrchestrator>? logger = null)
+    {
+        _gather = gather;
+        _summarise = summarise;
+        _validate = validate;
+        _commit = commit;
+        _logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<PipelineOrchestrator>.Instance;
+    }
+
+    public async Task ExecuteAsync<T>(CancellationToken ct = default)
+    {
+        var data = await _gather.GatherAsync<T>(ct);
+        var summary = await _summarise.SummariseAsync(data, ct);
+        var valid = await _validate.ValidateAsync(summary, ct);
+
+        if (valid)
+        {
+            await _commit.CommitAsync(summary, ct);
+            _logger.LogInformation("Committed summary for {Type}", typeof(T).Name);
+        }
+        else
+        {
+            _logger.LogInformation("Discarding summary for {Type}", typeof(T).Name);
+            Discarded?.Invoke(this, new PipelineDiscardedEvent(typeof(T), summary));
+        }
+    }
+}

--- a/Validation.Infrastructure/Pipeline/PipelineWorker.cs
+++ b/Validation.Infrastructure/Pipeline/PipelineWorker.cs
@@ -1,0 +1,63 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Validation.Infrastructure.Pipeline;
+
+public enum PipelineWorkerMode
+{
+    Periodic,
+    OnDemand
+}
+
+public class PipelineWorkerOptions
+{
+    public PipelineWorkerMode Mode { get; set; } = PipelineWorkerMode.Periodic;
+    public TimeSpan Interval { get; set; } = TimeSpan.FromMinutes(1);
+}
+
+public class PipelineWorker : BackgroundService
+{
+    private readonly PipelineOrchestrator _orchestrator;
+    private readonly ILogger<PipelineWorker> _logger;
+    private readonly PipelineWorkerOptions _options;
+
+    public PipelineWorker(PipelineOrchestrator orchestrator, ILogger<PipelineWorker> logger, IOptions<PipelineWorkerOptions> options)
+    {
+        _orchestrator = orchestrator;
+        _logger = logger;
+        _options = options.Value;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (_options.Mode == PipelineWorkerMode.OnDemand)
+        {
+            await _orchestrator.ExecuteAsync<object>(stoppingToken);
+            return;
+        }
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await _orchestrator.ExecuteAsync<object>(stoppingToken);
+            await Task.Delay(_options.Interval, stoppingToken);
+        }
+    }
+}
+
+public static class MetricsPipelineExtensions
+{
+    public static IServiceCollection AddMetricsPipeline(this IServiceCollection services, Action<PipelineWorkerOptions>? configure = null)
+    {
+        services.AddSingleton<PipelineOrchestrator>();
+        services.AddSingleton<PipelineWorkerOptions>(sp =>
+        {
+            var opts = new PipelineWorkerOptions();
+            configure?.Invoke(opts);
+            return opts;
+        });
+        services.AddHostedService<PipelineWorker>();
+        return services;
+    }
+}

--- a/Validation.Tests/PipelineOrchestratorTests.cs
+++ b/Validation.Tests/PipelineOrchestratorTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Validation.Infrastructure.Pipeline;
+using Xunit;
+
+namespace Validation.Tests;
+
+public class PipelineOrchestratorTests
+{
+    private class TestGather : IGatherService
+    {
+        public Task<IEnumerable<T>> GatherAsync<T>(CancellationToken ct = default)
+            => Task.FromResult<IEnumerable<T>>((IEnumerable<T>)(object)new[] {1, 2});
+    }
+
+    private class TestSummarise : ISummarisationService
+    {
+        public Task<T> SummariseAsync<T>(IEnumerable<T> items, CancellationToken ct = default)
+            => Task.FromResult((T)(object)3);
+    }
+
+    private class TestValidate : IValidationService
+    {
+        public bool Valid { get; set; } = true;
+        public Task<bool> ValidateAsync<T>(T summary, CancellationToken ct = default)
+            => Task.FromResult(Valid);
+    }
+
+    private class TestCommit : ICommitService
+    {
+        public int Called { get; private set; }
+        public Task CommitAsync<T>(T summary, CancellationToken ct = default)
+        { Called++; return Task.CompletedTask; }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ValidData_Commits()
+    {
+        var gather = new TestGather();
+        var summarise = new TestSummarise();
+        var validate = new TestValidate {Valid = true};
+        var commit = new TestCommit();
+        var orchestrator = new PipelineOrchestrator(gather, summarise, validate, commit);
+
+        await orchestrator.ExecuteAsync<int>(CancellationToken.None);
+
+        Assert.Equal(1, commit.Called);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_InvalidData_DiscardEventRaised()
+    {
+        var gather = new TestGather();
+        var summarise = new TestSummarise();
+        var validate = new TestValidate {Valid = false};
+        var commit = new TestCommit();
+        var orchestrator = new PipelineOrchestrator(gather, summarise, validate, commit);
+        bool discarded = false;
+        orchestrator.Discarded += (_, _) => discarded = true;
+
+        await orchestrator.ExecuteAsync<int>(CancellationToken.None);
+
+        Assert.True(discarded);
+        Assert.Equal(0, commit.Called);
+    }
+}


### PR DESCRIPTION
## Summary
- implement new PipelineOrchestrator and worker with interfaces and gather services
- provide in-memory and HTTP gather implementations
- expose AddMetricsPipeline DI extension
- fix reliability policy and validator for failing tests
- add unit tests for orchestrator

## Testing
- `dotnet test Validation.Tests/Validation.Tests.csproj -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_688c802ace348330916a49821c8368ae