### PR TITLE
Add pipeline orchestrator

### DIFF
--- a/Validation.Infrastructure/EnhancedManualValidatorService.cs
+++ b/Validation.Infrastructure/EnhancedManualValidatorService.cs
@@ -150,6 +150,7 @@ public class EnhancedManualValidatorService : IEnhancedManualValidatorService
                             _logger.LogError(ex, "Error executing named rule {RuleName} for type {Type}",
                                 kvp.Key, type.Name);
                             result.IsValid = false;
+                            result.FailedRules.Add(kvp.Key);
                             result.Errors.Add($"Rule '{kvp.Key}' execution failed: {ex.Message}");
                         }
                     }

--- a/Validation.Infrastructure/Pipeline/HttpGatherService.cs
+++ b/Validation.Infrastructure/Pipeline/HttpGatherService.cs
@@ -1,0 +1,21 @@
+using System.Net.Http.Json;
+
+namespace Validation.Infrastructure.Pipeline;
+
+public class HttpGatherService : IGatherService
+{
+    private readonly HttpClient _client;
+    private readonly string _endpoint;
+
+    public HttpGatherService(HttpClient client, string endpoint)
+    {
+        _client = client;
+        _endpoint = endpoint;
+    }
+
+    public async Task<IEnumerable<T>> GatherAsync<T>(CancellationToken cancellationToken = default)
+    {
+        var data = await _client.GetFromJsonAsync<IEnumerable<T>>(_endpoint, cancellationToken);
+        return data ?? Array.Empty<T>();
+    }
+}

--- a/Validation.Infrastructure/Pipeline/InMemoryGatherService.cs
+++ b/Validation.Infrastructure/Pipeline/InMemoryGatherService.cs
@@ -1,0 +1,31 @@
+using System.Collections.Concurrent;
+
+namespace Validation.Infrastructure.Pipeline;
+
+public class InMemoryGatherService : IGatherService
+{
+    private readonly ConcurrentDictionary<Type, IList<object>> _storage = new();
+
+    public void Add<T>(T item)
+    {
+        var list = _storage.GetOrAdd(typeof(T), _ => new List<object>());
+        lock (list)
+        {
+            list.Add(item!);
+        }
+    }
+
+    public Task<IEnumerable<T>> GatherAsync<T>(CancellationToken cancellationToken = default)
+    {
+        if (_storage.TryGetValue(typeof(T), out var list))
+        {
+            lock (list)
+            {
+                var result = list.Cast<T>().ToList();
+                list.Clear();
+                return Task.FromResult<IEnumerable<T>>(result);
+            }
+        }
+        return Task.FromResult<IEnumerable<T>>(Array.Empty<T>());
+    }
+}

--- a/Validation.Infrastructure/Pipeline/Interfaces.cs
+++ b/Validation.Infrastructure/Pipeline/Interfaces.cs
@@ -1,0 +1,21 @@
+namespace Validation.Infrastructure.Pipeline;
+
+public interface IGatherService
+{
+    Task<IEnumerable<T>> GatherAsync<T>(CancellationToken cancellationToken = default);
+}
+
+public interface ISummarisationService
+{
+    Task<T> SummariseAsync<T>(IEnumerable<T> items, CancellationToken cancellationToken = default);
+}
+
+public interface IValidationService
+{
+    Task<bool> ValidateAsync<T>(T summary, CancellationToken cancellationToken = default);
+}
+
+public interface ICommitService
+{
+    Task CommitAsync<T>(T summary, CancellationToken cancellationToken = default);
+}

--- a/Validation.Infrastructure/Pipeline/PipelineOrchestrator.cs
+++ b/Validation.Infrastructure/Pipeline/PipelineOrchestrator.cs
@@ -1,0 +1,49 @@
+using Microsoft.Extensions.Logging;
+using Validation.Infrastructure.Metrics;
+
+namespace Validation.Infrastructure.Pipeline;
+
+public class PipelineOrchestrator
+{
+    private readonly IGatherService _gather;
+    private readonly ISummarisationService _summarise;
+    private readonly IValidationService _validate;
+    private readonly ICommitService _commit;
+    private readonly IMetricsCollector _metrics;
+    private readonly ILogger<PipelineOrchestrator> _logger;
+
+    public PipelineOrchestrator(
+        IGatherService gather,
+        ISummarisationService summarise,
+        IValidationService validate,
+        ICommitService commit,
+        IMetricsCollector metrics,
+        ILogger<PipelineOrchestrator> logger)
+    {
+        _gather = gather;
+        _summarise = summarise;
+        _validate = validate;
+        _commit = commit;
+        _metrics = metrics;
+        _logger = logger;
+    }
+
+    public event Action<Type>? Discarded;
+
+    public async Task ExecuteAsync<T>(CancellationToken cancellationToken = default)
+    {
+        var gathered = await _gather.GatherAsync<T>(cancellationToken);
+        var summary = await _summarise.SummariseAsync(gathered, cancellationToken);
+        var valid = await _validate.ValidateAsync(summary, cancellationToken);
+
+        _metrics.RecordValidationResult(typeof(T).Name, valid);
+
+        if (!valid)
+        {
+            Discarded?.Invoke(typeof(T));
+            return;
+        }
+
+        await _commit.CommitAsync(summary, cancellationToken);
+    }
+}

--- a/Validation.Infrastructure/Pipeline/PipelineWorker.cs
+++ b/Validation.Infrastructure/Pipeline/PipelineWorker.cs
@@ -1,0 +1,45 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Validation.Infrastructure.Pipeline;
+
+public class PipelineWorkerOptions
+{
+    public int IntervalMs { get; set; } = 60000;
+    public bool Enabled { get; set; } = true;
+}
+
+public class PipelineWorker : BackgroundService
+{
+    private readonly PipelineOrchestrator _pipeline;
+    private readonly ILogger<PipelineWorker> _logger;
+    private readonly PipelineWorkerOptions _options;
+
+    public PipelineWorker(PipelineOrchestrator pipeline, ILogger<PipelineWorker> logger, IOptions<PipelineWorkerOptions> options)
+    {
+        _pipeline = pipeline;
+        _logger = logger;
+        _options = options.Value;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!_options.Enabled)
+            return;
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await _pipeline.ExecuteAsync<object>(stoppingToken);
+                await Task.Delay(_options.IntervalMs, stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Pipeline worker error");
+                await Task.Delay(5000, stoppingToken);
+            }
+        }
+    }
+}

--- a/Validation.Infrastructure/Pipeline/ServiceCollectionExtensions.cs
+++ b/Validation.Infrastructure/Pipeline/ServiceCollectionExtensions.cs
@@ -1,0 +1,44 @@
+using Microsoft.Extensions.DependencyInjection;
+using System.Linq;
+
+namespace Validation.Infrastructure.Pipeline;
+
+public static class MetricsPipelineServiceCollectionExtensions
+{
+    public static IServiceCollection AddMetricsPipeline(this IServiceCollection services)
+    {
+        services.AddSingleton<PipelineOrchestrator>();
+        services.AddSingleton<PipelineWorkerOptions>();
+        services.AddSingleton<IGatherService, InMemoryGatherService>();
+        services.AddSingleton<ISummarisationService, SumSummarisationService>();
+        services.AddSingleton<IValidationService, PassThroughValidationService>();
+        services.AddSingleton<ICommitService, NoOpCommitService>();
+        services.AddHostedService<PipelineWorker>();
+        return services;
+    }
+}
+
+// Minimal placeholder implementations
+public class SumSummarisationService : ISummarisationService
+{
+    public Task<T> SummariseAsync<T>(IEnumerable<T> items, CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(items.Last());
+    }
+}
+
+public class PassThroughValidationService : IValidationService
+{
+    public Task<bool> ValidateAsync<T>(T summary, CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(true);
+    }
+}
+
+public class NoOpCommitService : ICommitService
+{
+    public Task CommitAsync<T>(T summary, CancellationToken cancellationToken = default)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/Validation.Tests/PipelineOrchestratorTests.cs
+++ b/Validation.Tests/PipelineOrchestratorTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Validation.Infrastructure.Metrics;
+using Validation.Infrastructure.Pipeline;
+using Xunit;
+
+namespace Validation.Tests;
+
+public class PipelineOrchestratorTests
+{
+    private class TestGather : IGatherService
+    {
+        public IEnumerable<int> Data { get; set; } = new List<int>();
+        public Task<IEnumerable<T>> GatherAsync<T>(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IEnumerable<T>>(Data.Cast<T>().ToList());
+        }
+    }
+
+    private class SumService : ISummarisationService
+    {
+        public Task<T> SummariseAsync<T>(IEnumerable<T> items, CancellationToken cancellationToken = default)
+        {
+            var sum = items.Cast<int>().Sum();
+            return Task.FromResult((T)(object)sum);
+        }
+    }
+
+    private class TestValidator : IValidationService
+    {
+        public bool Result { get; set; }
+        public Task<bool> ValidateAsync<T>(T summary, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(Result);
+        }
+    }
+
+    private class TestCommit : ICommitService
+    {
+        public int CommitCount { get; private set; }
+        public Task CommitAsync<T>(T summary, CancellationToken cancellationToken = default)
+        {
+            CommitCount++;
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Success_Commits()
+    {
+        var gather = new TestGather { Data = new[] { 1, 2, 3 } };
+        var summarise = new SumService();
+        var validator = new TestValidator { Result = true };
+        var commit = new TestCommit();
+        var metrics = new MetricsCollector(NullLogger<MetricsCollector>.Instance);
+        var orchestrator = new PipelineOrchestrator(gather, summarise, validator, commit, metrics, NullLogger<PipelineOrchestrator>.Instance);
+
+        await orchestrator.ExecuteAsync<int>(CancellationToken.None);
+
+        Assert.Equal(1, commit.CommitCount);
+        var summary = await metrics.GetMetricsSummaryAsync();
+        Assert.Equal(1, summary.SuccessfulValidations);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ValidationFails_Discards()
+    {
+        var gather = new TestGather { Data = new[] { 1, 2 } };
+        var summarise = new SumService();
+        var validator = new TestValidator { Result = false };
+        var commit = new TestCommit();
+        var metrics = new MetricsCollector(NullLogger<MetricsCollector>.Instance);
+        var orchestrator = new PipelineOrchestrator(gather, summarise, validator, commit, metrics, NullLogger<PipelineOrchestrator>.Instance);
+
+        var discarded = false;
+        orchestrator.Discarded += _ => discarded = true;
+
+        await orchestrator.ExecuteAsync<int>(CancellationToken.None);
+
+        Assert.True(discarded);
+        Assert.Equal(0, commit.CommitCount);
+        var summary = await metrics.GetMetricsSummaryAsync();
+        Assert.Equal(1, summary.FailedValidations);
+    }
+}


### PR DESCRIPTION
## Summary
- add new pipeline orchestrator and hosted worker
- implement gather, summarise, validate and commit interfaces
- provide in-memory and HTTP gather services
- extend DI with AddMetricsPipeline
- fix reliability policy and validator to satisfy updated tests
- add tests for pipeline orchestrator

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688c802ace348330916a49821c8368ae