### PR TITLE
Support delete and commit flows via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
 # validation
+
+## Validation Flow Configuration
+
+`AddValidationFlows` can be configured via JSON. Each entry describes which consumers to register and any validation plan settings.
+
+```json
+[
+  {
+    "Type": "Namespace.Type, Assembly",
+    "SaveValidation": true,
+    "SaveCommit": true,
+    "DeleteValidation": true,
+    "DeleteCommit": true,
+    "MetricProperty": "Metric",
+    "ThresholdType": 1,
+    "ThresholdValue": 0.2,
+    "ManualRules": [
+      { "Property": "Metric", "MinValue": 0 }
+    ]
+  }
+]
+```
+
+Boolean flags control which message consumers are added. `ManualRules` allows simple manual validation rules where `Property` refers to a numeric property and `MinValue` specifies the minimum allowed value.
+
+## Samples
+
+Example configuration files can be found under the `config` folder.
+

--- a/Validation.Infrastructure/DI/ValidationFlowConfig.cs
+++ b/Validation.Infrastructure/DI/ValidationFlowConfig.cs
@@ -7,7 +7,16 @@ public class ValidationFlowConfig
     public string Type { get; set; } = string.Empty;
     public bool SaveValidation { get; set; }
     public bool SaveCommit { get; set; }
+    public bool DeleteValidation { get; set; }
+    public bool DeleteCommit { get; set; }
     public string? MetricProperty { get; set; }
     public ThresholdType? ThresholdType { get; set; }
     public decimal? ThresholdValue { get; set; }
+    public List<ManualRuleConfig>? ManualRules { get; set; }
+}
+
+public class ManualRuleConfig
+{
+    public string Property { get; set; } = string.Empty;
+    public decimal? MinValue { get; set; }
 }

--- a/Validation.Infrastructure/EnhancedManualValidatorService.cs
+++ b/Validation.Infrastructure/EnhancedManualValidatorService.cs
@@ -150,6 +150,7 @@ public class EnhancedManualValidatorService : IEnhancedManualValidatorService
                             _logger.LogError(ex, "Error executing named rule {RuleName} for type {Type}",
                                 kvp.Key, type.Name);
                             result.IsValid = false;
+                            result.FailedRules.Add(kvp.Key);
                             result.Errors.Add($"Rule '{kvp.Key}' execution failed: {ex.Message}");
                         }
                     }

--- a/Validation.Infrastructure/Messaging/DeleteCommitConsumer.cs
+++ b/Validation.Infrastructure/Messaging/DeleteCommitConsumer.cs
@@ -1,0 +1,21 @@
+using MassTransit;
+using Validation.Domain.Events;
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Infrastructure.Messaging;
+
+public class DeleteCommitConsumer<T> : IConsumer<DeleteValidated>
+{
+    private readonly ISaveAuditRepository _repository;
+
+    public DeleteCommitConsumer(ISaveAuditRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task Consume(ConsumeContext<DeleteValidated> context)
+    {
+        await _repository.DeleteAsync(context.Message.EntityId, context.CancellationToken);
+    }
+}
+

--- a/Validation.Tests/AddValidationFlowsTests.cs
+++ b/Validation.Tests/AddValidationFlowsTests.cs
@@ -20,7 +20,12 @@ public class AddValidationFlowsTests
                 "SaveCommit": true,
                 "MetricProperty": "Metric",
                 "ThresholdType": 1,
-                "ThresholdValue": 0.2
+                "ThresholdValue": 0.2,
+                "DeleteValidation": true,
+                "DeleteCommit": true,
+                "ManualRules": [
+                    { "Property": "Metric", "MinValue": 0 }
+                ]
             }]
             """;
 
@@ -36,12 +41,21 @@ public class AddValidationFlowsTests
                 Type = element.GetProperty("Type").GetString()!,
                 SaveValidation = element.GetProperty("SaveValidation").GetBoolean(),
                 SaveCommit = element.GetProperty("SaveCommit").GetBoolean(),
+                DeleteValidation = element.GetProperty("DeleteValidation").GetBoolean(),
+                DeleteCommit = element.GetProperty("DeleteCommit").GetBoolean(),
                 MetricProperty = element.GetProperty("MetricProperty").GetString(),
-                ThresholdType = thresholdTypeElement.ValueKind == JsonValueKind.Number 
-                    ? (ThresholdType?)thresholdTypeElement.GetInt32() 
+                ThresholdType = thresholdTypeElement.ValueKind == JsonValueKind.Number
+                    ? (ThresholdType?)thresholdTypeElement.GetInt32()
                     : null,
-                ThresholdValue = thresholdValueElement.ValueKind == JsonValueKind.Number 
-                    ? thresholdValueElement.GetDecimal() 
+                ThresholdValue = thresholdValueElement.ValueKind == JsonValueKind.Number
+                    ? thresholdValueElement.GetDecimal()
+                    : null,
+                ManualRules = element.TryGetProperty("ManualRules", out var rulesEl) && rulesEl.ValueKind == JsonValueKind.Array
+                    ? rulesEl.EnumerateArray().Select(r => new ManualRuleConfig
+                        {
+                            Property = r.GetProperty("Property").GetString()!,
+                            MinValue = r.TryGetProperty("MinValue", out var mv) && mv.ValueKind == JsonValueKind.Number ? mv.GetDecimal() : null
+                        }).ToList()
                     : null
             });
         }
@@ -57,10 +71,15 @@ public class AddValidationFlowsTests
         // Verify that the consumers were registered
         Assert.NotNull(scope.ServiceProvider.GetService<SaveValidationConsumer<Item>>());
         Assert.NotNull(scope.ServiceProvider.GetService<SaveCommitConsumer<Item>>());
-        
+        Assert.NotNull(scope.ServiceProvider.GetService<DeleteValidationConsumer<Item>>());
+        Assert.NotNull(scope.ServiceProvider.GetService<DeleteCommitConsumer<Item>>());
+
         // Verify that validation plan provider was configured
         var planProvider = scope.ServiceProvider.GetRequiredService<IValidationPlanProvider>();
         Assert.NotNull(planProvider);
+
+        var manualValidator = scope.ServiceProvider.GetRequiredService<IManualValidatorService>();
+        Assert.False(manualValidator.Validate(new Item(-1))); // rule should fail for negative metric
     }
 
     [Fact]

--- a/config/sample.json
+++ b/config/sample.json
@@ -1,0 +1,15 @@
+[
+  {
+    "Type": "Validation.Domain.Entities.Item, Validation.Domain",
+    "SaveValidation": true,
+    "SaveCommit": true,
+    "DeleteValidation": true,
+    "DeleteCommit": true,
+    "MetricProperty": "Metric",
+    "ThresholdType": 1,
+    "ThresholdValue": 0.2,
+    "ManualRules": [
+      { "Property": "Metric", "MinValue": 0 }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- extend `ValidationFlowConfig` with delete flow flags and manual rule config
- register delete validation & commit consumers and manual rules in DI
- add new `DeleteCommitConsumer`
- enhance reliability policy logic and manual validator
- document JSON config schema and sample configuration
- test registration of delete consumers and manual rules

## Testing
- `dotnet test -l "trx;LogFileName=/tmp/test.trx"`

------
https://chatgpt.com/codex/tasks/task_e_688c801987688330891f3dbeb3726e7a