### PR TITLE
Extend validation flow configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
-# validation
+# Validation Library
+
+This repository provides infrastructure components for configuring validation flows using MassTransit. Flows are defined using JSON configuration files.
+
+## Validation Flow Configuration Schema
+
+Each element in the configuration array has the following properties:
+
+- `Type` (string, required): Fully qualified type name of the entity to validate.
+- `SaveValidation` (bool): Registers the `SaveValidationConsumer<T>`.
+- `SaveCommit` (bool): Registers the `SaveCommitConsumer<T>`.
+- `DeleteValidation` (bool): Registers the `DeleteValidationConsumer<T>`.
+- `DeleteCommit` (bool): Registers the `DeleteCommitConsumer<T>`.
+- `MetricProperty` (string, optional): Name of the numeric property used for metric based validation.
+- `ThresholdType` (int, optional): Specifies the threshold comparison type.
+- `ThresholdValue` (decimal, optional): Value used with `ThresholdType`.
+- `ManualValidationRules` (array of strings, optional): Names of entity properties used to generate simple manual validator rules. String properties must be non‑empty and numeric properties must be greater than zero.
+
+## Sample Configuration
+
+A sample configuration file is provided in [`config/sample-validation-flows.json`](config/sample-validation-flows.json):
+
+```json
+[
+  {
+    "Type": "Validation.Domain.Entities.Item, Validation.Domain",
+    "SaveValidation": true,
+    "SaveCommit": true,
+    "DeleteValidation": true,
+    "DeleteCommit": true,
+    "MetricProperty": "Metric",
+    "ThresholdType": 1,
+    "ThresholdValue": 0.2,
+    "ManualValidationRules": ["Metric"]
+  }
+]
+```
+
+Use `AddValidationFlows` to register flows from this configuration.
+
+```csharp
+var configs = JsonSerializer.Deserialize<List<ValidationFlowConfig>>(File.ReadAllText("config/sample-validation-flows.json"));
+services.AddValidationFlows(configs!);
+```

--- a/Validation.Domain/Events/DeleteValidation.cs
+++ b/Validation.Domain/Events/DeleteValidation.cs
@@ -3,3 +3,4 @@ namespace Validation.Domain.Events;
 public record DeleteValidated(Guid EntityId, Guid AuditId, string EntityType);
 public record DeleteRejected(Guid EntityId, Guid AuditId, string Reason, string EntityType);
 public record DeleteValidationFailed(Guid EntityId, string Error, string EntityType);
+public record DeleteCommitFault(Guid EntityId, Guid AuditId, string Error, string EntityType);

--- a/Validation.Infrastructure/DI/ValidationFlowConfig.cs
+++ b/Validation.Infrastructure/DI/ValidationFlowConfig.cs
@@ -7,7 +7,10 @@ public class ValidationFlowConfig
     public string Type { get; set; } = string.Empty;
     public bool SaveValidation { get; set; }
     public bool SaveCommit { get; set; }
+    public bool DeleteValidation { get; set; }
+    public bool DeleteCommit { get; set; }
     public string? MetricProperty { get; set; }
     public ThresholdType? ThresholdType { get; set; }
     public decimal? ThresholdValue { get; set; }
+    public string[]? ManualValidationRules { get; set; }
 }

--- a/Validation.Infrastructure/EnhancedManualValidatorService.cs
+++ b/Validation.Infrastructure/EnhancedManualValidatorService.cs
@@ -150,6 +150,7 @@ public class EnhancedManualValidatorService : IEnhancedManualValidatorService
                             _logger.LogError(ex, "Error executing named rule {RuleName} for type {Type}",
                                 kvp.Key, type.Name);
                             result.IsValid = false;
+                            result.FailedRules.Add(kvp.Key);
                             result.Errors.Add($"Rule '{kvp.Key}' execution failed: {ex.Message}");
                         }
                     }

--- a/Validation.Infrastructure/Messaging/DeleteCommitConsumer.cs
+++ b/Validation.Infrastructure/Messaging/DeleteCommitConsumer.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Threading.Tasks;
+using MassTransit;
+using Validation.Domain.Events;
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Infrastructure.Messaging;
+
+public class DeleteCommitConsumer<T> : IConsumer<DeleteValidated>
+{
+    private readonly ISaveAuditRepository _repository;
+
+    public DeleteCommitConsumer(ISaveAuditRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task Consume(ConsumeContext<DeleteValidated> context)
+    {
+        try
+        {
+            await _repository.DeleteAsync(context.Message.AuditId, context.CancellationToken);
+        }
+        catch (Exception ex)
+        {
+            // In this simplified example we just log the exception via MassTransit
+            await context.Publish(new DeleteCommitFault(context.Message.EntityId, context.Message.AuditId, ex.Message, typeof(T).Name));
+        }
+    }
+}

--- a/Validation.Infrastructure/Reliability/DeletePipelineReliabilityPolicy.cs
+++ b/Validation.Infrastructure/Reliability/DeletePipelineReliabilityPolicy.cs
@@ -68,7 +68,6 @@ public class DeletePipelineReliabilityPolicy
                     }
                     else
                     {
-                        // Retryable exception but retries exhausted - this will be wrapped below
                         break;
                     }
                 }
@@ -101,14 +100,7 @@ public class DeletePipelineReliabilityPolicy
 
     private bool ShouldRetry(Exception exception, int attempt)
     {
-        if (attempt >= _options.MaxRetryAttempts - 1)
-            return false;
-
-        // Don't retry on certain exception types
-        if (exception is ArgumentException or ArgumentNullException)
-            return false;
-
-        return true;
+        return exception is not (ArgumentException or ArgumentNullException);
     }
 
     private bool IsCircuitOpen()

--- a/config/sample-validation-flows.json
+++ b/config/sample-validation-flows.json
@@ -1,0 +1,13 @@
+[
+  {
+    "Type": "Validation.Domain.Entities.Item, Validation.Domain",
+    "SaveValidation": true,
+    "SaveCommit": true,
+    "DeleteValidation": true,
+    "DeleteCommit": true,
+    "MetricProperty": "Metric",
+    "ThresholdType": 1,
+    "ThresholdValue": 0.2,
+    "ManualValidationRules": ["Metric"]
+  }
+]


### PR DESCRIPTION
## Summary
- add delete validation/commit to flow config
- register delete consumers and manual rules in validation flow registration
- add DeleteCommitConsumer and DeleteCommitFault event
- document JSON configuration in README
- provide sample configuration file
- extend tests for delete flows and manual rules
- fix EnhancedManualValidatorService and reliability policy

## Testing
- `dotnet build --no-restore --verbosity minimal`
- `MSBUILDTERMINALLOGGING=0 dotnet test --no-build -v minimal` *(fails: TerminalLogger out of range)*

------
https://chatgpt.com/codex/tasks/task_e_688c801987688330891f3dbeb3726e7a