### PR TITLE
Add delete validation flows and manual rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
 # validation
+
+## Validation Flow Configuration
+
+`AddValidationFlows` reads a collection of `ValidationFlowConfig` objects, which can be loaded from JSON.
+Each entry specifies which consumers to enable and optional validation settings.
+
+```json
+[
+  {
+    "Type": "Validation.Domain.Entities.Item, Validation.Domain",
+    "SaveValidation": true,
+    "SaveCommit": true,
+    "DeleteValidation": true,
+    "DeleteCommit": true,
+    "MetricProperty": "Metric",
+    "ThresholdType": 1,
+    "ThresholdValue": 0.2,
+    "ManualRules": ["Metric > 0"]
+  }
+]
+```
+
+* `Type` – fully qualified type of the entity.
+* `SaveValidation` / `SaveCommit` – registers save validation and commit consumers.
+* `DeleteValidation` / `DeleteCommit` – registers delete validation and commit consumers.
+* `MetricProperty`, `ThresholdType`, `ThresholdValue` – configure automatic validation plans.
+* `ManualRules` – list of simple rule expressions (`Property operator value`) registered via `AddValidatorRule`.
+
+Sample configurations are provided under the `config` folder.

--- a/Validation.Domain/Events/DeleteCommitFault.cs
+++ b/Validation.Domain/Events/DeleteCommitFault.cs
@@ -1,0 +1,3 @@
+namespace Validation.Domain.Events;
+
+public record DeleteCommitFault<T>(Guid EntityId, Guid AuditId, string Error);

--- a/Validation.Infrastructure/DI/ValidationFlowConfig.cs
+++ b/Validation.Infrastructure/DI/ValidationFlowConfig.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Validation.Domain.Validation;
 
 namespace Validation.Infrastructure.DI;
@@ -7,7 +8,10 @@ public class ValidationFlowConfig
     public string Type { get; set; } = string.Empty;
     public bool SaveValidation { get; set; }
     public bool SaveCommit { get; set; }
+    public bool DeleteValidation { get; set; }
+    public bool DeleteCommit { get; set; }
     public string? MetricProperty { get; set; }
     public ThresholdType? ThresholdType { get; set; }
     public decimal? ThresholdValue { get; set; }
+    public List<string> ManualRules { get; set; } = new();
 }

--- a/Validation.Infrastructure/EnhancedManualValidatorService.cs
+++ b/Validation.Infrastructure/EnhancedManualValidatorService.cs
@@ -150,6 +150,7 @@ public class EnhancedManualValidatorService : IEnhancedManualValidatorService
                             _logger.LogError(ex, "Error executing named rule {RuleName} for type {Type}",
                                 kvp.Key, type.Name);
                             result.IsValid = false;
+                            result.FailedRules.Add(kvp.Key);
                             result.Errors.Add($"Rule '{kvp.Key}' execution failed: {ex.Message}");
                         }
                     }
@@ -177,6 +178,7 @@ public class EnhancedManualValidatorService : IEnhancedManualValidatorService
                             _logger.LogError(ex, "Error executing anonymous rule {Index} for type {Type}",
                                 i, type.Name);
                             result.IsValid = false;
+                            result.FailedRules.Add($"Anonymous rule {i}");
                             result.Errors.Add($"Anonymous rule {i} execution failed: {ex.Message}");
                         }
                     }

--- a/Validation.Infrastructure/Messaging/DeleteCommitConsumer.cs
+++ b/Validation.Infrastructure/Messaging/DeleteCommitConsumer.cs
@@ -1,0 +1,27 @@
+using MassTransit;
+using Validation.Domain.Events;
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Infrastructure.Messaging;
+
+public class DeleteCommitConsumer<T> : IConsumer<DeleteValidated>
+{
+    private readonly ISaveAuditRepository _repository;
+
+    public DeleteCommitConsumer(ISaveAuditRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task Consume(ConsumeContext<DeleteValidated> context)
+    {
+        try
+        {
+            await _repository.DeleteAsync(context.Message.AuditId, context.CancellationToken);
+        }
+        catch (Exception ex)
+        {
+            await context.Publish(new DeleteCommitFault<T>(context.Message.EntityId, context.Message.AuditId, ex.Message));
+        }
+    }
+}

--- a/config/sample-flows.json
+++ b/config/sample-flows.json
@@ -1,0 +1,13 @@
+[
+  {
+    "Type": "Validation.Domain.Entities.Item, Validation.Domain",
+    "SaveValidation": true,
+    "SaveCommit": true,
+    "DeleteValidation": true,
+    "DeleteCommit": true,
+    "MetricProperty": "Metric",
+    "ThresholdType": 1,
+    "ThresholdValue": 0.2,
+    "ManualRules": ["Metric > 0"]
+  }
+]


### PR DESCRIPTION
## Summary
- extend `ValidationFlowConfig` with delete flow flags and manual rules
- support registering delete flows in `AddValidationFlows`
- parse simple manual rule expressions
- implement `DeleteCommitConsumer` and related fault event
- document JSON configuration and add sample config
- adjust reliability policy and validator service to satisfy tests
- add tests for delete flows and manual rule registration

## Testing
- `dotnet test Validation.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_688c801987688330891f3dbeb3726e7a