### PR TITLE
Add SummaryRecord model and repository

### DIFF
--- a/Validation.Domain/Entities/SummaryRecord.cs
+++ b/Validation.Domain/Entities/SummaryRecord.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Validation.Domain.Entities;
+
+public class SummaryRecord
+{
+    public int Id { get; set; }
+    public string ProgramName { get; set; } = string.Empty;
+    public string Entity { get; set; } = string.Empty;
+    public decimal MetricValue { get; set; }
+    public DateTime RecordedAt { get; set; } = DateTime.UtcNow;
+    public Guid RuntimeId { get; set; }
+}

--- a/Validation.Domain/Repositories/ISummaryRecordRepository.cs
+++ b/Validation.Domain/Repositories/ISummaryRecordRepository.cs
@@ -1,0 +1,11 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Validation.Domain.Entities;
+
+namespace Validation.Domain.Repositories;
+
+public interface ISummaryRecordRepository
+{
+    Task AddAsync(SummaryRecord record, CancellationToken ct = default);
+    Task<SummaryRecord?> GetLatestAsync(string programName, string entity, CancellationToken ct = default);
+}

--- a/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
+++ b/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
@@ -10,6 +10,7 @@ using Serilog;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.Messaging;
 using Validation.Infrastructure.Repositories;
+using Validation.Domain.Repositories;
 using Validation.Infrastructure;
 using Validation.Infrastructure.Reliability;
 using Validation.Infrastructure.Metrics;
@@ -25,6 +26,7 @@ public static class ServiceCollectionExtensions
         Action<IBusRegistrationConfigurator>? configureBus = null)
     {
         services.AddScoped<ISaveAuditRepository, EfCoreSaveAuditRepository>();
+        services.AddScoped<ISummaryRecordRepository, EfCoreSummaryRecordRepository>();
         services.AddSingleton<IValidationPlanProvider, InMemoryValidationPlanProvider>();
         services.AddSingleton<IManualValidatorService, ManualValidatorService>();
         services.AddSingleton<IEnhancedManualValidatorService, EnhancedManualValidatorService>();
@@ -69,6 +71,7 @@ public static class ServiceCollectionExtensions
     {
         services.AddSingleton(database);
         services.AddScoped<ISaveAuditRepository, MongoSaveAuditRepository>();
+        services.AddScoped<ISummaryRecordRepository, MongoSummaryRecordRepository>();
         services.AddSingleton<IValidationPlanProvider, InMemoryValidationPlanProvider>();
         services.AddSingleton<IManualValidatorService, ManualValidatorService>();
 
@@ -135,6 +138,7 @@ public static class ServiceCollectionExtensions
 
         // Register dependencies for consumers
         services.AddScoped<ISaveAuditRepository, EfCoreSaveAuditRepository>();
+        services.AddScoped<ISummaryRecordRepository, EfCoreSummaryRecordRepository>();
         services.AddSingleton<IManualValidatorService, ManualValidatorService>();
         services.AddScoped<SummarisationValidator>();
 
@@ -196,6 +200,7 @@ public static class ValidationFlowServiceCollectionExtensions
         options.Services.AddDbContext<TContext>(o => o.UseInMemoryDatabase(connectionString));
         options.Services.AddScoped<DbContext>(sp => sp.GetRequiredService<TContext>());
         options.Services.AddScoped<ISaveAuditRepository, EfCoreSaveAuditRepository>();
+        options.Services.AddScoped<ISummaryRecordRepository, EfCoreSummaryRecordRepository>();
         return options.Services;
     }
 
@@ -205,6 +210,7 @@ public static class ValidationFlowServiceCollectionExtensions
         var database = client.GetDatabase(dbName);
         options.Services.AddSingleton(database);
         options.Services.AddScoped<ISaveAuditRepository, MongoSaveAuditRepository>();
+        options.Services.AddScoped<ISummaryRecordRepository, MongoSummaryRecordRepository>();
         return options.Services;
     }
 
@@ -214,6 +220,7 @@ public static class ValidationFlowServiceCollectionExtensions
         services.AddScoped<IValidationRule, TRule>();
         services.AddSingleton<IValidationPlanProvider, InMemoryValidationPlanProvider>();
         services.AddSingleton<IManualValidatorService, ManualValidatorService>();
+        services.AddScoped<ISummaryRecordRepository, EfCoreSummaryRecordRepository>();
         services.AddScoped<SummarisationValidator>();
         services.AddMassTransitTestHarness(x =>
         {

--- a/Validation.Infrastructure/Repositories/EfCoreSummaryRecordRepository.cs
+++ b/Validation.Infrastructure/Repositories/EfCoreSummaryRecordRepository.cs
@@ -1,0 +1,31 @@
+using Microsoft.EntityFrameworkCore;
+using Validation.Domain.Entities;
+using Validation.Domain.Repositories;
+
+namespace Validation.Infrastructure.Repositories;
+
+public class EfCoreSummaryRecordRepository : ISummaryRecordRepository
+{
+    private readonly DbContext _context;
+    private readonly DbSet<SummaryRecord> _set;
+
+    public EfCoreSummaryRecordRepository(DbContext context)
+    {
+        _context = context;
+        _set = context.Set<SummaryRecord>();
+    }
+
+    public async Task AddAsync(SummaryRecord record, CancellationToken ct = default)
+    {
+        await _set.AddAsync(record, ct);
+        await _context.SaveChangesAsync(ct);
+    }
+
+    public async Task<SummaryRecord?> GetLatestAsync(string programName, string entity, CancellationToken ct = default)
+    {
+        return await _set
+            .Where(r => r.ProgramName == programName && r.Entity == entity)
+            .OrderByDescending(r => r.RecordedAt)
+            .FirstOrDefaultAsync(ct);
+    }
+}

--- a/Validation.Infrastructure/Repositories/MongoSummaryRecordRepository.cs
+++ b/Validation.Infrastructure/Repositories/MongoSummaryRecordRepository.cs
@@ -1,0 +1,27 @@
+using MongoDB.Driver;
+using Validation.Domain.Entities;
+using Validation.Domain.Repositories;
+
+namespace Validation.Infrastructure.Repositories;
+
+public class MongoSummaryRecordRepository : ISummaryRecordRepository
+{
+    private readonly IMongoCollection<SummaryRecord> _collection;
+
+    public MongoSummaryRecordRepository(IMongoDatabase database)
+    {
+        _collection = database.GetCollection<SummaryRecord>(nameof(SummaryRecord).ToLowerInvariant());
+    }
+
+    public async Task AddAsync(SummaryRecord record, CancellationToken ct = default)
+    {
+        await _collection.InsertOneAsync(record, cancellationToken: ct);
+    }
+
+    public async Task<SummaryRecord?> GetLatestAsync(string programName, string entity, CancellationToken ct = default)
+    {
+        var filter = Builders<SummaryRecord>.Filter.Eq(r => r.ProgramName, programName) &
+                     Builders<SummaryRecord>.Filter.Eq(r => r.Entity, entity);
+        return await _collection.Find(filter).SortByDescending(r => r.RecordedAt).FirstOrDefaultAsync(ct);
+    }
+}

--- a/Validation.Tests/InMemorySummaryRecordRepository.cs
+++ b/Validation.Tests/InMemorySummaryRecordRepository.cs
@@ -1,0 +1,24 @@
+using Validation.Domain.Entities;
+using Validation.Domain.Repositories;
+
+namespace Validation.Tests;
+
+public class InMemorySummaryRecordRepository : ISummaryRecordRepository
+{
+    public List<SummaryRecord> Records { get; } = new();
+
+    public Task AddAsync(SummaryRecord record, CancellationToken ct = default)
+    {
+        Records.Add(record);
+        return Task.CompletedTask;
+    }
+
+    public Task<SummaryRecord?> GetLatestAsync(string programName, string entity, CancellationToken ct = default)
+    {
+        var record = Records
+            .Where(r => r.ProgramName == programName && r.Entity == entity)
+            .OrderByDescending(r => r.RecordedAt)
+            .FirstOrDefault();
+        return Task.FromResult<SummaryRecord?>(record);
+    }
+}

--- a/Validation.Tests/SummaryRecordRepositoryTests.cs
+++ b/Validation.Tests/SummaryRecordRepositoryTests.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Threading.Tasks;
+using Validation.Domain.Entities;
+using Validation.Tests;
+using Xunit;
+
+namespace Validation.Tests;
+
+public class SummaryRecordRepositoryTests
+{
+    [Fact]
+    public async Task GetLatestAsync_ReturnsLatestRecord()
+    {
+        var repo = new InMemorySummaryRecordRepository();
+        var runtimeId = Guid.NewGuid();
+        await repo.AddAsync(new SummaryRecord
+        {
+            ProgramName = "prog",
+            Entity = "entity",
+            MetricValue = 1,
+            RecordedAt = DateTime.UtcNow.AddMinutes(-1),
+            RuntimeId = runtimeId
+        });
+        var latest = new SummaryRecord
+        {
+            ProgramName = "prog",
+            Entity = "entity",
+            MetricValue = 2,
+            RecordedAt = DateTime.UtcNow,
+            RuntimeId = runtimeId
+        };
+        await repo.AddAsync(latest);
+
+        var result = await repo.GetLatestAsync("prog", "entity");
+        Assert.NotNull(result);
+        Assert.Equal(2, result!.MetricValue);
+    }
+}

--- a/Validation.Tests/TestDbContext.cs
+++ b/Validation.Tests/TestDbContext.cs
@@ -11,4 +11,5 @@ public class TestDbContext : DbContext
 
     public DbSet<SaveAudit> SaveAudits => Set<SaveAudit>();
     public DbSet<Validation.Domain.Entities.Item> Items => Set<Validation.Domain.Entities.Item>();
+    public DbSet<Validation.Domain.Entities.SummaryRecord> SummaryRecords => Set<Validation.Domain.Entities.SummaryRecord>();
 }


### PR DESCRIPTION
## Summary
- add `SummaryRecord` entity and repository interface
- implement EF Core and Mongo repositories
- register summary record repository in DI
- add in-memory test repository and tests

## Testing
- `dotnet test --filter FullyQualifiedName~SummaryRecordRepositoryTests.GetLatestAsync_ReturnsLatestRecord`
- `dotnet test` *(fails: DeletePipelineReliabilityTests, UnifiedValidationSystemTests)*

------
https://chatgpt.com/codex/tasks/task_e_688c8f1660a48330be42bc1a83012a0c