### PR TITLE
Add SetupValidation<T> extension and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # validation
+
+This repository demonstrates a unified validation system. Services can register validation flows and database providers using the fluent API.
+
+## Quick Example
+
+```csharp
+services.AddSetupValidation<Item>(
+    b => b.UseEntityFramework<AppDbContext>(),
+    item => item.Metric,
+    ThresholdType.GreaterThan,
+    5m);
+```

--- a/Validation.Infrastructure/EnhancedManualValidatorService.cs
+++ b/Validation.Infrastructure/EnhancedManualValidatorService.cs
@@ -150,6 +150,7 @@ public class EnhancedManualValidatorService : IEnhancedManualValidatorService
                             _logger.LogError(ex, "Error executing named rule {RuleName} for type {Type}",
                                 kvp.Key, type.Name);
                             result.IsValid = false;
+                            result.FailedRules.Add(kvp.Key);
                             result.Errors.Add($"Rule '{kvp.Key}' execution failed: {ex.Message}");
                         }
                     }
@@ -177,6 +178,7 @@ public class EnhancedManualValidatorService : IEnhancedManualValidatorService
                             _logger.LogError(ex, "Error executing anonymous rule {Index} for type {Type}",
                                 i, type.Name);
                             result.IsValid = false;
+                            result.FailedRules.Add($"Anonymous rule {i}");
                             result.Errors.Add($"Anonymous rule {i} execution failed: {ex.Message}");
                         }
                     }

--- a/Validation.Infrastructure/Reliability/DeletePipelineReliabilityPolicy.cs
+++ b/Validation.Infrastructure/Reliability/DeletePipelineReliabilityPolicy.cs
@@ -54,7 +54,6 @@ public class DeletePipelineReliabilityPolicy
                 
                 if (ShouldRetry(ex, attempts - 1))
                 {
-                    Interlocked.Increment(ref _consecutiveFailures);
                     _lastFailureTime = DateTime.UtcNow;
 
                     _logger.LogWarning(ex, 
@@ -74,6 +73,12 @@ public class DeletePipelineReliabilityPolicy
                 }
                 else
                 {
+                    if (attempts >= _options.MaxRetryAttempts)
+                    {
+                        // Retries exhausted - break to wrap in reliability exception
+                        break;
+                    }
+
                     // Non-retryable exception - rethrow immediately
                     _logger.LogError(ex, "Delete pipeline operation failed with non-retryable exception");
                     throw;
@@ -81,8 +86,11 @@ public class DeletePipelineReliabilityPolicy
             }
         }
 
+        _lastFailureTime = DateTime.UtcNow;
+        Interlocked.Increment(ref _consecutiveFailures);
+
         _logger.LogError(lastException, "Delete pipeline operation failed after {Attempts} attempts", attempts);
-        
+
         // Always wrap retryable exceptions that exhausted retries in DeletePipelineReliabilityException
         throw new DeletePipelineReliabilityException(
             $"Delete pipeline operation failed after {attempts} attempts", lastException);

--- a/Validation.Tests/AddSetupValidationExtensionsTests.cs
+++ b/Validation.Tests/AddSetupValidationExtensionsTests.cs
@@ -1,0 +1,35 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.EntityFrameworkCore;
+using Validation.Domain.Entities;
+using Validation.Infrastructure.DI;
+using Validation.Infrastructure.Messaging;
+using Validation.Infrastructure.Setup;
+using Validation.Domain.Validation;
+
+namespace Validation.Tests;
+
+public class AddSetupValidationExtensionsTests
+{
+    [Fact]
+    public void AddSetupValidation_registers_plan_and_consumers()
+    {
+        var services = new ServiceCollection();
+
+        services.AddSetupValidation<Item>(
+            b => b.UseEntityFramework<TestDbContext>(),
+            item => item.Metric,
+            ThresholdType.GreaterThan,
+            10m);
+
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+
+        var planProvider = scope.ServiceProvider.GetRequiredService<IValidationPlanProvider>();
+        var plan = planProvider.GetPlan(typeof(Item));
+        Assert.Equal(ThresholdType.GreaterThan, plan.ThresholdType);
+        Assert.Equal(10m, plan.ThresholdValue);
+
+        Assert.NotNull(scope.ServiceProvider.GetService<SaveValidationConsumer<Item>>());
+        Assert.NotNull(scope.ServiceProvider.GetService<SaveCommitConsumer<Item>>());
+    }
+}


### PR DESCRIPTION
## Summary
- implement `AddSetupValidation<T>` for simplified database and plan registration
- ensure failure cases record failed rules
- refine delete pipeline reliability policy
- add demo usage with the new extension
- document quick example

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688c8fa5110c8330b11055971236ba2c