### PR TITLE
Add SetupValidation builder helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# validation
+# Validation
+
+This repository demonstrates a unified validation system. The `AddSetupValidation<T>` extension
+provides a quick way to configure a database and a summarisation plan in a single call.
+
+```csharp
+services.AddSetupValidation<Item>(
+    builder => builder.UseEntityFramework<SampleDbContext>(o => o.UseInMemoryDatabase("sample")),
+    item => item.Metric,
+    ThresholdType.GreaterThan,
+    5m);
+```
+
+This registers an EF Core context, a validation plan using the `Metric` property and the
+necessary MassTransit consumers for save validation flows.

--- a/Validation.Infrastructure/Setup/SetupValidationBuilder.cs
+++ b/Validation.Infrastructure/Setup/SetupValidationBuilder.cs
@@ -47,7 +47,10 @@ public class SetupValidationBuilder
             {
                 services.AddDbContext<TContext>(options => options.UseInMemoryDatabase("ValidationDb"));
             }
+
             services.AddScoped<DbContext, TContext>();
+            services.AddScoped(typeof(IGenericRepository<>), typeof(EfGenericRepository<>));
+            services.AddScoped<ISaveAuditRepository, EfCoreSaveAuditRepository>();
         });
         return this;
     }
@@ -62,6 +65,8 @@ public class SetupValidationBuilder
             var client = new MongoClient(connectionString);
             var database = client.GetDatabase(databaseName);
             services.AddSingleton(database);
+            services.AddScoped(typeof(IGenericRepository<>), typeof(MongoGenericRepository<>));
+            services.AddScoped<ISaveAuditRepository, MongoSaveAuditRepository>();
         });
         return this;
     }

--- a/Validation.Tests/AddSetupValidationTests.cs
+++ b/Validation.Tests/AddSetupValidationTests.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.EntityFrameworkCore;
+using Validation.Domain.Entities;
+using Validation.Infrastructure.DI;
+using Validation.Infrastructure.Messaging;
+using Validation.Domain.Validation;
+
+namespace Validation.Tests;
+
+public class AddSetupValidationTests
+{
+    [Fact]
+    public void AddSetupValidation_registers_plan_and_consumers()
+    {
+        var services = new ServiceCollection();
+        services.AddSetupValidation<Item>(
+            b => b.UseEntityFramework<TestDbContext>(o => o.UseInMemoryDatabase("addsetup")),
+            i => i.Metric,
+            ThresholdType.GreaterThan,
+            10m);
+
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+
+        Assert.NotNull(scope.ServiceProvider.GetService<DbContext>());
+        Assert.NotNull(scope.ServiceProvider.GetService<SaveValidationConsumer<Item>>());
+        Assert.NotNull(scope.ServiceProvider.GetService<SaveCommitConsumer<Item>>());
+
+        var planProvider = scope.ServiceProvider.GetRequiredService<IValidationPlanProvider>();
+        var plan = planProvider.GetPlan(typeof(Item));
+        Assert.Equal(ThresholdType.GreaterThan, plan.ThresholdType);
+        Assert.Equal(10m, plan.ThresholdValue);
+    }
+}


### PR DESCRIPTION
## Summary
- extend SetupValidationBuilder to register repositories
- add `AddSetupValidation<T>` helper to register DB and plan in one call
- update sample app and README with new extension
- test `AddSetupValidation`

## Testing
- `dotnet test Validation.sln --no-build --verbosity minimal` *(fails: System.ArgumentException Cannot create an instance of MassTransit.TypeCache+CachedType`1)*

------
https://chatgpt.com/codex/tasks/task_e_688c8fa5110c8330b11055971236ba2c