### PR TITLE
Implement SetupValidation generic helper

### DIFF
--- a/UNIFIED_VALIDATION_SYSTEM.md
+++ b/UNIFIED_VALIDATION_SYSTEM.md
@@ -75,22 +75,11 @@ Event implementations:
 Comprehensive validation system setup with fluent API:
 
 ```csharp
-services.AddSetupValidation()
-    .UseEntityFramework<MyDbContext>()
-    .AddValidationFlow<Item>(flow => flow
-        .EnableSaveValidation()
-        .EnableDeleteValidation()
-        .EnableSoftDelete()
-        .WithThreshold(x => x.Metric, ThresholdType.GreaterThan, 100)
-        .WithValidationTimeout(TimeSpan.FromMinutes(5))
-        .EnableAuditing())
-    .ConfigureMetrics(metrics => metrics
-        .EnableDetailedMetrics()
-        .WithProcessingInterval(TimeSpan.FromMinutes(1)))
-    .ConfigureReliability(reliability => reliability
-        .WithMaxRetries(3)
-        .WithRetryDelay(TimeSpan.FromSeconds(1)))
-    .Build();
+// Simplified setup for a single entity type
+services.AddSetupValidation<Item>(b => b.UseEntityFramework<MyDbContext>(),
+    item => item.Metric,
+    ThresholdType.GreaterThan,
+    100m);
 ```
 
 ### 4. Enhanced Configuration (`ValidationFlowConfig`)
@@ -155,9 +144,12 @@ services.AddValidation(setup => setup
 
 ```csharp
 // Comprehensive validation system
-services.AddSetupValidation()
-    .UseEntityFramework<MyDbContext>(options => 
-        options.UseInMemoryDatabase("ValidationDb"))
+services.AddSetupValidation<Item>(b =>
+    b.UseEntityFramework<MyDbContext>(options =>
+        options.UseInMemoryDatabase("ValidationDb")),
+    item => item.Metric,
+    ThresholdType.GreaterThan,
+    100m)
     
     .AddValidationFlow<Item>(flow => flow
         .EnableSaveValidation()
@@ -183,21 +175,18 @@ services.AddSetupValidation()
     
     .ConfigureAuditing(auditing => auditing
         .EnableDetailedAuditing()
-        .WithRetentionPeriod(TimeSpan.FromDays(365)))
-    
-    .Build();
+        .WithRetentionPeriod(TimeSpan.FromDays(365)));
 ```
 
 ### MongoDB Setup
 
 ```csharp
 // MongoDB-based validation system
-services.AddSetupValidation()
-    .UseMongoDB("mongodb://localhost:27017", "validation")
-    .AddValidationFlow<Item>(flow => flow
-        .EnableSaveValidation()
-        .EnableSoftDelete())
-    .Build();
+services.AddSetupValidation<Item>(b =>
+    b.UseMongoDB("mongodb://localhost:27017", "validation"),
+    item => item.Metric,
+    ThresholdType.GreaterThan,
+    50m);
 ```
 
 ### Event Handling

--- a/Validation.SampleApp/Program.cs
+++ b/Validation.SampleApp/Program.cs
@@ -3,10 +3,12 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.EntityFrameworkCore;
 using Validation.Domain.Entities;
 using Validation.Domain.Validation;
 using Validation.Infrastructure;
 using Validation.Infrastructure.Setup;
+using Validation.Infrastructure.DI;
 
 class Program
 {
@@ -19,28 +21,11 @@ class Program
         var host = Host.CreateDefaultBuilder(args)
             .ConfigureServices((context, services) =>
             {
-                // Configure the unified validation system using the fluent builder
-                services.AddSetupValidation()
-                    .AddValidationFlow<Item>(flow => flow
-                        .EnableSaveValidation()
-                        .EnableDeleteValidation()
-                        .EnableSoftDelete()
-                        .WithThreshold(x => x.Metric, ThresholdType.GreaterThan, 5)
-                        .WithValidationTimeout(TimeSpan.FromMinutes(1))
-                        .EnableAuditing())
-                    
-                    .AddRule<Item>("PositiveValue", item => item.Metric > 0)
-                    .AddRule<Item>("ReasonableRange", item => item.Metric <= 1000)
-                    
-                    .ConfigureMetrics(metrics => metrics
-                        .WithProcessingInterval(TimeSpan.FromSeconds(30))
-                        .EnableDetailedMetrics(false))
-                    
-                    .ConfigureReliability(reliability => reliability
-                        .WithMaxRetries(2)
-                        .WithRetryDelay(TimeSpan.FromMilliseconds(500)))
-                    
-                    .Build();
+                // Configure the unified validation system using the simplified method
+                services.AddSetupValidation<Item>(b => b.UseEntityFramework<MyDbContext>(),
+                    item => item.Metric,
+                    ThresholdType.GreaterThan,
+                    5m);
             })
             .ConfigureLogging(logging =>
             {
@@ -153,4 +138,11 @@ class Program
             logger.LogInformation("  Attempt Number: {AttemptNumber}", retryableEvent.AttemptNumber);
         }
     }
+}
+
+public class MyDbContext : DbContext
+{
+    public MyDbContext(DbContextOptions<MyDbContext> options) : base(options) { }
+
+    public DbSet<Item> Items { get; set; } = null!;
 }

--- a/Validation.Tests/AddSetupValidationTests.cs
+++ b/Validation.Tests/AddSetupValidationTests.cs
@@ -1,0 +1,36 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.EntityFrameworkCore;
+using Validation.Domain.Entities;
+using Validation.Domain.Validation;
+using Validation.Infrastructure.DI;
+using Validation.Infrastructure.Messaging;
+using Validation.Tests;
+using Xunit;
+
+namespace Validation.Tests;
+
+public class AddSetupValidationTests
+{
+    [Fact]
+    public void AddSetupValidation_registers_plan_and_consumers()
+    {
+        var services = new ServiceCollection();
+
+        services.AddSetupValidation<Item>(builder =>
+            builder.UseEntityFramework<TestDbContext>(),
+            item => item.Metric,
+            ThresholdType.GreaterThan,
+            10m);
+
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+
+        Assert.NotNull(scope.ServiceProvider.GetService<SaveValidationConsumer<Item>>());
+        Assert.NotNull(scope.ServiceProvider.GetService<SaveCommitConsumer<Item>>());
+
+        var planProvider = scope.ServiceProvider.GetRequiredService<IValidationPlanProvider>();
+        var plan = planProvider.GetPlan(typeof(Item));
+        Assert.Equal(ThresholdType.GreaterThan, plan.ThresholdType);
+        Assert.Equal(10m, plan.ThresholdValue);
+    }
+}


### PR DESCRIPTION
## Summary
- support Mongo in `SetupValidationBuilder`
- add `AddSetupValidation<T>` extension for simplified setup
- demonstrate new extension in sample program and documentation
- cover new scenario with tests

## Testing
- `dotnet build Validation.sln --no-restore --verbosity minimal`
- `dotnet test Validation.Tests/Validation.Tests.csproj --no-build --verbosity minimal` *(fails: Cannot create an instance of MassTransit.TypeCache+CachedType`1)*

------
https://chatgpt.com/codex/tasks/task_e_688c8fa5110c8330b11055971236ba2c