### PR TITLE
Add commit consumer helpers

### DIFF
--- a/Validation.Domain/Events/DeleteCommitFault.cs
+++ b/Validation.Domain/Events/DeleteCommitFault.cs
@@ -1,0 +1,3 @@
+namespace Validation.Domain.Events;
+
+public record DeleteCommitFault<T>(Guid EntityId, Guid AuditId, string Error);

--- a/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
+++ b/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
@@ -107,6 +107,34 @@ public static class ServiceCollectionExtensions
         return services;
     }
 
+    public static IServiceCollection AddSaveCommit<T>(
+        this IServiceCollection services,
+        Action<IBusRegistrationConfigurator>? configureBus = null)
+    {
+        services.AddScoped<SaveCommitConsumer<T>>();
+        services.AddMassTransitTestHarness(x =>
+        {
+            x.AddConsumer<SaveCommitConsumer<T>>();
+            configureBus?.Invoke(x);
+            x.UsingInMemory((context, cfg) => cfg.ConfigureEndpoints(context));
+        });
+        return services;
+    }
+
+    public static IServiceCollection AddDeleteCommit<T>(
+        this IServiceCollection services,
+        Action<IBusRegistrationConfigurator>? configureBus = null)
+    {
+        services.AddScoped<DeleteCommitConsumer<T>>();
+        services.AddMassTransitTestHarness(x =>
+        {
+            x.AddConsumer<DeleteCommitConsumer<T>>();
+            configureBus?.Invoke(x);
+            x.UsingInMemory((context, cfg) => cfg.ConfigureEndpoints(context));
+        });
+        return services;
+    }
+
     public static IServiceCollection AddValidationFlows(this IServiceCollection services, IEnumerable<ValidationFlowConfig> configs)
     {
         // Set up validation plan provider with configurations

--- a/Validation.Infrastructure/Messaging/DeleteCommitConsumer.cs
+++ b/Validation.Infrastructure/Messaging/DeleteCommitConsumer.cs
@@ -1,0 +1,31 @@
+using MassTransit;
+using Validation.Domain.Events;
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Infrastructure.Messaging;
+
+public class DeleteCommitConsumer<T> : IConsumer<DeleteValidated>
+{
+    private readonly ISaveAuditRepository _repository;
+
+    public DeleteCommitConsumer(ISaveAuditRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task Consume(ConsumeContext<DeleteValidated> context)
+    {
+        try
+        {
+            var audit = await _repository.GetAsync(context.Message.AuditId, context.CancellationToken);
+            if (audit != null)
+            {
+                await _repository.DeleteAsync(audit.Id, context.CancellationToken);
+            }
+        }
+        catch (Exception ex)
+        {
+            await context.Publish(new DeleteCommitFault<T>(context.Message.EntityId, context.Message.AuditId, ex.Message));
+        }
+    }
+}

--- a/Validation.Tests/AddCommitExtensionsTests.cs
+++ b/Validation.Tests/AddCommitExtensionsTests.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.DependencyInjection;
+using Validation.Infrastructure.DI;
+using Validation.Infrastructure.Messaging;
+using Validation.Infrastructure.Repositories;
+using Validation.Domain.Entities;
+
+namespace Validation.Tests;
+
+public class AddCommitExtensionsTests
+{
+    [Fact]
+    public void AddSaveCommit_registers_consumer()
+    {
+        var services = new ServiceCollection();
+        services.AddScoped<ISaveAuditRepository, InMemorySaveAuditRepository>();
+        services.AddSaveCommit<Item>();
+
+        Assert.Contains(services, d => d.ServiceType == typeof(SaveCommitConsumer<Item>));
+    }
+
+    [Fact]
+    public void AddDeleteCommit_registers_consumer()
+    {
+        var services = new ServiceCollection();
+        services.AddScoped<ISaveAuditRepository, InMemorySaveAuditRepository>();
+        services.AddDeleteCommit<Item>();
+
+        Assert.Contains(services, d => d.ServiceType == typeof(DeleteCommitConsumer<Item>));
+    }
+}

--- a/Validation.Tests/DeleteCommitConsumerTests.cs
+++ b/Validation.Tests/DeleteCommitConsumerTests.cs
@@ -1,0 +1,43 @@
+using MassTransit;
+using MassTransit.Testing;
+using Validation.Domain.Entities;
+using Validation.Domain.Events;
+using Validation.Infrastructure.Messaging;
+using Validation.Infrastructure.Repositories;
+using Validation.Infrastructure;
+
+namespace Validation.Tests;
+
+public class DeleteCommitConsumerTests
+{
+    private class FailingRepository : ISaveAuditRepository
+    {
+        public Task AddAsync(SaveAudit entity, CancellationToken ct = default) => Task.CompletedTask;
+        public Task DeleteAsync(Guid id, CancellationToken ct = default) => throw new Exception("fail");
+        public Task<SaveAudit?> GetAsync(Guid id, CancellationToken ct = default) => Task.FromResult<SaveAudit?>(new SaveAudit { Id = id, EntityId = id });
+        public Task UpdateAsync(SaveAudit entity, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<SaveAudit?> GetLastAsync(Guid entityId, CancellationToken ct = default) => Task.FromResult<SaveAudit?>(null);
+    }
+
+    [Fact]
+    public async Task Publish_DeleteCommitFault_on_error()
+    {
+        var repo = new FailingRepository();
+        var consumer = new DeleteCommitConsumer<Item>(repo);
+
+        var harness = new InMemoryTestHarness();
+        harness.Consumer(() => consumer);
+
+        await harness.Start();
+        try
+        {
+            await harness.InputQueueSendEndpoint.Send(new DeleteValidated(Guid.NewGuid(), Guid.NewGuid(), typeof(Item).Name));
+
+            Assert.True(await harness.Published.Any<DeleteCommitFault<Item>>());
+        }
+        finally
+        {
+            await harness.Stop();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add DeleteCommitFault event
- implement DeleteCommitConsumer for delete commit events
- add Save/Delete commit registration helpers
- test the new consumers and DI extensions

## Testing
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_688c8fdd96d483309f975b99031284be