### PR TITLE
Switch to new ValidationFlow.Messages events

### DIFF
--- a/Validation.Domain/Events/SaveRequested.Generic.cs
+++ b/Validation.Domain/Events/SaveRequested.Generic.cs
@@ -1,3 +1,5 @@
+using System;
 namespace Validation.Domain.Events;
 
+[Obsolete("Use ValidationFlow.Messages.SaveRequested<T> instead")]
 public record SaveRequested<T>(T Entity, string? App = null);

--- a/Validation.Domain/Events/SaveRequested.cs
+++ b/Validation.Domain/Events/SaveRequested.cs
@@ -1,3 +1,5 @@
+using System;
 namespace Validation.Domain.Events;
 
+[Obsolete("Use ValidationFlow.Messages.SaveRequested<T> instead")]
 public record SaveRequested(Guid Id);

--- a/Validation.Domain/Events/SaveValidated.Generic.cs
+++ b/Validation.Domain/Events/SaveValidated.Generic.cs
@@ -1,3 +1,5 @@
+using System;
 namespace Validation.Domain.Events;
 
+[Obsolete("Use ValidationFlow.Messages.SaveValidated<T> instead")]
 public record SaveValidated<T>(Guid EntityId, Guid AuditId);

--- a/Validation.Domain/Events/SaveValidated.cs
+++ b/Validation.Domain/Events/SaveValidated.cs
@@ -1,3 +1,5 @@
+using System;
 namespace Validation.Domain.Events;
 
+[Obsolete("Use ValidationFlow.Messages.SaveValidated<T> instead")]
 public record SaveValidated(Guid Id, bool IsValid, decimal Metric);

--- a/Validation.Infrastructure/Messaging/DeleteValidationConsumer.cs
+++ b/Validation.Infrastructure/Messaging/DeleteValidationConsumer.cs
@@ -1,11 +1,11 @@
 using MassTransit;
-using Validation.Domain.Events;
+using ValidationFlow.Messages;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.Repositories;
 
 namespace Validation.Infrastructure.Messaging;
 
-public class DeleteValidationConsumer<T> : IConsumer<DeleteRequested>
+public class DeleteValidationConsumer<T> : IConsumer<DeleteRequested<T>>
 {
     private readonly IValidationPlanProvider _planProvider;
     private readonly SummarisationValidator _validator;
@@ -16,7 +16,7 @@ public class DeleteValidationConsumer<T> : IConsumer<DeleteRequested>
         _validator = validator;
     }
 
-    public Task Consume(ConsumeContext<DeleteRequested> context)
+    public Task Consume(ConsumeContext<DeleteRequested<T>> context)
     {
         var rules = _planProvider.GetRules<T>();
         // execute manual rules with zero metrics since delete; actual logic omitted

--- a/Validation.Infrastructure/Messaging/ReliableDeleteValidationConsumer.cs
+++ b/Validation.Infrastructure/Messaging/ReliableDeleteValidationConsumer.cs
@@ -4,13 +4,14 @@ using System.Threading.Tasks;
 using MassTransit;
 using Microsoft.Extensions.Logging;
 using Validation.Domain.Events;
+using ValidationFlow.Messages;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.Reliability;
 using Validation.Infrastructure.Repositories;
 
 namespace Validation.Infrastructure.Messaging;
 
-public class ReliableDeleteValidationConsumer<T> : IConsumer<DeleteRequested>
+public class ReliableDeleteValidationConsumer<T> : IConsumer<DeleteRequested<T>>
 {
     private readonly IValidationPlanProvider _planProvider;
     private readonly SummarisationValidator _validator;
@@ -33,14 +34,14 @@ public class ReliableDeleteValidationConsumer<T> : IConsumer<DeleteRequested>
         _logger = logger;
     }
 
-    public async Task Consume(ConsumeContext<DeleteRequested> context)
+    public async Task Consume(ConsumeContext<DeleteRequested<T>> context)
     {
         using var activity = ActivitySource.StartActivity("DeleteValidation");
-        activity?.SetTag("entity.id", context.Message.Id.ToString());
+        activity?.SetTag("entity.id", context.Message.EntityId.ToString());
         activity?.SetTag("entity.type", typeof(T).Name);
 
         _logger.LogInformation("Starting delete validation for entity {EntityId} of type {EntityType}",
-            context.Message.Id, typeof(T).Name);
+            context.Message.EntityId, typeof(T).Name);
 
         try
         {
@@ -50,15 +51,15 @@ public class ReliableDeleteValidationConsumer<T> : IConsumer<DeleteRequested>
             }, context.CancellationToken);
 
             _logger.LogInformation("Delete validation completed successfully for entity {EntityId}",
-                context.Message.Id);
+                context.Message.EntityId);
         }
         catch (DeletePipelineCircuitOpenException ex)
         {
             _logger.LogError(ex, "Delete validation failed due to circuit breaker being open for entity {EntityId}",
-                context.Message.Id);
+                context.Message.EntityId);
             
             // Send to dead letter queue or handle graceful degradation
-            await context.Publish(new DeleteValidationFailed(context.Message.Id, "Circuit breaker open", typeof(T).Name),
+            await context.Publish(new DeleteValidationFailed(context.Message.EntityId, "Circuit breaker open", typeof(T).Name),
                 context.CancellationToken);
             
             throw;
@@ -66,24 +67,24 @@ public class ReliableDeleteValidationConsumer<T> : IConsumer<DeleteRequested>
         catch (DeletePipelineReliabilityException ex)
         {
             _logger.LogError(ex, "Delete validation failed after all retry attempts for entity {EntityId}",
-                context.Message.Id);
+                context.Message.EntityId);
             
-            await context.Publish(new DeleteValidationFailed(context.Message.Id, ex.Message, typeof(T).Name),
+            await context.Publish(new DeleteValidationFailed(context.Message.EntityId, ex.Message, typeof(T).Name),
                 context.CancellationToken);
             
             throw;
         }
     }
 
-    private async Task ValidateDeleteAsync(ConsumeContext<DeleteRequested> context, CancellationToken cancellationToken)
+    private async Task ValidateDeleteAsync(ConsumeContext<DeleteRequested<T>> context, CancellationToken cancellationToken)
     {
         // Get the last audit record to understand the current state
-        var lastAudit = await _auditRepository.GetLastAsync(context.Message.Id, cancellationToken);
+        var lastAudit = await _auditRepository.GetLastAsync(context.Message.EntityId, cancellationToken);
         
         if (lastAudit == null)
         {
             _logger.LogWarning("No audit record found for entity {EntityId}. Allowing delete.",
-                context.Message.Id);
+                context.Message.EntityId);
         }
 
         // Get validation rules for this entity type
@@ -93,13 +94,13 @@ public class ReliableDeleteValidationConsumer<T> : IConsumer<DeleteRequested>
         var isValid = _validator.Validate(lastAudit?.Metric ?? 0m, 0m, rules);
 
         _logger.LogDebug("Delete validation result for entity {EntityId}: {IsValid}",
-            context.Message.Id, isValid);
+            context.Message.EntityId, isValid);
 
         // Create audit record for the delete operation
         var deleteAudit = new SaveAudit
         {
             Id = Guid.NewGuid(),
-            EntityId = context.Message.Id,
+            EntityId = context.Message.EntityId,
             IsValid = isValid,
             Metric = 0m, // Zero metric for delete operation
             Timestamp = DateTime.UtcNow
@@ -110,12 +111,12 @@ public class ReliableDeleteValidationConsumer<T> : IConsumer<DeleteRequested>
         // Publish validation result
         if (isValid)
         {
-            await context.Publish(new DeleteValidated(context.Message.Id, deleteAudit.Id, typeof(T).Name),
+            await context.Publish(new DeleteValidated<T>(context.Message.AppName, context.Message.EntityType, context.Message.EntityId, true),
                 cancellationToken);
         }
         else
         {
-            await context.Publish(new DeleteRejected(context.Message.Id, deleteAudit.Id, "Validation failed", typeof(T).Name),
+            await context.Publish(new DeleteRejected<T>(context.Message.AppName, context.Message.EntityType, context.Message.EntityId, "Validation failed"),
                 cancellationToken);
         }
     }

--- a/Validation.Infrastructure/Messaging/SaveRequestedConsumer.cs
+++ b/Validation.Infrastructure/Messaging/SaveRequestedConsumer.cs
@@ -1,12 +1,13 @@
 using MassTransit;
-using Validation.Domain.Events;
+using ValidationFlow.Messages;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.Repositories;
 using Validation.Infrastructure;
+using Validation.Domain.Entities;
 
 namespace Validation.Infrastructure.Messaging;
 
-public class SaveRequestedConsumer : IConsumer<SaveRequested>
+public class SaveRequestedConsumer : IConsumer<SaveRequested<Item>>
 {
     private readonly ISaveAuditRepository _repository;
     private readonly IValidationRule _rule;
@@ -18,7 +19,7 @@ public class SaveRequestedConsumer : IConsumer<SaveRequested>
         _rule = rule;
     }
 
-    public async Task Consume(ConsumeContext<SaveRequested> context)
+    public async Task Consume(ConsumeContext<SaveRequested<Item>> context)
     {
         var metric = new Random().Next(0, 100); // simulate metric
         var isValid = _rule.Validate(_previousMetric, metric);
@@ -26,11 +27,11 @@ public class SaveRequestedConsumer : IConsumer<SaveRequested>
         var audit = new SaveAudit
         {
             Id = Guid.NewGuid(),
-            EntityId = context.Message.Id,
+            EntityId = context.Message.EntityId,
             IsValid = isValid,
             Metric = metric
         };
         await _repository.AddAsync(audit, context.CancellationToken);
-        await context.Publish(new SaveValidated(context.Message.Id, isValid, metric), context.CancellationToken);
+        await context.Publish(new SaveValidated<Item>(context.Message.AppName, context.Message.EntityType, context.Message.EntityId, context.Message.Payload, isValid), context.CancellationToken);
     }
 }

--- a/Validation.Infrastructure/Messaging/SaveValidationConsumer.cs
+++ b/Validation.Infrastructure/Messaging/SaveValidationConsumer.cs
@@ -1,11 +1,11 @@
 using MassTransit;
-using Validation.Domain.Events;
+using ValidationFlow.Messages;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.Repositories;
 
 namespace Validation.Infrastructure.Messaging;
 
-public class SaveValidationConsumer<T> : IConsumer<SaveRequested>
+public class SaveValidationConsumer<T> : IConsumer<SaveRequested<T>>
 {
     private readonly IValidationPlanProvider _planProvider;
     private readonly ISaveAuditRepository _repository;
@@ -18,9 +18,9 @@ public class SaveValidationConsumer<T> : IConsumer<SaveRequested>
         _validator = validator;
     }
 
-    public async Task Consume(ConsumeContext<SaveRequested> context)
+    public async Task Consume(ConsumeContext<SaveRequested<T>> context)
     {
-        var last = await _repository.GetLastAsync(context.Message.Id, context.CancellationToken);
+        var last = await _repository.GetLastAsync(context.Message.EntityId, context.CancellationToken);
         var metric = new Random().Next(0, 100);
         var rules = _planProvider.GetRules<T>();
         var isValid = _validator.Validate(last?.Metric ?? 0m, metric, rules);
@@ -28,12 +28,13 @@ public class SaveValidationConsumer<T> : IConsumer<SaveRequested>
         var audit = new SaveAudit
         {
             Id = Guid.NewGuid(),
-            EntityId = context.Message.Id,
+            EntityId = context.Message.EntityId,
             IsValid = isValid,
             Metric = metric
         };
 
         await _repository.AddAsync(audit, context.CancellationToken);
-        await context.Publish(new SaveValidated<T>(context.Message.Id, audit.Id));
+        await context.Publish(new SaveValidated<T>(context.Message.AppName, context.Message.EntityType, context.Message.EntityId, context.Message.Payload, isValid));
+        await context.Publish(new SaveCommitRequested<T>(context.Message.AppName, context.Message.EntityType, context.Message.EntityId, context.Message.Payload, audit.Id));
     }
 }

--- a/Validation.Infrastructure/Repositories/EventPublishingRepository.cs
+++ b/Validation.Infrastructure/Repositories/EventPublishingRepository.cs
@@ -1,5 +1,7 @@
 using MassTransit;
 using Validation.Domain.Events;
+using ValidationFlow.Messages;
+using System.Reflection;
 using Validation.Domain.Repositories;
 
 namespace Validation.Infrastructure.Repositories;
@@ -7,19 +9,26 @@ namespace Validation.Infrastructure.Repositories;
 public class EventPublishingRepository<T> : IEntityRepository<T>
 {
     private readonly IBus _bus;
-
-    public EventPublishingRepository(IBus bus)
+    private readonly string _appName;
+    public EventPublishingRepository(IBus bus, string? appName = null)
     {
         _bus = bus;
+        _appName = appName ?? Assembly.GetEntryAssembly()?.GetName().Name ?? "Unknown";
     }
 
     public Task SaveAsync(T entity, string? app = null, CancellationToken ct = default)
     {
-        return _bus.Publish(new SaveRequested<T>(entity, app), ct);
+        var idProp = typeof(T).GetProperty("Id");
+        var id = idProp != null && idProp.PropertyType == typeof(Guid)
+            ? (Guid)(idProp.GetValue(entity) ?? Guid.Empty)
+            : Guid.Empty;
+        var appName = app ?? _appName;
+        return _bus.Publish(new ValidationFlow.Messages.SaveRequested<T>(appName, typeof(T).Name, id, entity), ct);
     }
 
     public Task DeleteAsync(Guid id, string? app = null, CancellationToken ct = default)
     {
-        return _bus.Publish(new DeleteRequested(id), ct);
+        var appName = app ?? _appName;
+        return _bus.Publish(new ValidationFlow.Messages.DeleteRequested<T>(appName, typeof(T).Name, id), ct);
     }
 }

--- a/Validation.Infrastructure/Validation.Infrastructure.csproj
+++ b/Validation.Infrastructure/Validation.Infrastructure.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Validation.Domain\Validation.Domain.csproj" />
+    <ProjectReference Include="..\ValidationFlow.Messages\ValidationFlow.Messages.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Validation.Tests/EventPublishingRepositoryTests.cs
+++ b/Validation.Tests/EventPublishingRepositoryTests.cs
@@ -1,6 +1,6 @@
 using MassTransit.Testing;
 using Validation.Domain.Entities;
-using Validation.Domain.Events;
+using ValidationFlow.Messages;
 using Validation.Infrastructure.Repositories;
 
 namespace Validation.Tests;
@@ -37,7 +37,7 @@ public class EventPublishingRepositoryTests
             var repository = new EventPublishingRepository<Item>(harness.Bus);
             var id = Guid.NewGuid();
             await repository.DeleteAsync(id);
-            Assert.True(await harness.Published.Any<DeleteRequested>());
+            Assert.True(await harness.Published.Any<DeleteRequested<Item>>());
         }
         finally
         {

--- a/Validation.Tests/SaveCommitConsumerTests.cs
+++ b/Validation.Tests/SaveCommitConsumerTests.cs
@@ -1,6 +1,6 @@
 using MassTransit;
 using MassTransit.Testing;
-using Validation.Domain.Events;
+using ValidationFlow.Messages;
 using Validation.Infrastructure.Messaging;
 using Validation.Infrastructure;
 using Validation.Infrastructure.Repositories;
@@ -31,7 +31,8 @@ public class SaveCommitConsumerTests
         await harness.Start();
         try
         {
-            await harness.InputQueueSendEndpoint.Send(new SaveValidated<Item>(Guid.NewGuid(), Guid.NewGuid()));
+            var msg = new SaveCommitRequested<Item>("TestApp", nameof(Item), Guid.NewGuid(), new Item(5), Guid.NewGuid());
+            await harness.InputQueueSendEndpoint.Send(msg);
 
             Assert.True(await harness.Published.Any<SaveCommitFault<Item>>());
         }

--- a/Validation.Tests/SavePipelineTests.cs
+++ b/Validation.Tests/SavePipelineTests.cs
@@ -1,7 +1,7 @@
 using MassTransit;
 using MassTransit.Testing;
 using Validation.Domain.Entities;
-using Validation.Domain.Events;
+using ValidationFlow.Messages;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.Messaging;
 using Validation.Infrastructure.Repositories;
@@ -68,7 +68,7 @@ public class SavePipelineTests
         await harness.Start();
         try
         {
-            await harness.InputQueueSendEndpoint.Send(new SaveRequested(Guid.NewGuid()));
+            await harness.InputQueueSendEndpoint.Send(new SaveRequested<Item>("TestApp", nameof(Item), Guid.NewGuid(), new Item(5)));
 
             Assert.True(await harness.Published.Any<SaveValidated<Item>>());
             Assert.False(await harness.Published.Any<SaveCommitFault<Item>>());
@@ -90,7 +90,7 @@ public class SavePipelineTests
         await harness.Start();
         try
         {
-            await harness.InputQueueSendEndpoint.Send(new SaveRequested(Guid.NewGuid()));
+            await harness.InputQueueSendEndpoint.Send(new SaveRequested<Item>("TestApp", nameof(Item), Guid.NewGuid(), new Item(5)));
 
             Assert.True(await harness.Published.Any<SaveCommitFault<Item>>());
         }
@@ -110,9 +110,10 @@ public class SavePipelineTests
         await harness.Start();
         try
         {
-            await harness.InputQueueSendEndpoint.Send(new SaveRequested(Guid.NewGuid()));
+            var msg = new SaveRequested<Item>("TestApp", nameof(Item), Guid.NewGuid(), new Item(5));
+            await harness.InputQueueSendEndpoint.Send(msg);
 
-            Assert.True(await validationConsumer.Consumed.Any<SaveRequested>());
+            Assert.True(await validationConsumer.Consumed.Any<SaveRequested<Item>>());
             Assert.True(await harness.Published.Any<SaveValidated<Item>>());
         }
         finally

--- a/Validation.Tests/SaveValidationConsumerTests.cs
+++ b/Validation.Tests/SaveValidationConsumerTests.cs
@@ -1,6 +1,6 @@
 using MassTransit;
 using MassTransit.Testing;
-using Validation.Domain.Events;
+using ValidationFlow.Messages;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.Messaging;
 using Validation.Domain.Entities;
@@ -28,7 +28,8 @@ public class SaveValidationConsumerTests
         await harness.Start();
         try
         {
-            await harness.InputQueueSendEndpoint.Send(new SaveRequested(Guid.NewGuid()));
+            var message = new SaveRequested<Item>("TestApp", nameof(Item), Guid.NewGuid(), new Item(5));
+            await harness.InputQueueSendEndpoint.Send(message);
 
             Assert.True(await harness.Published.Any<SaveValidated<Item>>());
         }

--- a/Validation.Tests/ValidationFlowIntegrationTests.cs
+++ b/Validation.Tests/ValidationFlowIntegrationTests.cs
@@ -1,6 +1,7 @@
 using MassTransit.Testing;
 using Microsoft.Extensions.DependencyInjection;
-using Validation.Domain.Events;
+using ValidationFlow.Messages;
+using Validation.Domain.Entities;
 using Validation.Infrastructure.Messaging;
 using MassTransit;
 using Validation.Domain.Validation;
@@ -27,9 +28,9 @@ public class ValidationFlowIntegrationTests
         {
             using var scope = provider.CreateScope();
             var publish = scope.ServiceProvider.GetRequiredService<IPublishEndpoint>();
-            await publish.Publish(new SaveRequested(Guid.NewGuid()));
+            await publish.Publish(new SaveRequested<Item>("TestApp", nameof(Item), Guid.NewGuid(), new Item(5)));
 
-            Assert.True(await harness.Published.Any<SaveValidated>());
+            Assert.True(await harness.Published.Any<SaveValidated<Item>>());
             var ctx = scope.ServiceProvider.GetRequiredService<TestDbContext>();
             Assert.Equal(1, ctx.SaveAudits.Count());
         }

--- a/Validation.Tests/ValidationWorkflowTests.cs
+++ b/Validation.Tests/ValidationWorkflowTests.cs
@@ -1,8 +1,9 @@
 using MassTransit;
 using MassTransit.Testing;
-using Validation.Domain.Events;
+using ValidationFlow.Messages;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.Messaging;
+using Validation.Domain.Entities;
 
 namespace Validation.Tests;
 
@@ -20,9 +21,10 @@ public class ValidationWorkflowTests
         await harness.Start();
         try
         {
-            await harness.InputQueueSendEndpoint.Send(new SaveRequested(Guid.NewGuid()));
-            Assert.True(await harness.Consumed.Any<SaveRequested>());
-            Assert.True(await consumerHarness.Consumed.Any<SaveRequested>());
+            var msg = new SaveRequested<Item>("TestApp", nameof(Item), Guid.NewGuid(), new Item(5));
+            await harness.InputQueueSendEndpoint.Send(msg);
+            Assert.True(await harness.Consumed.Any<SaveRequested<Item>>());
+            Assert.True(await consumerHarness.Consumed.Any<SaveRequested<Item>>());
             Assert.Single(repository.Audits);
         }
         finally


### PR DESCRIPTION
## Summary
- use unified message types from `ValidationFlow.Messages`
- propagate AppName and EntityType when publishing events
- update infrastructure consumers to handle new messages
- mark old domain events as obsolete
- update tests for new message formats

## Testing
- `dotnet test Validation.Tests/Validation.Tests.csproj -v minimal` *(fails: 5, passed: 70)*

------
https://chatgpt.com/codex/tasks/task_e_688c8fe797f08330abb64bb10d6e0224