### PR TITLE
Implement metrics summarisation pipeline

### DIFF
--- a/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
+++ b/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
@@ -45,10 +45,10 @@ public static class ServiceCollectionExtensions
 
         services.AddMassTransit(x =>
         {
-            // Register the enhanced consumers
-            x.AddConsumer<ReliableDeleteValidationConsumer<Validation.Domain.Entities.Item>>(typeof(ReliabilityConsumerDefinition<>));
-            x.AddConsumer<ReliableDeleteValidationConsumer<Validation.Domain.Entities.NannyRecord>>(typeof(ReliabilityConsumerDefinition<>));
-            
+            // Register the enhanced consumers with closed generic definitions
+            x.AddConsumer<ReliableDeleteValidationConsumer<Validation.Domain.Entities.Item>>(typeof(ReliabilityConsumerDefinition<ReliableDeleteValidationConsumer<Validation.Domain.Entities.Item>>));
+            x.AddConsumer<ReliableDeleteValidationConsumer<Validation.Domain.Entities.NannyRecord>>(typeof(ReliabilityConsumerDefinition<ReliableDeleteValidationConsumer<Validation.Domain.Entities.NannyRecord>>));
+
             configureBus?.Invoke(x);
         });
 

--- a/Validation.Infrastructure/EnhancedManualValidatorService.cs
+++ b/Validation.Infrastructure/EnhancedManualValidatorService.cs
@@ -150,6 +150,7 @@ public class EnhancedManualValidatorService : IEnhancedManualValidatorService
                             _logger.LogError(ex, "Error executing named rule {RuleName} for type {Type}",
                                 kvp.Key, type.Name);
                             result.IsValid = false;
+                            result.FailedRules.Add(kvp.Key);
                             result.Errors.Add($"Rule '{kvp.Key}' execution failed: {ex.Message}");
                         }
                     }
@@ -177,6 +178,7 @@ public class EnhancedManualValidatorService : IEnhancedManualValidatorService
                             _logger.LogError(ex, "Error executing anonymous rule {Index} for type {Type}",
                                 i, type.Name);
                             result.IsValid = false;
+                            result.FailedRules.Add($"Anonymous rule {i}");
                             result.Errors.Add($"Anonymous rule {i} execution failed: {ex.Message}");
                         }
                     }

--- a/Validation.Infrastructure/Metrics/Pipeline/HttpGatherer.cs
+++ b/Validation.Infrastructure/Metrics/Pipeline/HttpGatherer.cs
@@ -1,0 +1,21 @@
+using System.Net.Http.Json;
+
+namespace Validation.Infrastructure.Metrics;
+
+public class HttpGatherer : IMetricsGatherer
+{
+    private readonly HttpClient _client;
+    private readonly string _url;
+
+    public HttpGatherer(HttpClient client, string url)
+    {
+        _client = client;
+        _url = url;
+    }
+
+    public async Task<IEnumerable<decimal>> GatherAsync(CancellationToken cancellationToken = default)
+    {
+        var values = await _client.GetFromJsonAsync<IEnumerable<decimal>>(_url, cancellationToken);
+        return values ?? Enumerable.Empty<decimal>();
+    }
+}

--- a/Validation.Infrastructure/Metrics/Pipeline/InMemoryGatherer.cs
+++ b/Validation.Infrastructure/Metrics/Pipeline/InMemoryGatherer.cs
@@ -1,0 +1,16 @@
+namespace Validation.Infrastructure.Metrics;
+
+public class InMemoryGatherer : IMetricsGatherer
+{
+    private readonly IEnumerable<decimal> _values;
+
+    public InMemoryGatherer(IEnumerable<decimal> values)
+    {
+        _values = values;
+    }
+
+    public Task<IEnumerable<decimal>> GatherAsync(CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(_values);
+    }
+}

--- a/Validation.Infrastructure/Metrics/Pipeline/Interfaces.cs
+++ b/Validation.Infrastructure/Metrics/Pipeline/Interfaces.cs
@@ -1,0 +1,17 @@
+namespace Validation.Infrastructure.Metrics;
+
+public interface IMetricsGatherer
+{
+    Task<IEnumerable<decimal>> GatherAsync(CancellationToken cancellationToken = default);
+}
+
+public interface ISummarisationService
+{
+    Task<decimal> SummariseAsync(IEnumerable<decimal> values, CancellationToken ct = default);
+}
+
+public class MetricsPipelineOptions
+{
+    public int IntervalMs { get; set; } = 60000;
+    public Validation.Domain.Validation.ValidationPlan ValidationPlan { get; set; } = new(new Validation.Domain.Validation.IValidationRule[] { });
+}

--- a/Validation.Infrastructure/Metrics/Pipeline/PipelineOrchestrator.cs
+++ b/Validation.Infrastructure/Metrics/Pipeline/PipelineOrchestrator.cs
@@ -1,0 +1,50 @@
+using Microsoft.Extensions.Logging;
+using Validation.Domain.Validation;
+
+namespace Validation.Infrastructure.Metrics;
+
+public class PipelineOrchestrator
+{
+    private readonly IEnumerable<IMetricsGatherer> _gatherers;
+    private readonly ISummarisationService _summariser;
+    private readonly SummarisationValidator _validator;
+    private readonly IMetricsCollector _collector;
+    private readonly MetricsPipelineOptions _options;
+    private readonly ILogger<PipelineOrchestrator> _logger;
+
+    public PipelineOrchestrator(
+        IEnumerable<IMetricsGatherer> gatherers,
+        ISummarisationService summariser,
+        SummarisationValidator validator,
+        IMetricsCollector collector,
+        MetricsPipelineOptions options,
+        ILogger<PipelineOrchestrator> logger)
+    {
+        _gatherers = gatherers;
+        _summariser = summariser;
+        _validator = validator;
+        _collector = collector;
+        _options = options;
+        _logger = logger;
+    }
+
+    public async Task RunAsync(CancellationToken cancellationToken = default)
+    {
+        var values = new List<decimal>();
+        foreach (var g in _gatherers)
+        {
+            values.AddRange(await g.GatherAsync(cancellationToken));
+        }
+
+        var summary = await _summariser.SummariseAsync(values, cancellationToken);
+
+        if (_validator.Validate(0m, summary, _options.ValidationPlan))
+        {
+            _collector.RecordValidationDuration("pipeline", (double)summary);
+        }
+        else
+        {
+            _logger.LogWarning("Metrics summary failed validation: {Summary}", summary);
+        }
+    }
+}

--- a/Validation.Infrastructure/Metrics/Pipeline/PipelineWorker.cs
+++ b/Validation.Infrastructure/Metrics/Pipeline/PipelineWorker.cs
@@ -1,0 +1,35 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Validation.Infrastructure.Metrics;
+
+public class PipelineWorker : BackgroundService
+{
+    private readonly PipelineOrchestrator _orchestrator;
+    private readonly MetricsPipelineOptions _options;
+    private readonly ILogger<PipelineWorker> _logger;
+
+    public PipelineWorker(PipelineOrchestrator orchestrator, MetricsPipelineOptions options, ILogger<PipelineWorker> logger)
+    {
+        _orchestrator = orchestrator;
+        _options = options;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await _orchestrator.RunAsync(stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error running metrics pipeline");
+            }
+
+            await Task.Delay(_options.IntervalMs, stoppingToken);
+        }
+    }
+}

--- a/Validation.Infrastructure/Metrics/Pipeline/ServiceCollectionExtensions.cs
+++ b/Validation.Infrastructure/Metrics/Pipeline/ServiceCollectionExtensions.cs
@@ -1,0 +1,18 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Validation.Infrastructure.Metrics;
+
+public static class MetricsPipelineExtensions
+{
+    public static IServiceCollection AddMetricsPipeline(this IServiceCollection services, Action<MetricsPipelineOptions>? configure = null)
+    {
+        var options = new MetricsPipelineOptions();
+        configure?.Invoke(options);
+
+        services.AddSingleton(options);
+        services.AddSingleton<PipelineOrchestrator>();
+        services.AddHostedService<PipelineWorker>();
+
+        return services;
+    }
+}

--- a/Validation.Tests/PipelineOrchestratorTests.cs
+++ b/Validation.Tests/PipelineOrchestratorTests.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Validation.Domain.Validation;
+using Validation.Infrastructure.Metrics;
+using Xunit;
+
+namespace Validation.Tests;
+
+public class PipelineOrchestratorTests
+{
+    private class TestMetricsCollector : IMetricsCollector
+    {
+        public List<double> Durations { get; } = new();
+
+        public void RecordValidationDuration(string entityType, double durationMs) => Durations.Add(durationMs);
+        public void RecordValidationResult(string entityType, bool success) { }
+        public void RecordCircuitBreakerState(string operation, bool isOpen) { }
+        public void RecordRetryAttempt(string operation, int attemptNumber) { }
+        public Task<MetricsSummary> GetMetricsSummaryAsync(System.TimeSpan? period = null) => Task.FromResult(new MetricsSummary());
+    }
+
+    private class SumSummarisationService : ISummarisationService
+    {
+        public Task<decimal> SummariseAsync(IEnumerable<decimal> values, System.Threading.CancellationToken ct = default) => Task.FromResult(values.Sum());
+    }
+
+    [Fact]
+    public async Task RunAsync_Commits_when_validation_passes()
+    {
+        var collector = new TestMetricsCollector();
+        var gatherer = new InMemoryGatherer(new decimal[] { 1m, 2m, 3m });
+        var summariser = new SumSummarisationService();
+        var options = new MetricsPipelineOptions { ValidationPlan = new ValidationPlan(new[] { new AlwaysValidRule() }) };
+        var orchestrator = new PipelineOrchestrator(new[] { gatherer }, summariser, new SummarisationValidator(), collector, options, NullLogger<PipelineOrchestrator>.Instance);
+
+        await orchestrator.RunAsync();
+
+        Assert.Single(collector.Durations);
+        Assert.Equal(6, collector.Durations[0]);
+    }
+
+    private class AlwaysInvalidRule : IValidationRule
+    {
+        public bool Validate(decimal previousValue, decimal newValue) => false;
+    }
+
+    [Fact]
+    public async Task RunAsync_Does_not_commit_when_validation_fails()
+    {
+        var collector = new TestMetricsCollector();
+        var gatherer = new InMemoryGatherer(new decimal[] { 1m });
+        var summariser = new SumSummarisationService();
+        var options = new MetricsPipelineOptions { ValidationPlan = new ValidationPlan(new[] { new AlwaysInvalidRule() }) };
+        var orchestrator = new PipelineOrchestrator(new[] { gatherer }, summariser, new SummarisationValidator(), collector, options, NullLogger<PipelineOrchestrator>.Instance);
+
+        await orchestrator.RunAsync();
+
+        Assert.Empty(collector.Durations);
+    }
+}


### PR DESCRIPTION
## Summary
- add new metrics pipeline orchestrator and worker
- support in-memory and HTTP gatherers
- expose AddMetricsPipeline for DI
- fix EnhancedManualValidatorService to report failed rules when exceptions occur
- adjust reliability policy retry tracking
- provide tests for PipelineOrchestrator

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688c8ff4e4e88330ada5d3071db2a8b0