### PR TITLE
Add summarisation pipeline orchestrator

### DIFF
--- a/Validation.Infrastructure/Metrics/AverageSummarisationService.cs
+++ b/Validation.Infrastructure/Metrics/AverageSummarisationService.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Validation.Infrastructure.Metrics;
+
+public class AverageSummarisationService : ISummarisationService
+{
+    public decimal Summarise(IEnumerable<decimal> metrics)
+    {
+        var list = metrics.ToList();
+        return list.Count == 0 ? 0 : list.Average();
+    }
+}

--- a/Validation.Infrastructure/Metrics/Gatherers/HttpGatherer.cs
+++ b/Validation.Infrastructure/Metrics/Gatherers/HttpGatherer.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Validation.Infrastructure.Metrics;
+
+public class HttpGatherer : IMetricsGatherer
+{
+    private readonly HttpClient _client;
+    private readonly string _url;
+
+    public HttpGatherer(HttpClient client, string url)
+    {
+        _client = client;
+        _url = url;
+    }
+
+    public async Task<IEnumerable<decimal>> GatherAsync(CancellationToken cancellationToken = default)
+    {
+        var response = await _client.GetStringAsync(_url, cancellationToken);
+        return decimal.TryParse(response, out var value)
+            ? new[] { value }
+            : Array.Empty<decimal>();
+    }
+}

--- a/Validation.Infrastructure/Metrics/Gatherers/InMemoryGatherer.cs
+++ b/Validation.Infrastructure/Metrics/Gatherers/InMemoryGatherer.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Validation.Infrastructure.Metrics;
+
+public class InMemoryGatherer : IMetricsGatherer
+{
+    private readonly IEnumerable<decimal> _values;
+
+    public InMemoryGatherer(IEnumerable<decimal> values)
+    {
+        _values = values;
+    }
+
+    public Task<IEnumerable<decimal>> GatherAsync(CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(_values);
+    }
+}

--- a/Validation.Infrastructure/Metrics/IMetricsGatherer.cs
+++ b/Validation.Infrastructure/Metrics/IMetricsGatherer.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Validation.Infrastructure.Metrics;
+
+public interface IMetricsGatherer
+{
+    Task<IEnumerable<decimal>> GatherAsync(CancellationToken cancellationToken = default);
+}

--- a/Validation.Infrastructure/Metrics/ISummarisationService.cs
+++ b/Validation.Infrastructure/Metrics/ISummarisationService.cs
@@ -1,0 +1,8 @@
+using System.Collections.Generic;
+
+namespace Validation.Infrastructure.Metrics;
+
+public interface ISummarisationService
+{
+    decimal Summarise(IEnumerable<decimal> metrics);
+}

--- a/Validation.Infrastructure/Metrics/MetricsPipelineExtensions.cs
+++ b/Validation.Infrastructure/Metrics/MetricsPipelineExtensions.cs
@@ -1,0 +1,20 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Validation.Infrastructure.Metrics;
+
+public static class MetricsPipelineExtensions
+{
+    public static IServiceCollection AddMetricsPipeline<T>(this IServiceCollection services, TimeSpan? interval = null)
+    {
+        services.AddSingleton<ISummarisationService, AverageSummarisationService>();
+        services.AddSingleton<IMetricsGatherer, InMemoryGatherer>(_ => new InMemoryGatherer(Array.Empty<decimal>()));
+        services.AddSingleton<PipelineOrchestrator<T>>();
+        services.AddHostedService(sp => new PipelineWorker<T>(
+            sp.GetRequiredService<PipelineOrchestrator<T>>(),
+            sp.GetRequiredService<ILogger<PipelineWorker<T>>>(),
+            interval ?? TimeSpan.FromMinutes(5)));
+        return services;
+    }
+}

--- a/Validation.Infrastructure/Metrics/PipelineOrchestrator.cs
+++ b/Validation.Infrastructure/Metrics/PipelineOrchestrator.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Validation.Domain.Validation;
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Infrastructure.Metrics;
+
+public class PipelineOrchestrator<T>
+{
+    private readonly IEnumerable<IMetricsGatherer> _gatherers;
+    private readonly ISummarisationService _summariser;
+    private readonly IValidationPlanProvider _planProvider;
+    private readonly SummarisationValidator _validator;
+    private readonly ISaveAuditRepository _repository;
+    private readonly ILogger<PipelineOrchestrator<T>> _logger;
+
+    public PipelineOrchestrator(
+        IEnumerable<IMetricsGatherer> gatherers,
+        ISummarisationService summariser,
+        IValidationPlanProvider planProvider,
+        SummarisationValidator validator,
+        ISaveAuditRepository repository,
+        ILogger<PipelineOrchestrator<T>> logger)
+    {
+        _gatherers = gatherers;
+        _summariser = summariser;
+        _planProvider = planProvider;
+        _validator = validator;
+        _repository = repository;
+        _logger = logger;
+    }
+
+    public async Task RunAsync(Guid entityId, CancellationToken cancellationToken = default)
+    {
+        var metricLists = await Task.WhenAll(_gatherers.Select(g => g.GatherAsync(cancellationToken)));
+        var metrics = metricLists.SelectMany(m => m).ToList();
+        var summary = _summariser.Summarise(metrics);
+
+        var plan = _planProvider.GetPlan(typeof(T));
+        var previous = await _repository.GetLastAsync(entityId, cancellationToken);
+        var isValid = _validator.Validate(previous?.Metric ?? 0m, summary, plan);
+
+        var audit = new SaveAudit
+        {
+            Id = Guid.NewGuid(),
+            EntityId = entityId,
+            Metric = summary,
+            IsValid = isValid
+        };
+
+        await _repository.AddAsync(audit, cancellationToken);
+        _logger.LogInformation("Pipeline processed entity {Entity} with metric {Metric} valid={Valid}", entityId, summary, isValid);
+    }
+}

--- a/Validation.Infrastructure/Metrics/PipelineWorker.cs
+++ b/Validation.Infrastructure/Metrics/PipelineWorker.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Validation.Infrastructure.Metrics;
+
+public class PipelineWorker<T> : BackgroundService
+{
+    private readonly PipelineOrchestrator<T> _orchestrator;
+    private readonly ILogger<PipelineWorker<T>> _logger;
+    private readonly TimeSpan _interval;
+
+    public PipelineWorker(PipelineOrchestrator<T> orchestrator, ILogger<PipelineWorker<T>> logger, TimeSpan interval)
+    {
+        _orchestrator = orchestrator;
+        _logger = logger;
+        _interval = interval;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await _orchestrator.RunAsync(Guid.NewGuid(), stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Pipeline execution failed");
+            }
+
+            await Task.Delay(_interval, stoppingToken);
+        }
+    }
+}

--- a/Validation.Tests/MetricsPipelineOrchestratorTests.cs
+++ b/Validation.Tests/MetricsPipelineOrchestratorTests.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Validation.Domain.Entities;
+using Validation.Domain.Validation;
+using Validation.Infrastructure.Metrics;
+using Validation.Tests;
+using Xunit;
+
+public class MetricsPipelineOrchestratorTests
+{
+    [Fact]
+    public async Task Orchestrator_runs_pipeline_and_commits_audit()
+    {
+        var gatherer = new InMemoryGatherer(new[] {1m, 3m});
+        var summariser = new AverageSummarisationService();
+        var planProvider = new InMemoryValidationPlanProvider();
+        planProvider.AddPlan<Item>(new ValidationPlan(_ => 0m, ThresholdType.RawDifference, 10m));
+        var validator = new SummarisationValidator();
+        var repo = new InMemorySaveAuditRepository();
+        var orchestrator = new PipelineOrchestrator<Item>(new[] {gatherer}, summariser, planProvider, validator, repo, NullLogger<PipelineOrchestrator<Item>>.Instance);
+
+        var id = Guid.NewGuid();
+        await orchestrator.RunAsync(id);
+
+        var audit = repo.Audits.Single(a => a.EntityId == id);
+        Assert.Equal(2m, audit.Metric);
+        Assert.True(audit.IsValid);
+    }
+}


### PR DESCRIPTION
## Summary
- create `PipelineOrchestrator` to gather, summarise, validate and commit metrics
- add `PipelineWorker` background service and DI helper `AddMetricsPipeline`
- provide in-memory and HTTP gatherers with averaging summarisation service
- add orchestration unit test

## Testing
- `dotnet test --filter MetricsPipelineOrchestratorTests`
- `dotnet test` *(fails: Cannot create an instance of MassTransit.TypeCache+CachedType`1[Validation.Infrastructure.Reliability.ReliabilityConsumerDefinition`1[T]] because Type.ContainsGenericParameters is true)*

------
https://chatgpt.com/codex/tasks/task_e_688c8ff4e4e88330ada5d3071db2a8b0