### PR TITLE
Add summarisation pipeline orchestrator

### DIFF
--- a/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
+++ b/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
@@ -46,9 +46,11 @@ public static class ServiceCollectionExtensions
         services.AddMassTransit(x =>
         {
             // Register the enhanced consumers
-            x.AddConsumer<ReliableDeleteValidationConsumer<Validation.Domain.Entities.Item>>(typeof(ReliabilityConsumerDefinition<>));
-            x.AddConsumer<ReliableDeleteValidationConsumer<Validation.Domain.Entities.NannyRecord>>(typeof(ReliabilityConsumerDefinition<>));
-            
+            x.AddConsumer<ReliableDeleteValidationConsumer<Validation.Domain.Entities.Item>,
+                ReliabilityConsumerDefinition<ReliableDeleteValidationConsumer<Validation.Domain.Entities.Item>>>();
+            x.AddConsumer<ReliableDeleteValidationConsumer<Validation.Domain.Entities.NannyRecord>,
+                ReliabilityConsumerDefinition<ReliableDeleteValidationConsumer<Validation.Domain.Entities.NannyRecord>>>();
+
             configureBus?.Invoke(x);
         });
 

--- a/Validation.Infrastructure/EnhancedManualValidatorService.cs
+++ b/Validation.Infrastructure/EnhancedManualValidatorService.cs
@@ -150,6 +150,7 @@ public class EnhancedManualValidatorService : IEnhancedManualValidatorService
                             _logger.LogError(ex, "Error executing named rule {RuleName} for type {Type}",
                                 kvp.Key, type.Name);
                             result.IsValid = false;
+                            result.FailedRules.Add(kvp.Key);
                             result.Errors.Add($"Rule '{kvp.Key}' execution failed: {ex.Message}");
                         }
                     }

--- a/Validation.Infrastructure/Metrics/Pipeline/AverageSummarisationService.cs
+++ b/Validation.Infrastructure/Metrics/Pipeline/AverageSummarisationService.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Validation.Infrastructure.Metrics;
+
+public class AverageSummarisationService : ISummarisationService
+{
+    public Task<decimal> SummariseAsync(IEnumerable<decimal> data, CancellationToken cancellationToken = default)
+    {
+        var list = data.ToList();
+        var avg = list.Count == 0 ? 0m : list.Average();
+        return Task.FromResult(avg);
+    }
+}

--- a/Validation.Infrastructure/Metrics/Pipeline/HttpMetricsGatherer.cs
+++ b/Validation.Infrastructure/Metrics/Pipeline/HttpMetricsGatherer.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Validation.Infrastructure.Metrics;
+
+public class HttpMetricsGatherer : IMetricsGatherer
+{
+    private readonly HttpClient _client;
+    private readonly string _url;
+
+    public HttpMetricsGatherer(HttpClient client, string url)
+    {
+        _client = client;
+        _url = url;
+    }
+
+    public async Task<IEnumerable<decimal>> GatherAsync(CancellationToken cancellationToken = default)
+    {
+        var json = await _client.GetStringAsync(_url, cancellationToken);
+        var data = JsonSerializer.Deserialize<List<decimal>>(json) ?? new();
+        return data;
+    }
+}

--- a/Validation.Infrastructure/Metrics/Pipeline/IMetricsGatherer.cs
+++ b/Validation.Infrastructure/Metrics/Pipeline/IMetricsGatherer.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Validation.Infrastructure.Metrics;
+
+public interface IMetricsGatherer
+{
+    Task<IEnumerable<decimal>> GatherAsync(CancellationToken cancellationToken = default);
+}

--- a/Validation.Infrastructure/Metrics/Pipeline/ISummarisationService.cs
+++ b/Validation.Infrastructure/Metrics/Pipeline/ISummarisationService.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Validation.Infrastructure.Metrics;
+
+public interface ISummarisationService
+{
+    Task<decimal> SummariseAsync(IEnumerable<decimal> data, CancellationToken cancellationToken = default);
+}

--- a/Validation.Infrastructure/Metrics/Pipeline/ISummaryCommitter.cs
+++ b/Validation.Infrastructure/Metrics/Pipeline/ISummaryCommitter.cs
@@ -1,0 +1,9 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Validation.Infrastructure.Metrics;
+
+public interface ISummaryCommitter
+{
+    Task CommitAsync(decimal summary, CancellationToken cancellationToken = default);
+}

--- a/Validation.Infrastructure/Metrics/Pipeline/InMemoryMetricsGatherer.cs
+++ b/Validation.Infrastructure/Metrics/Pipeline/InMemoryMetricsGatherer.cs
@@ -1,0 +1,23 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Validation.Infrastructure.Metrics;
+
+public class InMemoryMetricsGatherer : IMetricsGatherer
+{
+    private readonly ConcurrentQueue<decimal> _metrics = new();
+
+    public void Add(decimal value) => _metrics.Enqueue(value);
+
+    public Task<IEnumerable<decimal>> GatherAsync(CancellationToken cancellationToken = default)
+    {
+        var list = new List<decimal>();
+        while (_metrics.TryDequeue(out var v))
+        {
+            list.Add(v);
+        }
+        return Task.FromResult<IEnumerable<decimal>>(list);
+    }
+}

--- a/Validation.Infrastructure/Metrics/Pipeline/InMemorySummaryCommitter.cs
+++ b/Validation.Infrastructure/Metrics/Pipeline/InMemorySummaryCommitter.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Validation.Infrastructure.Metrics;
+
+public class InMemorySummaryCommitter : ISummaryCommitter
+{
+    public List<decimal> Committed { get; } = new();
+
+    public Task CommitAsync(decimal summary, CancellationToken cancellationToken = default)
+    {
+        Committed.Add(summary);
+        return Task.CompletedTask;
+    }
+}

--- a/Validation.Infrastructure/Metrics/Pipeline/MetricsPipelineExtensions.cs
+++ b/Validation.Infrastructure/Metrics/Pipeline/MetricsPipelineExtensions.cs
@@ -1,0 +1,23 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Validation.Domain.Validation;
+
+namespace Validation.Infrastructure.Metrics;
+
+public static class MetricsPipelineExtensions
+{
+    public static IServiceCollection AddMetricsPipeline(this IServiceCollection services, Action<PipelineWorkerOptions>? configure = null)
+    {
+        services.AddSingleton<IMetricsGatherer, InMemoryMetricsGatherer>();
+        services.AddSingleton<ISummarisationService, AverageSummarisationService>();
+        services.AddSingleton<ISummaryCommitter, InMemorySummaryCommitter>();
+        services.AddSingleton<SummarisationValidator>();
+        services.AddSingleton(new ValidationPlan(_ => 0m, ThresholdType.RawDifference, 100m));
+        services.AddSingleton<PipelineOrchestrator>();
+        var options = new PipelineWorkerOptions();
+        configure?.Invoke(options);
+        services.AddSingleton(options);
+        services.AddHostedService<PipelineWorker>();
+        return services;
+    }
+}

--- a/Validation.Infrastructure/Metrics/Pipeline/PipelineOrchestrator.cs
+++ b/Validation.Infrastructure/Metrics/Pipeline/PipelineOrchestrator.cs
@@ -1,0 +1,35 @@
+using Validation.Domain.Validation;
+
+namespace Validation.Infrastructure.Metrics;
+
+public class PipelineOrchestrator
+{
+    private readonly IMetricsGatherer _gatherer;
+    private readonly ISummarisationService _summariser;
+    private readonly SummarisationValidator _validator;
+    private readonly ValidationPlan _plan;
+    private readonly ISummaryCommitter _committer;
+
+    public PipelineOrchestrator(
+        IMetricsGatherer gatherer,
+        ISummarisationService summariser,
+        SummarisationValidator validator,
+        ValidationPlan plan,
+        ISummaryCommitter committer)
+    {
+        _gatherer = gatherer;
+        _summariser = summariser;
+        _validator = validator;
+        _plan = plan;
+        _committer = committer;
+    }
+
+    public async Task RunAsync(CancellationToken cancellationToken = default)
+    {
+        var metrics = await _gatherer.GatherAsync(cancellationToken);
+        var summary = await _summariser.SummariseAsync(metrics, cancellationToken);
+        if (!_validator.Validate(0m, summary, _plan))
+            throw new InvalidOperationException("Summary failed validation");
+        await _committer.CommitAsync(summary, cancellationToken);
+    }
+}

--- a/Validation.Infrastructure/Metrics/Pipeline/PipelineWorker.cs
+++ b/Validation.Infrastructure/Metrics/Pipeline/PipelineWorker.cs
@@ -1,0 +1,40 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Validation.Infrastructure.Metrics;
+
+public class PipelineWorkerOptions
+{
+    public int IntervalMs { get; set; } = 60000;
+}
+
+public class PipelineWorker : BackgroundService
+{
+    private readonly PipelineOrchestrator _orchestrator;
+    private readonly PipelineWorkerOptions _options;
+    private readonly ILogger<PipelineWorker> _logger;
+
+    public PipelineWorker(PipelineOrchestrator orchestrator, PipelineWorkerOptions options, ILogger<PipelineWorker> logger)
+    {
+        _orchestrator = orchestrator;
+        _options = options;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await _orchestrator.RunAsync(stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Pipeline orchestration failed");
+            }
+
+            await Task.Delay(_options.IntervalMs, stoppingToken);
+        }
+    }
+}

--- a/Validation.Tests/PipelineOrchestratorTests.cs
+++ b/Validation.Tests/PipelineOrchestratorTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Validation.Domain.Validation;
+using Validation.Infrastructure.Metrics;
+using Xunit;
+
+namespace Validation.Tests;
+
+public class PipelineOrchestratorTests
+{
+    private class DummyGatherer : IMetricsGatherer
+    {
+        public Task<IEnumerable<decimal>> GatherAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IEnumerable<decimal>>(new[] { 1m, 2m, 3m });
+        }
+    }
+
+    private class DummySummarisationService : ISummarisationService
+    {
+        public Task<decimal> SummariseAsync(IEnumerable<decimal> data, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(data.Sum());
+        }
+    }
+
+    private class DummyCommitter : ISummaryCommitter
+    {
+        public decimal? Summary { get; private set; }
+        public Task CommitAsync(decimal summary, CancellationToken cancellationToken = default)
+        {
+            Summary = summary;
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task Orchestrator_runs_pipeline_and_commits()
+    {
+        var gatherer = new DummyGatherer();
+        var summariser = new DummySummarisationService();
+        var validator = new SummarisationValidator();
+        var plan = new ValidationPlan(_ => 0m, ThresholdType.RawDifference, 100m);
+        var committer = new DummyCommitter();
+
+        var orchestrator = new PipelineOrchestrator(gatherer, summariser, validator, plan, committer);
+
+        await orchestrator.RunAsync();
+
+        Assert.Equal(6m, committer.Summary);
+    }
+
+    [Fact]
+    public async Task PipelineWorker_executes_orchestrator()
+    {
+        var gatherer = new DummyGatherer();
+        var summariser = new DummySummarisationService();
+        var validator = new SummarisationValidator();
+        var plan = new ValidationPlan(_ => 0m, ThresholdType.RawDifference, 100m);
+        var committer = new DummyCommitter();
+        var orchestrator = new PipelineOrchestrator(gatherer, summariser, validator, plan, committer);
+        var options = new PipelineWorkerOptions { IntervalMs = 10 };
+        var worker = new PipelineWorker(orchestrator, options, NullLogger<PipelineWorker>.Instance);
+
+        using var cts = new CancellationTokenSource(30);
+        await worker.StartAsync(cts.Token);
+        await Task.Delay(15);
+        await worker.StopAsync(CancellationToken.None);
+
+        Assert.NotNull(committer.Summary);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `PipelineOrchestrator` with gather/summarise/validate/commit steps
- create in‑memory and HTTP gatherers and average summarisation service
- add `PipelineWorker` background service and DI extension
- enhance validator service error reporting
- fix reliability policy logic
- introduce tests for the new pipeline

## Testing
- `dotnet test Validation.Tests/Validation.Tests.csproj -v minimal --filter FullyQualifiedName~DeletePipelineReliabilityTests.ExecuteAsync_PermanentFailure_ThrowsAfterMaxRetries`
- `dotnet test Validation.Tests/Validation.Tests.csproj -v minimal --filter FullyQualifiedName~DeletePipelineReliabilityTests.ExecuteAsync_CircuitBreakerOpen_ThrowsCircuitOpenException`
- `dotnet test Validation.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_688c8ff4e4e88330ada5d3071db2a8b0