### PR TITLE
Add generic setup validation helper with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# validation
+# Validation
+
+This repository contains a unified validation framework with fluent configuration APIs.
+
+## Quick start
+
+Register validation with Entity Framework:
+
+```csharp
+services.AddSetupValidation<Item>(builder =>
+{
+    builder.UseEntityFramework<MyDbContext>();
+}, x => x.Metric);
+```
+
+Or with MongoDB:
+
+```csharp
+services.AddSetupValidation<Item>(b =>
+    b.UseMongoDB("mongodb://localhost:27017", "validation"),
+    x => x.Metric);
+```
+
+See `Validation.SampleApp` for a complete example.

--- a/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
+++ b/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
@@ -46,9 +46,9 @@ public static class ServiceCollectionExtensions
         services.AddMassTransit(x =>
         {
             // Register the enhanced consumers
-            x.AddConsumer<ReliableDeleteValidationConsumer<Validation.Domain.Entities.Item>>(typeof(ReliabilityConsumerDefinition<>));
-            x.AddConsumer<ReliableDeleteValidationConsumer<Validation.Domain.Entities.NannyRecord>>(typeof(ReliabilityConsumerDefinition<>));
-            
+            x.AddConsumer<ReliableDeleteValidationConsumer<Validation.Domain.Entities.Item>>();
+            x.AddConsumer<ReliableDeleteValidationConsumer<Validation.Domain.Entities.NannyRecord>>();
+
             configureBus?.Invoke(x);
         });
 

--- a/Validation.Infrastructure/EnhancedManualValidatorService.cs
+++ b/Validation.Infrastructure/EnhancedManualValidatorService.cs
@@ -150,6 +150,7 @@ public class EnhancedManualValidatorService : IEnhancedManualValidatorService
                             _logger.LogError(ex, "Error executing named rule {RuleName} for type {Type}",
                                 kvp.Key, type.Name);
                             result.IsValid = false;
+                            result.FailedRules.Add(kvp.Key);
                             result.Errors.Add($"Rule '{kvp.Key}' execution failed: {ex.Message}");
                         }
                     }
@@ -177,6 +178,7 @@ public class EnhancedManualValidatorService : IEnhancedManualValidatorService
                             _logger.LogError(ex, "Error executing anonymous rule {Index} for type {Type}",
                                 i, type.Name);
                             result.IsValid = false;
+                            result.FailedRules.Add($"Anonymous rule {i}");
                             result.Errors.Add($"Anonymous rule {i} execution failed: {ex.Message}");
                         }
                     }


### PR DESCRIPTION
## Summary
- extend `SetupValidationBuilder` to accept metric selectors and expose `AddSetupValidation<T>` for quick configuration
- update enhanced validator to record failed rules when exceptions occur
- refine reliability policy and MassTransit setup
- add usage in sample program and README
- implement integration tests for EF and Mongo setups

## Testing
- `dotnet build --no-restore Validation.sln`
- `dotnet test --no-build Validation.sln`


------
https://chatgpt.com/codex/tasks/task_e_688c9266ae708330824622b11f179ec9