### PR TITLE
Add fluent setup extension with metric selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# validation
+# Unified Validation System
+
+This repository demonstrates a fluent configuration API for registering validation flows and infrastructure services.
+
+```csharp
+services.AddSetupValidation<Item>(builder =>
+{
+    builder.UseEntityFramework<AppDbContext>();
+}, item => item.Metric);
+```
+
+See `Validation.SampleApp` for a runnable example.

--- a/Validation.Domain/Validation/ValidationPlan.cs
+++ b/Validation.Domain/Validation/ValidationPlan.cs
@@ -21,4 +21,11 @@ public class ValidationPlan
         ThresholdType = thresholdType;
         ThresholdValue = thresholdValue;
     }
+
+    // Constructor for metric tracking without thresholds
+    public ValidationPlan(Func<object, decimal> metricSelector)
+    {
+        Rules = Enumerable.Empty<IValidationRule>();
+        MetricSelector = metricSelector;
+    }
 }

--- a/Validation.Infrastructure/EnhancedManualValidatorService.cs
+++ b/Validation.Infrastructure/EnhancedManualValidatorService.cs
@@ -150,6 +150,7 @@ public class EnhancedManualValidatorService : IEnhancedManualValidatorService
                             _logger.LogError(ex, "Error executing named rule {RuleName} for type {Type}",
                                 kvp.Key, type.Name);
                             result.IsValid = false;
+                            result.FailedRules.Add(kvp.Key);
                             result.Errors.Add($"Rule '{kvp.Key}' execution failed: {ex.Message}");
                         }
                     }
@@ -177,6 +178,7 @@ public class EnhancedManualValidatorService : IEnhancedManualValidatorService
                             _logger.LogError(ex, "Error executing anonymous rule {Index} for type {Type}",
                                 i, type.Name);
                             result.IsValid = false;
+                            result.FailedRules.Add($"Anonymous rule {i}");
                             result.Errors.Add($"Anonymous rule {i} execution failed: {ex.Message}");
                         }
                     }

--- a/Validation.Infrastructure/Reliability/DeletePipelineReliabilityPolicy.cs
+++ b/Validation.Infrastructure/Reliability/DeletePipelineReliabilityPolicy.cs
@@ -108,9 +108,6 @@ public class DeletePipelineReliabilityPolicy
 
     private bool ShouldRetry(Exception exception, int attempt)
     {
-        if (attempt >= _options.MaxRetryAttempts - 1)
-            return false;
-
         // Don't retry on certain exception types
         if (exception is ArgumentException or ArgumentNullException)
             return false;


### PR DESCRIPTION
## Summary
- enhance `SetupValidationBuilder` with metric selectors and DB provider tracking
- add helper `AddSetupValidation<T>` for simplified setup
- support metric-only plans
- update validation services for reliability and manual validation
- show usage in sample app and docs
- add integration tests for EF and Mongo setups

## Testing
- `dotnet test Validation.Tests/Validation.Tests.csproj --no-build --filter FullyQualifiedName~UnifiedValidationSystemTests -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_688c9266ae708330824622b11f179ec9