### PR TITLE
Implement simple metrics pipeline orchestrator

### DIFF
--- a/Validation.Infrastructure/DI/MetricsPipelineServiceCollectionExtensions.cs
+++ b/Validation.Infrastructure/DI/MetricsPipelineServiceCollectionExtensions.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.DependencyInjection;
+using Validation.Infrastructure.Pipeline;
+
+namespace Validation.Infrastructure.DI;
+
+public static class MetricsPipelineServiceCollectionExtensions
+{
+    public static IServiceCollection AddMetricsPipeline(this IServiceCollection services)
+    {
+        services.AddSingleton<PipelineOrchestrator>();
+        services.AddHostedService<PipelineWorker>();
+        return services;
+    }
+}

--- a/Validation.Infrastructure/Pipeline/IMetricGatherer.cs
+++ b/Validation.Infrastructure/Pipeline/IMetricGatherer.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Validation.Infrastructure.Pipeline;
+
+public interface IMetricGatherer
+{
+    Task<IEnumerable<decimal>> GatherMetricsAsync(CancellationToken cancellationToken = default);
+}

--- a/Validation.Infrastructure/Pipeline/ISummarisationService.cs
+++ b/Validation.Infrastructure/Pipeline/ISummarisationService.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Validation.Infrastructure.Pipeline;
+
+public interface ISummarisationService
+{
+    Task<decimal> SummariseAsync(IEnumerable<decimal> metrics, CancellationToken cancellationToken = default);
+}

--- a/Validation.Infrastructure/Pipeline/InMemoryMetricGatherer.cs
+++ b/Validation.Infrastructure/Pipeline/InMemoryMetricGatherer.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Validation.Infrastructure.Pipeline;
+
+public class InMemoryMetricGatherer : IMetricGatherer
+{
+    private readonly IEnumerable<decimal> _metrics;
+
+    public InMemoryMetricGatherer(IEnumerable<decimal> metrics)
+    {
+        _metrics = metrics;
+    }
+
+    public Task<IEnumerable<decimal>> GatherMetricsAsync(CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(_metrics);
+    }
+}

--- a/Validation.Infrastructure/Pipeline/InMemorySummarisationService.cs
+++ b/Validation.Infrastructure/Pipeline/InMemorySummarisationService.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Validation.Infrastructure.Pipeline;
+
+public class InMemorySummarisationService : ISummarisationService
+{
+    public Task<decimal> SummariseAsync(IEnumerable<decimal> metrics, CancellationToken cancellationToken = default)
+    {
+        var data = metrics.ToList();
+        decimal result = data.Count == 0 ? 0m : data.Average();
+        return Task.FromResult(result);
+    }
+}

--- a/Validation.Infrastructure/Pipeline/PipelineOrchestrator.cs
+++ b/Validation.Infrastructure/Pipeline/PipelineOrchestrator.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Validation.Domain.Validation;
+
+namespace Validation.Infrastructure.Pipeline;
+
+public class PipelineOrchestrator
+{
+    private readonly IEnumerable<IMetricGatherer> _gatherers;
+    private readonly ISummarisationService _summarisationService;
+    private readonly SummarisationValidator _validator = new();
+    private readonly List<decimal> _committed = new();
+    private decimal _lastSummary;
+
+    public PipelineOrchestrator(IEnumerable<IMetricGatherer> gatherers, ISummarisationService summarisationService)
+    {
+        _gatherers = gatherers;
+        _summarisationService = summarisationService;
+    }
+
+    public async Task<IEnumerable<decimal>> GatherDataAsync(CancellationToken cancellationToken = default)
+    {
+        var results = new List<decimal>();
+        foreach (var gatherer in _gatherers)
+        {
+            var data = await gatherer.GatherMetricsAsync(cancellationToken);
+            if (data != null) results.AddRange(data);
+        }
+        return results;
+    }
+
+    public Task<decimal> SummariseAsync(IEnumerable<decimal> metrics, CancellationToken cancellationToken = default)
+    {
+        return _summarisationService.SummariseAsync(metrics, cancellationToken);
+    }
+
+    public bool Validate(decimal previous, decimal current)
+    {
+        var plan = new ValidationPlan(_ => current, ThresholdType.RawDifference, 10);
+        return _validator.Validate(previous, current, plan);
+    }
+
+    public Task CommitResultsAsync(decimal summary, CancellationToken cancellationToken = default)
+    {
+        _committed.Add(summary);
+        _lastSummary = summary;
+        return Task.CompletedTask;
+    }
+
+    public async Task RunPipelineAsync(CancellationToken cancellationToken = default)
+    {
+        var data = await GatherDataAsync(cancellationToken);
+        var summary = await SummariseAsync(data, cancellationToken);
+        if (Validate(_lastSummary, summary))
+        {
+            await CommitResultsAsync(summary, cancellationToken);
+        }
+    }
+
+    public IReadOnlyList<decimal> CommittedResults => _committed.AsReadOnly();
+}

--- a/Validation.Infrastructure/Pipeline/PipelineWorker.cs
+++ b/Validation.Infrastructure/Pipeline/PipelineWorker.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+
+namespace Validation.Infrastructure.Pipeline;
+
+public class PipelineWorker : BackgroundService
+{
+    private readonly PipelineOrchestrator _orchestrator;
+    private readonly TimeSpan _delay;
+
+    public PipelineWorker(PipelineOrchestrator orchestrator)
+    {
+        _orchestrator = orchestrator;
+        _delay = TimeSpan.FromSeconds(30);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await _orchestrator.RunPipelineAsync(stoppingToken);
+            await Task.Delay(_delay, stoppingToken);
+        }
+    }
+}

--- a/Validation.Tests/PipelineOrchestratorTests.cs
+++ b/Validation.Tests/PipelineOrchestratorTests.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Validation.Infrastructure.Pipeline;
+using Xunit;
+
+namespace Validation.Tests;
+
+public class PipelineOrchestratorTests
+{
+    [Fact]
+    public async Task RunPipeline_Commits_When_Validation_Passes()
+    {
+        var gatherers = new List<IMetricGatherer>
+        {
+            new InMemoryMetricGatherer(new[] {1m, 2m, 3m})
+        };
+        var summary = new InMemorySummarisationService();
+        var orchestrator = new PipelineOrchestrator(gatherers, summary);
+
+        await orchestrator.RunPipelineAsync();
+
+        Assert.Single(orchestrator.CommittedResults);
+        Assert.Equal(2m, orchestrator.CommittedResults[0]);
+    }
+
+    [Fact]
+    public async Task RunPipeline_DoesNotCommit_When_Validation_Fails()
+    {
+        var gatherers = new List<IMetricGatherer>
+        {
+            new InMemoryMetricGatherer(new[] {20m})
+        };
+        var summary = new InMemorySummarisationService();
+        var orchestrator = new PipelineOrchestrator(gatherers, summary);
+
+        await orchestrator.RunPipelineAsync();
+
+        Assert.Empty(orchestrator.CommittedResults);
+    }
+}


### PR DESCRIPTION
## Summary
- add `PipelineOrchestrator` with gather, summarise, validate and commit
- provide in-memory metric gatherer and summariser
- host orchestrator through `PipelineWorker`
- expose DI helper `AddMetricsPipeline`
- test orchestrator pipeline behaviour

## Testing
- `dotnet build`
- `dotnet test --filter FullyQualifiedName~PipelineOrchestratorTests`
- `dotnet test` *(fails: DeletePipelineReliabilityTests and others)*

------
https://chatgpt.com/codex/tasks/task_e_688c92849d748330b0fba8721d98d5b7