### PR TITLE
Implement metrics pipeline orchestrator and worker

### DIFF
--- a/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
+++ b/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
@@ -46,8 +46,10 @@ public static class ServiceCollectionExtensions
         services.AddMassTransit(x =>
         {
             // Register the enhanced consumers
-            x.AddConsumer<ReliableDeleteValidationConsumer<Validation.Domain.Entities.Item>>(typeof(ReliabilityConsumerDefinition<>));
-            x.AddConsumer<ReliableDeleteValidationConsumer<Validation.Domain.Entities.NannyRecord>>(typeof(ReliabilityConsumerDefinition<>));
+            x.AddConsumer<ReliableDeleteValidationConsumer<Validation.Domain.Entities.Item>>(
+                typeof(ReliabilityConsumerDefinition<ReliableDeleteValidationConsumer<Validation.Domain.Entities.Item>>));
+            x.AddConsumer<ReliableDeleteValidationConsumer<Validation.Domain.Entities.NannyRecord>>(
+                typeof(ReliabilityConsumerDefinition<ReliableDeleteValidationConsumer<Validation.Domain.Entities.NannyRecord>>));
             
             configureBus?.Invoke(x);
         });

--- a/Validation.Infrastructure/EnhancedManualValidatorService.cs
+++ b/Validation.Infrastructure/EnhancedManualValidatorService.cs
@@ -150,6 +150,7 @@ public class EnhancedManualValidatorService : IEnhancedManualValidatorService
                             _logger.LogError(ex, "Error executing named rule {RuleName} for type {Type}",
                                 kvp.Key, type.Name);
                             result.IsValid = false;
+                            result.FailedRules.Add(kvp.Key);
                             result.Errors.Add($"Rule '{kvp.Key}' execution failed: {ex.Message}");
                         }
                     }

--- a/Validation.Infrastructure/Metrics/Pipeline/IMetricGatherer.cs
+++ b/Validation.Infrastructure/Metrics/Pipeline/IMetricGatherer.cs
@@ -1,0 +1,6 @@
+namespace Validation.Infrastructure.Metrics.Pipeline;
+
+public interface IMetricGatherer
+{
+    Task<IEnumerable<double>> GatherAsync(CancellationToken cancellationToken = default);
+}

--- a/Validation.Infrastructure/Metrics/Pipeline/ISummarisationService.cs
+++ b/Validation.Infrastructure/Metrics/Pipeline/ISummarisationService.cs
@@ -1,0 +1,8 @@
+namespace Validation.Infrastructure.Metrics.Pipeline;
+
+public interface ISummarisationService
+{
+    Task<double> SummariseAsync(IEnumerable<double> metrics, CancellationToken cancellationToken = default);
+    Task<bool> ValidateAsync(double summary, CancellationToken cancellationToken = default);
+    Task CommitAsync(double summary, CancellationToken cancellationToken = default);
+}

--- a/Validation.Infrastructure/Metrics/Pipeline/InMemoryMetricGatherer.cs
+++ b/Validation.Infrastructure/Metrics/Pipeline/InMemoryMetricGatherer.cs
@@ -1,0 +1,20 @@
+using System.Collections.Concurrent;
+
+namespace Validation.Infrastructure.Metrics.Pipeline;
+
+public class InMemoryMetricGatherer : IMetricGatherer
+{
+    private readonly ConcurrentQueue<double> _metrics = new();
+
+    public void AddMetric(double value) => _metrics.Enqueue(value);
+
+    public Task<IEnumerable<double>> GatherAsync(CancellationToken cancellationToken = default)
+    {
+        var list = new List<double>();
+        while (_metrics.TryDequeue(out var value))
+        {
+            list.Add(value);
+        }
+        return Task.FromResult<IEnumerable<double>>(list);
+    }
+}

--- a/Validation.Infrastructure/Metrics/Pipeline/InMemorySummarisationService.cs
+++ b/Validation.Infrastructure/Metrics/Pipeline/InMemorySummarisationService.cs
@@ -1,0 +1,23 @@
+namespace Validation.Infrastructure.Metrics.Pipeline;
+
+public class InMemorySummarisationService : ISummarisationService
+{
+    public List<double> Committed { get; } = new();
+
+    public Task<double> SummariseAsync(IEnumerable<double> metrics, CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(metrics.Any() ? metrics.Average() : 0);
+    }
+
+    public Task<bool> ValidateAsync(double summary, CancellationToken cancellationToken = default)
+    {
+        // Simple validation: always true
+        return Task.FromResult(true);
+    }
+
+    public Task CommitAsync(double summary, CancellationToken cancellationToken = default)
+    {
+        Committed.Add(summary);
+        return Task.CompletedTask;
+    }
+}

--- a/Validation.Infrastructure/Metrics/Pipeline/MetricsPipelineOptions.cs
+++ b/Validation.Infrastructure/Metrics/Pipeline/MetricsPipelineOptions.cs
@@ -1,0 +1,6 @@
+namespace Validation.Infrastructure.Metrics.Pipeline;
+
+public class MetricsPipelineOptions
+{
+    public TimeSpan RunInterval { get; set; } = TimeSpan.FromSeconds(30);
+}

--- a/Validation.Infrastructure/Metrics/Pipeline/MetricsPipelineServiceCollectionExtensions.cs
+++ b/Validation.Infrastructure/Metrics/Pipeline/MetricsPipelineServiceCollectionExtensions.cs
@@ -1,0 +1,18 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Validation.Infrastructure.Metrics.Pipeline;
+
+public static class MetricsPipelineServiceCollectionExtensions
+{
+    public static IServiceCollection AddMetricsPipeline(this IServiceCollection services, Action<MetricsPipelineOptions>? configure = null)
+    {
+        var options = new MetricsPipelineOptions();
+        configure?.Invoke(options);
+        services.AddSingleton(options);
+        services.AddSingleton<IMetricGatherer, InMemoryMetricGatherer>();
+        services.AddSingleton<ISummarisationService, InMemorySummarisationService>();
+        services.AddSingleton<PipelineOrchestrator>();
+        services.AddHostedService<PipelineWorker>();
+        return services;
+    }
+}

--- a/Validation.Infrastructure/Metrics/Pipeline/PipelineOrchestrator.cs
+++ b/Validation.Infrastructure/Metrics/Pipeline/PipelineOrchestrator.cs
@@ -1,0 +1,29 @@
+namespace Validation.Infrastructure.Metrics.Pipeline;
+
+public class PipelineOrchestrator
+{
+    private readonly IEnumerable<IMetricGatherer> _gatherers;
+    private readonly ISummarisationService _summarisation;
+
+    public PipelineOrchestrator(IEnumerable<IMetricGatherer> gatherers, ISummarisationService summarisation)
+    {
+        _gatherers = gatherers;
+        _summarisation = summarisation;
+    }
+
+    public async Task RunAsync(CancellationToken cancellationToken = default)
+    {
+        var allMetrics = new List<double>();
+        foreach (var gatherer in _gatherers)
+        {
+            var metrics = await gatherer.GatherAsync(cancellationToken);
+            allMetrics.AddRange(metrics);
+        }
+
+        var summary = await _summarisation.SummariseAsync(allMetrics, cancellationToken);
+        if (await _summarisation.ValidateAsync(summary, cancellationToken))
+        {
+            await _summarisation.CommitAsync(summary, cancellationToken);
+        }
+    }
+}

--- a/Validation.Infrastructure/Metrics/Pipeline/PipelineWorker.cs
+++ b/Validation.Infrastructure/Metrics/Pipeline/PipelineWorker.cs
@@ -1,0 +1,25 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace Validation.Infrastructure.Metrics.Pipeline;
+
+public class PipelineWorker : BackgroundService
+{
+    private readonly PipelineOrchestrator _orchestrator;
+    private readonly MetricsPipelineOptions _options;
+
+    public PipelineWorker(PipelineOrchestrator orchestrator, IOptions<MetricsPipelineOptions> options)
+    {
+        _orchestrator = orchestrator;
+        _options = options.Value;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await _orchestrator.RunAsync(stoppingToken);
+            await Task.Delay(_options.RunInterval, stoppingToken);
+        }
+    }
+}

--- a/Validation.Tests/PipelineOrchestratorTests.cs
+++ b/Validation.Tests/PipelineOrchestratorTests.cs
@@ -1,0 +1,95 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Validation.Infrastructure.Metrics.Pipeline;
+using Xunit;
+
+namespace Validation.Tests;
+
+public class PipelineOrchestratorTests
+{
+    private class TestGatherer : IMetricGatherer
+    {
+        private readonly IEnumerable<double> _data;
+        public bool Called { get; private set; }
+        public TestGatherer(IEnumerable<double> data) => _data = data;
+        public Task<IEnumerable<double>> GatherAsync(CancellationToken cancellationToken = default)
+        {
+            Called = true;
+            return Task.FromResult(_data);
+        }
+    }
+
+    private class TestSummarisation : ISummarisationService
+    {
+        public bool Summarised { get; protected set; }
+        public bool Validated { get; protected set; }
+        public bool Committed { get; protected set; }
+        public double Summary { get; protected set; }
+        public virtual Task<double> SummariseAsync(IEnumerable<double> metrics, CancellationToken cancellationToken = default)
+        {
+            Summarised = true;
+            Summary = metrics.Average();
+            return Task.FromResult(Summary);
+        }
+        public virtual Task<bool> ValidateAsync(double summary, CancellationToken cancellationToken = default)
+        {
+            Validated = true;
+            return Task.FromResult(true);
+        }
+        public virtual Task CommitAsync(double summary, CancellationToken cancellationToken = default)
+        {
+            Committed = true;
+            Summary = summary;
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task RunAsync_GathersSummarisesAndCommits()
+    {
+        var gatherers = new[] { new TestGatherer(new[] { 1.0, 2.0 }), new TestGatherer(new[] { 3.0 }) };
+        var summarisation = new TestSummarisation();
+        var orchestrator = new PipelineOrchestrator(gatherers, summarisation);
+
+        await orchestrator.RunAsync();
+
+        Assert.All(gatherers, g => Assert.True(g.Called));
+        Assert.True(summarisation.Summarised);
+        Assert.True(summarisation.Validated);
+        Assert.True(summarisation.Committed);
+        Assert.Equal(2.0, summarisation.Summary);
+    }
+
+    [Fact]
+    public async Task RunAsync_DoesNotCommitWhenValidationFails()
+    {
+        var gatherers = new[] { new TestGatherer(new[] { 1.0 }) };
+        var summarisation = new TestSummarisationOverrideValidate(false);
+        var orchestrator = new PipelineOrchestrator(gatherers, summarisation);
+
+        await orchestrator.RunAsync();
+
+        Assert.True(summarisation.Summarised);
+        Assert.True(summarisation.Validated);
+        Assert.False(summarisation.Committed);
+    }
+
+    private class TestSummarisationOverrideValidate : TestSummarisation
+    {
+        private readonly bool _validate;
+        public TestSummarisationOverrideValidate(bool validate) => _validate = validate;
+        public override Task<bool> ValidateAsync(double summary, CancellationToken cancellationToken = default)
+        {
+            Validated = true;
+            return Task.FromResult(_validate);
+        }
+        public override Task CommitAsync(double summary, CancellationToken cancellationToken = default)
+        {
+            Committed = true;
+            Summary = summary;
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- fix reliability policy and validator service tests
- add a metrics pipeline with gatherers and summarisation service
- add background worker and DI extension
- unit tests for pipeline orchestrator

## Testing
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_688c92849d748330b0fba8721d98d5b7