### PR TITLE
Switch consumers to unified messages

### DIFF
--- a/Validation.Domain/Events/DeleteRequested.cs
+++ b/Validation.Domain/Events/DeleteRequested.cs
@@ -1,3 +1,5 @@
+using System;
 namespace Validation.Domain.Events;
 
+[Obsolete("Use ValidationFlow.Messages.DeleteRequested instead")]
 public record DeleteRequested(Guid Id);

--- a/Validation.Domain/Events/DeleteValidation.cs
+++ b/Validation.Domain/Events/DeleteValidation.cs
@@ -1,5 +1,8 @@
+using System;
 namespace Validation.Domain.Events;
 
+[Obsolete("Use ValidationFlow.Messages.DeleteValidated instead")]
 public record DeleteValidated(Guid EntityId, Guid AuditId, string EntityType);
+[Obsolete("Use ValidationFlow.Messages.DeleteRejected instead")]
 public record DeleteRejected(Guid EntityId, Guid AuditId, string Reason, string EntityType);
 public record DeleteValidationFailed(Guid EntityId, string Error, string EntityType);

--- a/Validation.Domain/Events/SaveCommitFault.cs
+++ b/Validation.Domain/Events/SaveCommitFault.cs
@@ -1,3 +1,5 @@
+using System;
 namespace Validation.Domain.Events;
 
+[Obsolete("Use ValidationFlow.Messages.SaveCommitFault instead")]
 public record SaveCommitFault<T>(Guid EntityId, Guid AuditId, string Error);

--- a/Validation.Domain/Events/SaveRequested.Generic.cs
+++ b/Validation.Domain/Events/SaveRequested.Generic.cs
@@ -1,3 +1,5 @@
+using System;
 namespace Validation.Domain.Events;
 
+[Obsolete("Use ValidationFlow.Messages.SaveRequested instead")]
 public record SaveRequested<T>(T Entity, string? App = null);

--- a/Validation.Domain/Events/SaveRequested.cs
+++ b/Validation.Domain/Events/SaveRequested.cs
@@ -1,3 +1,5 @@
+using System;
 namespace Validation.Domain.Events;
 
+[Obsolete("Use ValidationFlow.Messages.SaveRequested instead")]
 public record SaveRequested(Guid Id);

--- a/Validation.Domain/Events/SaveValidated.Generic.cs
+++ b/Validation.Domain/Events/SaveValidated.Generic.cs
@@ -1,3 +1,5 @@
+using System;
 namespace Validation.Domain.Events;
 
+[Obsolete("Use ValidationFlow.Messages.SaveValidated instead")]
 public record SaveValidated<T>(Guid EntityId, Guid AuditId);

--- a/Validation.Domain/Events/SaveValidated.cs
+++ b/Validation.Domain/Events/SaveValidated.cs
@@ -1,3 +1,5 @@
+using System;
 namespace Validation.Domain.Events;
 
+[Obsolete("Use ValidationFlow.Messages.SaveValidated instead")]
 public record SaveValidated(Guid Id, bool IsValid, decimal Metric);

--- a/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
+++ b/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
@@ -217,7 +217,7 @@ public static class ValidationFlowServiceCollectionExtensions
         services.AddScoped<SummarisationValidator>();
         services.AddMassTransitTestHarness(x =>
         {
-            x.AddConsumer<SaveRequestedConsumer>();
+            x.AddConsumer(typeof(SaveRequestedConsumer<>));
             x.UsingInMemory((context, cfg) => cfg.ConfigureEndpoints(context));
         });
         services.AddLogging(b => b.AddSerilog());

--- a/Validation.Infrastructure/Messaging/DeleteValidationConsumer.cs
+++ b/Validation.Infrastructure/Messaging/DeleteValidationConsumer.cs
@@ -1,11 +1,11 @@
 using MassTransit;
-using Validation.Domain.Events;
+using ValidationFlow.Messages;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.Repositories;
 
 namespace Validation.Infrastructure.Messaging;
 
-public class DeleteValidationConsumer<T> : IConsumer<DeleteRequested>
+public class DeleteValidationConsumer<T> : IConsumer<DeleteRequested<T>>
 {
     private readonly IValidationPlanProvider _planProvider;
     private readonly SummarisationValidator _validator;
@@ -16,7 +16,7 @@ public class DeleteValidationConsumer<T> : IConsumer<DeleteRequested>
         _validator = validator;
     }
 
-    public Task Consume(ConsumeContext<DeleteRequested> context)
+    public Task Consume(ConsumeContext<DeleteRequested<T>> context)
     {
         var rules = _planProvider.GetRules<T>();
         // execute manual rules with zero metrics since delete; actual logic omitted

--- a/Validation.Infrastructure/Messaging/ReliableDeleteValidationConsumer.cs
+++ b/Validation.Infrastructure/Messaging/ReliableDeleteValidationConsumer.cs
@@ -3,14 +3,14 @@ using System.Diagnostics;
 using System.Threading.Tasks;
 using MassTransit;
 using Microsoft.Extensions.Logging;
-using Validation.Domain.Events;
+using ValidationFlow.Messages;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.Reliability;
 using Validation.Infrastructure.Repositories;
 
 namespace Validation.Infrastructure.Messaging;
 
-public class ReliableDeleteValidationConsumer<T> : IConsumer<DeleteRequested>
+public class ReliableDeleteValidationConsumer<T> : IConsumer<DeleteRequested<T>>
 {
     private readonly IValidationPlanProvider _planProvider;
     private readonly SummarisationValidator _validator;
@@ -33,14 +33,14 @@ public class ReliableDeleteValidationConsumer<T> : IConsumer<DeleteRequested>
         _logger = logger;
     }
 
-    public async Task Consume(ConsumeContext<DeleteRequested> context)
+    public async Task Consume(ConsumeContext<DeleteRequested<T>> context)
     {
         using var activity = ActivitySource.StartActivity("DeleteValidation");
-        activity?.SetTag("entity.id", context.Message.Id.ToString());
+        activity?.SetTag("entity.id", context.Message.EntityId.ToString());
         activity?.SetTag("entity.type", typeof(T).Name);
 
         _logger.LogInformation("Starting delete validation for entity {EntityId} of type {EntityType}",
-            context.Message.Id, typeof(T).Name);
+            context.Message.EntityId, typeof(T).Name);
 
         try
         {
@@ -50,7 +50,7 @@ public class ReliableDeleteValidationConsumer<T> : IConsumer<DeleteRequested>
             }, context.CancellationToken);
 
             _logger.LogInformation("Delete validation completed successfully for entity {EntityId}",
-                context.Message.Id);
+                context.Message.EntityId);
         }
         catch (DeletePipelineCircuitOpenException ex)
         {
@@ -58,7 +58,7 @@ public class ReliableDeleteValidationConsumer<T> : IConsumer<DeleteRequested>
                 context.Message.Id);
             
             // Send to dead letter queue or handle graceful degradation
-            await context.Publish(new DeleteValidationFailed(context.Message.Id, "Circuit breaker open", typeof(T).Name),
+            await context.Publish(new DeleteValidationFailed(context.Message.AppName, context.Message.EntityType, context.Message.EntityId, "Circuit breaker open"),
                 context.CancellationToken);
             
             throw;
@@ -66,9 +66,9 @@ public class ReliableDeleteValidationConsumer<T> : IConsumer<DeleteRequested>
         catch (DeletePipelineReliabilityException ex)
         {
             _logger.LogError(ex, "Delete validation failed after all retry attempts for entity {EntityId}",
-                context.Message.Id);
+                context.Message.EntityId);
             
-            await context.Publish(new DeleteValidationFailed(context.Message.Id, ex.Message, typeof(T).Name),
+            await context.Publish(new DeleteValidationFailed(context.Message.AppName, context.Message.EntityType, context.Message.EntityId, ex.Message),
                 context.CancellationToken);
             
             throw;
@@ -78,12 +78,12 @@ public class ReliableDeleteValidationConsumer<T> : IConsumer<DeleteRequested>
     private async Task ValidateDeleteAsync(ConsumeContext<DeleteRequested> context, CancellationToken cancellationToken)
     {
         // Get the last audit record to understand the current state
-        var lastAudit = await _auditRepository.GetLastAsync(context.Message.Id, cancellationToken);
+        var lastAudit = await _auditRepository.GetLastAsync(context.Message.EntityId, cancellationToken);
         
         if (lastAudit == null)
         {
             _logger.LogWarning("No audit record found for entity {EntityId}. Allowing delete.",
-                context.Message.Id);
+                context.Message.EntityId);
         }
 
         // Get validation rules for this entity type
@@ -93,13 +93,13 @@ public class ReliableDeleteValidationConsumer<T> : IConsumer<DeleteRequested>
         var isValid = _validator.Validate(lastAudit?.Metric ?? 0m, 0m, rules);
 
         _logger.LogDebug("Delete validation result for entity {EntityId}: {IsValid}",
-            context.Message.Id, isValid);
+            context.Message.EntityId, isValid);
 
         // Create audit record for the delete operation
         var deleteAudit = new SaveAudit
         {
             Id = Guid.NewGuid(),
-            EntityId = context.Message.Id,
+            EntityId = context.Message.EntityId,
             IsValid = isValid,
             Metric = 0m, // Zero metric for delete operation
             Timestamp = DateTime.UtcNow
@@ -110,12 +110,12 @@ public class ReliableDeleteValidationConsumer<T> : IConsumer<DeleteRequested>
         // Publish validation result
         if (isValid)
         {
-            await context.Publish(new DeleteValidated(context.Message.Id, deleteAudit.Id, typeof(T).Name),
+            await context.Publish(new DeleteValidated<T>(context.Message.AppName, context.Message.EntityType, context.Message.EntityId, true),
                 cancellationToken);
         }
         else
         {
-            await context.Publish(new DeleteRejected(context.Message.Id, deleteAudit.Id, "Validation failed", typeof(T).Name),
+            await context.Publish(new DeleteRejected<T>(context.Message.AppName, context.Message.EntityType, context.Message.EntityId, "Validation failed"),
                 cancellationToken);
         }
     }

--- a/Validation.Infrastructure/Messaging/SaveCommitConsumer.cs
+++ b/Validation.Infrastructure/Messaging/SaveCommitConsumer.cs
@@ -1,5 +1,5 @@
 using MassTransit;
-using Validation.Domain.Events;
+using ValidationFlow.Messages;
 using Validation.Infrastructure.Repositories;
 
 namespace Validation.Infrastructure.Messaging;
@@ -17,15 +17,14 @@ public class SaveCommitConsumer<T> : IConsumer<SaveValidated<T>>
     {
         try
         {
-            var audit = await _repository.GetAsync(context.Message.AuditId, context.CancellationToken);
+            var audit = await _repository.GetLastAsync(context.Message.EntityId, context.CancellationToken);
             if (audit != null)
-            {
                 await _repository.UpdateAsync(audit, context.CancellationToken);
-            }
         }
         catch (Exception ex)
         {
-            await context.Publish(new SaveCommitFault<T>(context.Message.EntityId, context.Message.AuditId, ex.Message));
+            await context.Publish(new SaveCommitFault<T>(context.Message.AppName, context.Message.EntityType,
+                context.Message.EntityId, context.Message.Payload, ex.Message));
         }
     }
 }

--- a/Validation.Infrastructure/Messaging/SaveRequestedConsumer.cs
+++ b/Validation.Infrastructure/Messaging/SaveRequestedConsumer.cs
@@ -1,12 +1,12 @@
 using MassTransit;
-using Validation.Domain.Events;
+using ValidationFlow.Messages;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.Repositories;
 using Validation.Infrastructure;
 
 namespace Validation.Infrastructure.Messaging;
 
-public class SaveRequestedConsumer : IConsumer<SaveRequested>
+public class SaveRequestedConsumer<T> : IConsumer<SaveRequested<T>>
 {
     private readonly ISaveAuditRepository _repository;
     private readonly IValidationRule _rule;
@@ -18,7 +18,7 @@ public class SaveRequestedConsumer : IConsumer<SaveRequested>
         _rule = rule;
     }
 
-    public async Task Consume(ConsumeContext<SaveRequested> context)
+    public async Task Consume(ConsumeContext<SaveRequested<T>> context)
     {
         var metric = new Random().Next(0, 100); // simulate metric
         var isValid = _rule.Validate(_previousMetric, metric);
@@ -26,11 +26,12 @@ public class SaveRequestedConsumer : IConsumer<SaveRequested>
         var audit = new SaveAudit
         {
             Id = Guid.NewGuid(),
-            EntityId = context.Message.Id,
+            EntityId = context.Message.EntityId,
             IsValid = isValid,
             Metric = metric
         };
         await _repository.AddAsync(audit, context.CancellationToken);
-        await context.Publish(new SaveValidated(context.Message.Id, isValid, metric), context.CancellationToken);
+        await context.Publish(new SaveValidated<T>(context.Message.AppName, context.Message.EntityType,
+            context.Message.EntityId, context.Message.Payload, isValid), context.CancellationToken);
     }
 }

--- a/Validation.Infrastructure/Messaging/SaveValidationConsumer.cs
+++ b/Validation.Infrastructure/Messaging/SaveValidationConsumer.cs
@@ -1,11 +1,11 @@
 using MassTransit;
-using Validation.Domain.Events;
+using ValidationFlow.Messages;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.Repositories;
 
 namespace Validation.Infrastructure.Messaging;
 
-public class SaveValidationConsumer<T> : IConsumer<SaveRequested>
+public class SaveValidationConsumer<T> : IConsumer<SaveRequested<T>>
 {
     private readonly IValidationPlanProvider _planProvider;
     private readonly ISaveAuditRepository _repository;
@@ -18,9 +18,9 @@ public class SaveValidationConsumer<T> : IConsumer<SaveRequested>
         _validator = validator;
     }
 
-    public async Task Consume(ConsumeContext<SaveRequested> context)
+    public async Task Consume(ConsumeContext<SaveRequested<T>> context)
     {
-        var last = await _repository.GetLastAsync(context.Message.Id, context.CancellationToken);
+        var last = await _repository.GetLastAsync(context.Message.EntityId, context.CancellationToken);
         var metric = new Random().Next(0, 100);
         var rules = _planProvider.GetRules<T>();
         var isValid = _validator.Validate(last?.Metric ?? 0m, metric, rules);
@@ -28,12 +28,13 @@ public class SaveValidationConsumer<T> : IConsumer<SaveRequested>
         var audit = new SaveAudit
         {
             Id = Guid.NewGuid(),
-            EntityId = context.Message.Id,
+            EntityId = context.Message.EntityId,
             IsValid = isValid,
             Metric = metric
         };
 
         await _repository.AddAsync(audit, context.CancellationToken);
-        await context.Publish(new SaveValidated<T>(context.Message.Id, audit.Id));
+        await context.Publish(new SaveValidated<T>(context.Message.AppName, context.Message.EntityType,
+            context.Message.EntityId, context.Message.Payload, isValid));
     }
 }

--- a/Validation.Infrastructure/Repositories/EventPublishingRepository.cs
+++ b/Validation.Infrastructure/Repositories/EventPublishingRepository.cs
@@ -1,5 +1,5 @@
 using MassTransit;
-using Validation.Domain.Events;
+using ValidationFlow.Messages;
 using Validation.Domain.Repositories;
 
 namespace Validation.Infrastructure.Repositories;
@@ -7,19 +7,24 @@ namespace Validation.Infrastructure.Repositories;
 public class EventPublishingRepository<T> : IEntityRepository<T>
 {
     private readonly IBus _bus;
+    private readonly string _appName;
 
-    public EventPublishingRepository(IBus bus)
+    public EventPublishingRepository(IBus bus, string? appName = null)
     {
         _bus = bus;
+        _appName = appName ?? System.Reflection.Assembly.GetEntryAssembly()?.GetName().Name ?? "Unknown";
     }
 
     public Task SaveAsync(T entity, string? app = null, CancellationToken ct = default)
     {
-        return _bus.Publish(new SaveRequested<T>(entity, app), ct);
+        var appName = app ?? _appName;
+        var entityId = (Guid?)entity?.GetType().GetProperty("Id")?.GetValue(entity) ?? Guid.Empty;
+        return _bus.Publish(new SaveRequested<T>(appName, typeof(T).Name, entityId, entity), ct);
     }
 
     public Task DeleteAsync(Guid id, string? app = null, CancellationToken ct = default)
     {
-        return _bus.Publish(new DeleteRequested(id), ct);
+        var appName = app ?? _appName;
+        return _bus.Publish(new DeleteRequested<T>(appName, typeof(T).Name, id), ct);
     }
 }

--- a/Validation.Tests/EventPublishingRepositoryTests.cs
+++ b/Validation.Tests/EventPublishingRepositoryTests.cs
@@ -1,6 +1,7 @@
 using MassTransit.Testing;
+using System.Linq;
 using Validation.Domain.Entities;
-using Validation.Domain.Events;
+using ValidationFlow.Messages;
 using Validation.Infrastructure.Repositories;
 
 namespace Validation.Tests;
@@ -15,10 +16,13 @@ public class EventPublishingRepositoryTests
         await harness.Start();
         try
         {
-            var repository = new EventPublishingRepository<Item>(harness.Bus);
+            var repository = new EventPublishingRepository<Item>(harness.Bus, "TestApp");
             var item = new Item(5);
             await repository.SaveAsync(item);
             Assert.True(await harness.Published.Any<SaveRequested<Item>>());
+            var published = harness.Published.Select<SaveRequested<Item>>().First().Context.Message;
+            Assert.Equal("TestApp", published.AppName);
+            Assert.Equal("Item", published.EntityType);
         }
         finally
         {
@@ -34,10 +38,13 @@ public class EventPublishingRepositoryTests
         await harness.Start();
         try
         {
-            var repository = new EventPublishingRepository<Item>(harness.Bus);
+            var repository = new EventPublishingRepository<Item>(harness.Bus, "TestApp");
             var id = Guid.NewGuid();
             await repository.DeleteAsync(id);
-            Assert.True(await harness.Published.Any<DeleteRequested>());
+            Assert.True(await harness.Published.Any<DeleteRequested<Item>>());
+            var published = harness.Published.Select<DeleteRequested<Item>>().First().Context.Message;
+            Assert.Equal("TestApp", published.AppName);
+            Assert.Equal("Item", published.EntityType);
         }
         finally
         {

--- a/Validation.Tests/SaveCommitConsumerTests.cs
+++ b/Validation.Tests/SaveCommitConsumerTests.cs
@@ -1,6 +1,6 @@
 using MassTransit;
 using MassTransit.Testing;
-using Validation.Domain.Events;
+using ValidationFlow.Messages;
 using Validation.Infrastructure.Messaging;
 using Validation.Infrastructure;
 using Validation.Infrastructure.Repositories;
@@ -31,7 +31,7 @@ public class SaveCommitConsumerTests
         await harness.Start();
         try
         {
-            await harness.InputQueueSendEndpoint.Send(new SaveValidated<Item>(Guid.NewGuid(), Guid.NewGuid()));
+            await harness.InputQueueSendEndpoint.Send(new SaveValidated<Item>("TestApp", "Item", Guid.NewGuid(), new Item(1), true));
 
             Assert.True(await harness.Published.Any<SaveCommitFault<Item>>());
         }

--- a/Validation.Tests/SavePipelineTests.cs
+++ b/Validation.Tests/SavePipelineTests.cs
@@ -1,7 +1,7 @@
 using MassTransit;
 using MassTransit.Testing;
 using Validation.Domain.Entities;
-using Validation.Domain.Events;
+using ValidationFlow.Messages;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.Messaging;
 using Validation.Infrastructure.Repositories;
@@ -68,7 +68,7 @@ public class SavePipelineTests
         await harness.Start();
         try
         {
-            await harness.InputQueueSendEndpoint.Send(new SaveRequested(Guid.NewGuid()));
+            await harness.InputQueueSendEndpoint.Send(new SaveRequested<Item>("TestApp", "Item", Guid.NewGuid(), new Item(1)));
 
             Assert.True(await harness.Published.Any<SaveValidated<Item>>());
             Assert.False(await harness.Published.Any<SaveCommitFault<Item>>());
@@ -90,7 +90,7 @@ public class SavePipelineTests
         await harness.Start();
         try
         {
-            await harness.InputQueueSendEndpoint.Send(new SaveRequested(Guid.NewGuid()));
+            await harness.InputQueueSendEndpoint.Send(new SaveRequested<Item>("TestApp", "Item", Guid.NewGuid(), new Item(1)));
 
             Assert.True(await harness.Published.Any<SaveCommitFault<Item>>());
         }
@@ -110,9 +110,9 @@ public class SavePipelineTests
         await harness.Start();
         try
         {
-            await harness.InputQueueSendEndpoint.Send(new SaveRequested(Guid.NewGuid()));
+            await harness.InputQueueSendEndpoint.Send(new SaveRequested<Item>("TestApp", "Item", Guid.NewGuid(), new Item(1)));
 
-            Assert.True(await validationConsumer.Consumed.Any<SaveRequested>());
+            Assert.True(await validationConsumer.Consumed.Any<SaveRequested<Item>>());
             Assert.True(await harness.Published.Any<SaveValidated<Item>>());
         }
         finally

--- a/Validation.Tests/SaveValidationConsumerTests.cs
+++ b/Validation.Tests/SaveValidationConsumerTests.cs
@@ -1,6 +1,6 @@
 using MassTransit;
 using MassTransit.Testing;
-using Validation.Domain.Events;
+using ValidationFlow.Messages;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.Messaging;
 using Validation.Domain.Entities;
@@ -28,7 +28,7 @@ public class SaveValidationConsumerTests
         await harness.Start();
         try
         {
-            await harness.InputQueueSendEndpoint.Send(new SaveRequested(Guid.NewGuid()));
+            await harness.InputQueueSendEndpoint.Send(new SaveRequested<Item>("TestApp", "Item", Guid.NewGuid(), new Item(1))); 
 
             Assert.True(await harness.Published.Any<SaveValidated<Item>>());
         }

--- a/Validation.Tests/ValidationFlowIntegrationTests.cs
+++ b/Validation.Tests/ValidationFlowIntegrationTests.cs
@@ -1,6 +1,7 @@
 using MassTransit.Testing;
 using Microsoft.Extensions.DependencyInjection;
-using Validation.Domain.Events;
+using ValidationFlow.Messages;
+using Validation.Domain.Entities;
 using Validation.Infrastructure.Messaging;
 using MassTransit;
 using Validation.Domain.Validation;
@@ -14,7 +15,7 @@ public class ValidationFlowIntegrationTests
     public async Task Save_requested_triggers_validated_event_and_audit_saved()
     {
         var services = new ServiceCollection();
-        services.AddMassTransitTestHarness(cfg => cfg.AddConsumer<SaveRequestedConsumer>());
+        services.AddMassTransitTestHarness(cfg => cfg.AddConsumer<SaveRequestedConsumer<Item>>());
         services.AddValidationFlow<AlwaysValidRule>(opts =>
         {
             opts.SetupDatabase<TestDbContext>("flowtest");
@@ -27,9 +28,8 @@ public class ValidationFlowIntegrationTests
         {
             using var scope = provider.CreateScope();
             var publish = scope.ServiceProvider.GetRequiredService<IPublishEndpoint>();
-            await publish.Publish(new SaveRequested(Guid.NewGuid()));
-
-            Assert.True(await harness.Published.Any<SaveValidated>());
+            await publish.Publish(new SaveRequested<Item>("TestApp", "Item", Guid.NewGuid(), new Item(1)));
+            Assert.True(await harness.Published.Any<SaveValidated<Item>>());
             var ctx = scope.ServiceProvider.GetRequiredService<TestDbContext>();
             Assert.Equal(1, ctx.SaveAudits.Count());
         }

--- a/Validation.Tests/ValidationWorkflowTests.cs
+++ b/Validation.Tests/ValidationWorkflowTests.cs
@@ -1,8 +1,9 @@
 using MassTransit;
 using MassTransit.Testing;
-using Validation.Domain.Events;
+using ValidationFlow.Messages;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.Messaging;
+using Validation.Domain.Entities;
 
 namespace Validation.Tests;
 
@@ -13,16 +14,16 @@ public class ValidationWorkflowTests
     {
         var repository = new InMemorySaveAuditRepository();
         var rule = new RawDifferenceRule(100); // always valid
-        var consumer = new SaveRequestedConsumer(repository, rule);
+        var consumer = new SaveRequestedConsumer<Item>(repository, rule);
 
         var harness = new InMemoryTestHarness();
         var consumerHarness = harness.Consumer(() => consumer);
         await harness.Start();
         try
         {
-            await harness.InputQueueSendEndpoint.Send(new SaveRequested(Guid.NewGuid()));
-            Assert.True(await harness.Consumed.Any<SaveRequested>());
-            Assert.True(await consumerHarness.Consumed.Any<SaveRequested>());
+            await harness.InputQueueSendEndpoint.Send(new SaveRequested<Item>("TestApp", "Item", Guid.NewGuid(), new Item(1)));
+            Assert.True(await harness.Consumed.Any<SaveRequested<Item>>());
+            Assert.True(await consumerHarness.Consumed.Any<SaveRequested<Item>>());
             Assert.Single(repository.Audits);
         }
         finally


### PR DESCRIPTION
## Summary
- replace domain events with ValidationFlow.Messages and deprecate old types
- update event publishing repository to include AppName and EntityType
- refactor consumers for generic unified message types
- adjust tests for new messages

## Testing
- `dotnet test --no-build --framework net8.0` *(fails: DeletePipelineReliabilityTests, UnifiedValidationSystemTests, EnhancedManualValidatorServiceTests)*

------
https://chatgpt.com/codex/tasks/task_e_688c927e77608330b8dcc27a320a3173