### PR TITLE
Add commit consumer helpers

### DIFF
--- a/UNIFIED_VALIDATION_SYSTEM.md
+++ b/UNIFIED_VALIDATION_SYSTEM.md
@@ -200,6 +200,14 @@ services.AddSetupValidation()
     .Build();
 ```
 
+### Explicit Commit Registration
+
+```csharp
+// Manually register commit consumers
+services.AddSaveCommit<Item>();
+services.AddDeleteCommit<Item>();
+```
+
 ### Event Handling
 
 ```csharp

--- a/Validation.Domain/Events/DeleteCommitFault.cs
+++ b/Validation.Domain/Events/DeleteCommitFault.cs
@@ -1,0 +1,3 @@
+namespace Validation.Domain.Events;
+
+public record DeleteCommitFault<T>(Guid EntityId, Guid AuditId, string Error);

--- a/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
+++ b/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
@@ -107,6 +107,28 @@ public static class ServiceCollectionExtensions
         return services;
     }
 
+    public static IServiceCollection AddSaveCommit<T>(this IServiceCollection services)
+    {
+        services.AddScoped<SaveCommitConsumer<T>>();
+        services.AddMassTransit(x =>
+        {
+            x.AddConsumer<SaveCommitConsumer<T>>();
+            x.UsingInMemory((context, cfg) => cfg.ConfigureEndpoints(context));
+        });
+        return services;
+    }
+
+    public static IServiceCollection AddDeleteCommit<T>(this IServiceCollection services)
+    {
+        services.AddScoped<DeleteCommitConsumer<T>>();
+        services.AddMassTransit(x =>
+        {
+            x.AddConsumer<DeleteCommitConsumer<T>>();
+            x.UsingInMemory((context, cfg) => cfg.ConfigureEndpoints(context));
+        });
+        return services;
+    }
+
     public static IServiceCollection AddValidationFlows(this IServiceCollection services, IEnumerable<ValidationFlowConfig> configs)
     {
         // Set up validation plan provider with configurations

--- a/Validation.Infrastructure/Messaging/DeleteCommitConsumer.cs
+++ b/Validation.Infrastructure/Messaging/DeleteCommitConsumer.cs
@@ -1,0 +1,27 @@
+using MassTransit;
+using Validation.Domain.Events;
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Infrastructure.Messaging;
+
+public class DeleteCommitConsumer<T> : IConsumer<DeleteValidated>
+{
+    private readonly ISaveAuditRepository _repository;
+
+    public DeleteCommitConsumer(ISaveAuditRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task Consume(ConsumeContext<DeleteValidated> context)
+    {
+        try
+        {
+            await _repository.DeleteAsync(context.Message.AuditId, context.CancellationToken);
+        }
+        catch (Exception ex)
+        {
+            await context.Publish(new DeleteCommitFault<T>(context.Message.EntityId, context.Message.AuditId, ex.Message));
+        }
+    }
+}

--- a/Validation.Tests/AddCommitHelpersTests.cs
+++ b/Validation.Tests/AddCommitHelpersTests.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.DependencyInjection;
+using Validation.Domain.Entities;
+using Validation.Infrastructure.DI;
+using Validation.Infrastructure.Messaging;
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Tests;
+
+public class AddCommitHelpersTests
+{
+    [Fact]
+    public void AddSaveCommit_registers_consumer()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ISaveAuditRepository, InMemorySaveAuditRepository>();
+        services.AddSaveCommit<Item>();
+
+        using var provider = services.BuildServiceProvider();
+        Assert.NotNull(provider.GetService<SaveCommitConsumer<Item>>());
+    }
+
+    [Fact]
+    public void AddDeleteCommit_registers_consumer()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ISaveAuditRepository, InMemorySaveAuditRepository>();
+        services.AddDeleteCommit<Item>();
+
+        using var provider = services.BuildServiceProvider();
+        Assert.NotNull(provider.GetService<DeleteCommitConsumer<Item>>());
+    }
+}


### PR DESCRIPTION
## Summary
- add DeleteCommitConsumer and DeleteCommitFault domain event
- register Save/Delete commit consumers via AddSaveCommit<T>/AddDeleteCommit<T>
- document explicit commit registration
- test DI helpers for commit consumers

## Testing
- `dotnet test Validation.Tests/Validation.Tests.csproj -v minimal` *(fails: Retryable failure)*

------
https://chatgpt.com/codex/tasks/task_e_688c9276d5888330be7bb1d43eae8c6a