### PR TITLE
Add commit consumer registration helpers

### DIFF
--- a/UNIFIED_VALIDATION_SYSTEM.md
+++ b/UNIFIED_VALIDATION_SYSTEM.md
@@ -200,6 +200,14 @@ services.AddSetupValidation()
     .Build();
 ```
 
+### Explicit Commit Registration
+
+```csharp
+// Manually register commit consumers
+services.AddSaveCommit<Item>();
+services.AddDeleteCommit<Item>();
+```
+
 ### Event Handling
 
 ```csharp

--- a/Validation.Domain/Events/DeleteCommitFault.cs
+++ b/Validation.Domain/Events/DeleteCommitFault.cs
@@ -1,0 +1,3 @@
+namespace Validation.Domain.Events;
+
+public record DeleteCommitFault<T>(Guid EntityId, string Error);

--- a/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
+++ b/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
@@ -107,6 +107,42 @@ public static class ServiceCollectionExtensions
         return services;
     }
 
+    public static IServiceCollection AddSaveCommit<T>(this IServiceCollection services, string? endpointName = null)
+    {
+        services.AddScoped<SaveCommitConsumer<T>>();
+        services.AddMassTransit(x =>
+        {
+            x.AddConsumer<SaveCommitConsumer<T>>();
+            x.UsingInMemory((context, cfg) =>
+            {
+                cfg.ReceiveEndpoint(endpointName ?? $"save-{typeof(T).Name.ToLowerInvariant()}-commit", e =>
+                {
+                    e.ConfigureConsumer<SaveCommitConsumer<T>>(context);
+                });
+            });
+        });
+
+        return services;
+    }
+
+    public static IServiceCollection AddDeleteCommit<T>(this IServiceCollection services, string? endpointName = null)
+    {
+        services.AddScoped<DeleteCommitConsumer<T>>();
+        services.AddMassTransit(x =>
+        {
+            x.AddConsumer<DeleteCommitConsumer<T>>();
+            x.UsingInMemory((context, cfg) =>
+            {
+                cfg.ReceiveEndpoint(endpointName ?? $"delete-{typeof(T).Name.ToLowerInvariant()}-commit", e =>
+                {
+                    e.ConfigureConsumer<DeleteCommitConsumer<T>>(context);
+                });
+            });
+        });
+
+        return services;
+    }
+
     public static IServiceCollection AddValidationFlows(this IServiceCollection services, IEnumerable<ValidationFlowConfig> configs)
     {
         // Set up validation plan provider with configurations

--- a/Validation.Infrastructure/Messaging/DeleteCommitConsumer.cs
+++ b/Validation.Infrastructure/Messaging/DeleteCommitConsumer.cs
@@ -1,0 +1,27 @@
+using MassTransit;
+using Validation.Domain.Events;
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Infrastructure.Messaging;
+
+public class DeleteCommitConsumer<T> : IConsumer<DeleteValidated>
+{
+    private readonly ISaveAuditRepository _repository;
+
+    public DeleteCommitConsumer(ISaveAuditRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task Consume(ConsumeContext<DeleteValidated> context)
+    {
+        try
+        {
+            await _repository.DeleteAsync(context.Message.AuditId, context.CancellationToken);
+        }
+        catch (Exception ex)
+        {
+            await context.Publish(new DeleteCommitFault<T>(context.Message.EntityId, ex.Message));
+        }
+    }
+}

--- a/Validation.Tests/AddCommitConsumersTests.cs
+++ b/Validation.Tests/AddCommitConsumersTests.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.DependencyInjection;
+using Validation.Domain.Entities;
+using Validation.Infrastructure.DI;
+using Validation.Infrastructure.Messaging;
+using Xunit;
+
+namespace Validation.Tests;
+
+public class AddCommitConsumersTests
+{
+    [Fact]
+    public void AddSaveCommit_registers_consumer()
+    {
+        var services = new ServiceCollection();
+        services.AddSaveCommit<Item>();
+
+        using var provider = services.BuildServiceProvider();
+        var consumer = provider.GetService<SaveCommitConsumer<Item>>();
+        Assert.NotNull(consumer);
+    }
+
+    [Fact]
+    public void AddDeleteCommit_registers_consumer()
+    {
+        var services = new ServiceCollection();
+        services.AddDeleteCommit<Item>();
+
+        using var provider = services.BuildServiceProvider();
+        var consumer = provider.GetService<DeleteCommitConsumer<Item>>();
+        Assert.NotNull(consumer);
+    }
+}


### PR DESCRIPTION
## Summary
- add DeleteCommitConsumer and DeleteCommitFault message
- add AddSaveCommit and AddDeleteCommit service helpers
- document explicit commit registration
- unit test new DI helpers

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: missing .NET 8 runtime)*

------
https://chatgpt.com/codex/tasks/task_e_688c9276d5888330be7bb1d43eae8c6a