### PR TITLE
Add sequence validator

### DIFF
--- a/Validation.Domain/IApplicationNameProvider.cs
+++ b/Validation.Domain/IApplicationNameProvider.cs
@@ -1,0 +1,6 @@
+namespace Validation.Domain;
+
+public interface IApplicationNameProvider
+{
+    string ApplicationName { get; }
+}

--- a/Validation.Domain/IEntityIdProvider.cs
+++ b/Validation.Domain/IEntityIdProvider.cs
@@ -1,0 +1,10 @@
+namespace Validation.Domain;
+
+public interface IEntityIdProvider
+{
+    /// <summary>
+    /// Returns a stable discriminator key for audit/sequence validation.
+    /// Implementations must never return null or empty.
+    /// </summary>
+    string GetId<T>(T entity);
+}

--- a/Validation.Infrastructure/EnhancedManualValidatorService.cs
+++ b/Validation.Infrastructure/EnhancedManualValidatorService.cs
@@ -150,6 +150,7 @@ public class EnhancedManualValidatorService : IEnhancedManualValidatorService
                             _logger.LogError(ex, "Error executing named rule {RuleName} for type {Type}",
                                 kvp.Key, type.Name);
                             result.IsValid = false;
+                            result.FailedRules.Add(kvp.Key);
                             result.Errors.Add($"Rule '{kvp.Key}' execution failed: {ex.Message}");
                         }
                     }

--- a/Validation.Infrastructure/Reliability/DeletePipelineReliabilityPolicy.cs
+++ b/Validation.Infrastructure/Reliability/DeletePipelineReliabilityPolicy.cs
@@ -51,38 +51,33 @@ public class DeletePipelineReliabilityPolicy
             {
                 lastException = ex;
                 attempts++;
-                
-                if (ShouldRetry(ex, attempts - 1))
-                {
-                    Interlocked.Increment(ref _consecutiveFailures);
-                    _lastFailureTime = DateTime.UtcNow;
 
-                    _logger.LogWarning(ex, 
-                        "Delete pipeline operation failed. Attempt {Attempt} of {MaxAttempts}. Retrying in {DelayMs}ms",
-                        attempts, _options.MaxRetryAttempts, _options.RetryDelayMs);
+                var retryable = ex is not ArgumentException and not ArgumentNullException;
 
-                    if (attempts < _options.MaxRetryAttempts)
-                    {
-                        await Task.Delay(_options.RetryDelayMs, cancellationToken);
-                        continue;
-                    }
-                    else
-                    {
-                        // Retryable exception but retries exhausted - this will be wrapped below
-                        break;
-                    }
-                }
-                else
+                if (!retryable)
                 {
-                    // Non-retryable exception - rethrow immediately
                     _logger.LogError(ex, "Delete pipeline operation failed with non-retryable exception");
                     throw;
                 }
+
+                if (attempts >= _options.MaxRetryAttempts)
+                {
+                    break; // retries exhausted, will wrap below
+                }
+
+                _logger.LogWarning(ex,
+                    "Delete pipeline operation failed. Attempt {Attempt} of {MaxAttempts}. Retrying in {DelayMs}ms",
+                    attempts, _options.MaxRetryAttempts, _options.RetryDelayMs);
+
+                await Task.Delay(_options.RetryDelayMs, cancellationToken);
             }
         }
 
         _logger.LogError(lastException, "Delete pipeline operation failed after {Attempts} attempts", attempts);
-        
+
+        Interlocked.Increment(ref _consecutiveFailures);
+        _lastFailureTime = DateTime.UtcNow;
+
         // Always wrap retryable exceptions that exhausted retries in DeletePipelineReliabilityException
         throw new DeletePipelineReliabilityException(
             $"Delete pipeline operation failed after {attempts} attempts", lastException);
@@ -104,18 +99,6 @@ public class DeletePipelineReliabilityPolicy
             await operation(ct);
             return null;
         }, cancellationToken);
-    }
-
-    private bool ShouldRetry(Exception exception, int attempt)
-    {
-        if (attempt >= _options.MaxRetryAttempts - 1)
-            return false;
-
-        // Don't retry on certain exception types
-        if (exception is ArgumentException or ArgumentNullException)
-            return false;
-
-        return true;
     }
 
     private bool IsCircuitOpen()

--- a/Validation.Infrastructure/SequenceValidator.cs
+++ b/Validation.Infrastructure/SequenceValidator.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Validation.Domain;
+using Validation.Domain.Validation;
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Infrastructure;
+
+public static class SequenceValidator
+{
+    private static bool Compare(decimal prev, decimal current, decimal threshold, ThresholdType type)
+    {
+        var diff = Math.Abs(current - prev);
+        var pct  = prev == 0 ? 0 : diff / prev * 100m;
+        return type switch
+        {
+            ThresholdType.RawDifference => diff <= threshold,
+            ThresholdType.PercentChange => pct  <= threshold,
+            _                           => throw new ArgumentOutOfRangeException(nameof(type))
+        };
+    }
+
+    public static async Task<bool> ValidateAsync<T>(
+        T entity,
+        Func<T, decimal> metric,
+        ISaveAuditRepository auditRepo,
+        IEntityIdProvider idProvider,
+        decimal threshold,
+        ThresholdType type,
+        CancellationToken ct)
+    {
+        var keyString = idProvider.GetId(entity);
+        var key       = Guid.Parse(keyString);
+        var last      = await auditRepo.GetLastAsync(key, ct);
+        var prevValue = last?.Metric ?? 0m;
+        return Compare(prevValue, metric(entity), threshold, type);
+    }
+
+    public static async Task<bool> ValidateBatchAsync<T>(
+        IEnumerable<T> items,
+        Func<T, decimal> metric,
+        ISaveAuditRepository auditRepo,
+        IEntityIdProvider idProvider,
+        decimal threshold,
+        ThresholdType type,
+        Func<T, string>? keySelector,
+        CancellationToken ct)
+    {
+        var list    = items.ToList();
+        var history = new Dictionary<string, decimal>();
+
+        foreach (var item in list)
+        {
+            var keyString = keySelector != null ? keySelector(item) : idProvider.GetId(item);
+            var key       = Guid.Parse(keyString);
+
+            if (!history.TryGetValue(keyString, out var prev))
+            {
+                prev = (await auditRepo.GetLastAsync(key, ct))?.Metric ?? 0m;
+            }
+
+            if (!Compare(prev, metric(item), threshold, type))
+                return false;
+
+            history[keyString] = metric(item);
+        }
+
+        return true;
+    }
+}

--- a/Validation.Tests/SequenceValidatorTests.cs
+++ b/Validation.Tests/SequenceValidatorTests.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Validation.Domain.Entities;
+using Validation.Domain.Validation;
+using Validation.Domain;
+using Validation.Infrastructure;
+using Validation.Tests;
+
+namespace Validation.Tests;
+
+public class SequenceValidatorTests
+{
+    private class TestIdProvider : IEntityIdProvider
+    {
+        public string GetId<T>(T entity) => ((Item)(object)entity).Id.ToString();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_ReturnsTrue_WhenDifferenceWithinThreshold()
+    {
+        var repo = new InMemorySaveAuditRepository();
+        var item = new Item(110m);
+        await repo.AddAsync(new SaveAudit { Id = Guid.NewGuid(), EntityId = item.Id, Metric = 100m }, CancellationToken.None);
+        var result = await SequenceValidator.ValidateAsync(
+            item,
+            i => i.Metric,
+            repo,
+            new TestIdProvider(),
+            15m,
+            ThresholdType.RawDifference,
+            CancellationToken.None);
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task ValidateBatchAsync_ReturnsFalse_WhenAnyDifferenceExceedsThreshold()
+    {
+        var repo = new InMemorySaveAuditRepository();
+        var items = new List<Item>
+        {
+            new Item(110m),
+            new Item(160m)
+        };
+        await repo.AddAsync(new SaveAudit { Id = Guid.NewGuid(), EntityId = items[0].Id, Metric = 100m }, CancellationToken.None);
+        await repo.AddAsync(new SaveAudit { Id = Guid.NewGuid(), EntityId = items[1].Id, Metric = 100m }, CancellationToken.None);
+        var result = await SequenceValidator.ValidateBatchAsync(
+            items,
+            i => i.Metric,
+            repo,
+            new TestIdProvider(),
+            50m,
+            ThresholdType.RawDifference,
+            null,
+            CancellationToken.None);
+        Assert.False(result);
+    }
+}


### PR DESCRIPTION
## Summary
- add `IEntityIdProvider` and `IApplicationNameProvider` interfaces
- implement `SequenceValidator` in Infrastructure
- add tests for sequence validation
- capture failed rule names for exceptions in `EnhancedManualValidatorService`
- revise delete reliability policy retry logic

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688cb8b794d083309c8364335237ea82