### PR TITLE
Implement sequence validation utilities

### DIFF
--- a/Validation.Domain/IApplicationNameProvider.cs
+++ b/Validation.Domain/IApplicationNameProvider.cs
@@ -1,0 +1,5 @@
+namespace Validation.Domain;
+public interface IApplicationNameProvider
+{
+    string ApplicationName { get; }
+}

--- a/Validation.Domain/IEntityIdProvider.cs
+++ b/Validation.Domain/IEntityIdProvider.cs
@@ -1,0 +1,6 @@
+namespace Validation.Domain;
+public interface IEntityIdProvider
+{
+    /// <summary>Returns a stable discriminator key for audit/sequence validation. Implementations must never return null or empty.</summary>
+    string GetId<T>(T entity);
+}

--- a/Validation.Domain/Validation/IAuditMetricRepository.cs
+++ b/Validation.Domain/Validation/IAuditMetricRepository.cs
@@ -1,0 +1,9 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Validation.Domain.Validation;
+
+public interface IAuditMetricRepository
+{
+    Task<decimal?> GetLastMetricAsync(string id, CancellationToken ct = default);
+}

--- a/Validation.Domain/Validation/SequenceValidator.cs
+++ b/Validation.Domain/Validation/SequenceValidator.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Validation.Domain.Validation;
+
+public static class SequenceValidator
+{
+    private static bool Compare(decimal prev, decimal current, decimal threshold, ThresholdType type)
+    {
+        var diff = Math.Abs(current - prev);
+        var pct  = prev == 0 ? 0 : diff / prev * 100m;
+        return type switch
+        {
+            ThresholdType.RawDifference => diff <= threshold,
+            ThresholdType.PercentChange => pct  <= threshold,
+            _                           => throw new ArgumentOutOfRangeException(nameof(type))
+        };
+    }
+
+    public static async Task<bool> ValidateAsync<T>(
+        T entity,
+        Func<T, decimal> metric,
+        IAuditMetricRepository auditRepo,
+        IEntityIdProvider idProvider,
+        decimal threshold,
+        ThresholdType type,
+        CancellationToken ct)
+    {
+        var key       = idProvider.GetId(entity);
+        var prevValue = await auditRepo.GetLastMetricAsync(key, ct) ?? 0m;
+        return Compare(prevValue, metric(entity), threshold, type);
+    }
+
+    public static async Task<bool> ValidateBatchAsync<T>(
+        IEnumerable<T> items,
+        Func<T, decimal> metric,
+        IAuditMetricRepository auditRepo,
+        IEntityIdProvider idProvider,
+        decimal threshold,
+        ThresholdType type,
+        Func<T, string>? keySelector,
+        CancellationToken ct)
+    {
+        var list    = items.ToList();
+        var history = new Dictionary<string, decimal>();
+
+        foreach (var item in list)
+        {
+            var key = keySelector != null ? keySelector(item) : idProvider.GetId(item);
+
+            if (!history.TryGetValue(key, out var prev))
+            {
+                prev = await auditRepo.GetLastMetricAsync(key, ct) ?? 0m;
+            }
+
+            if (!Compare(prev, metric(item), threshold, type))
+                return false;
+
+            history[key] = metric(item);
+        }
+        return true;
+    }
+}

--- a/Validation.Infrastructure/EnhancedManualValidatorService.cs
+++ b/Validation.Infrastructure/EnhancedManualValidatorService.cs
@@ -150,6 +150,7 @@ public class EnhancedManualValidatorService : IEnhancedManualValidatorService
                             _logger.LogError(ex, "Error executing named rule {RuleName} for type {Type}",
                                 kvp.Key, type.Name);
                             result.IsValid = false;
+                            result.FailedRules.Add(kvp.Key);
                             result.Errors.Add($"Rule '{kvp.Key}' execution failed: {ex.Message}");
                         }
                     }

--- a/Validation.Infrastructure/Reliability/DeletePipelineReliabilityPolicy.cs
+++ b/Validation.Infrastructure/Reliability/DeletePipelineReliabilityPolicy.cs
@@ -54,7 +54,6 @@ public class DeletePipelineReliabilityPolicy
                 
                 if (ShouldRetry(ex, attempts - 1))
                 {
-                    Interlocked.Increment(ref _consecutiveFailures);
                     _lastFailureTime = DateTime.UtcNow;
 
                     _logger.LogWarning(ex, 
@@ -68,7 +67,8 @@ public class DeletePipelineReliabilityPolicy
                     }
                     else
                     {
-                        // Retryable exception but retries exhausted - this will be wrapped below
+                        // Retryable exception but retries exhausted - increment failure count once
+                        Interlocked.Increment(ref _consecutiveFailures);
                         break;
                     }
                 }
@@ -108,7 +108,7 @@ public class DeletePipelineReliabilityPolicy
 
     private bool ShouldRetry(Exception exception, int attempt)
     {
-        if (attempt >= _options.MaxRetryAttempts - 1)
+        if (attempt >= _options.MaxRetryAttempts)
             return false;
 
         // Don't retry on certain exception types

--- a/Validation.Infrastructure/Repositories/EfCoreSaveAuditRepository.cs
+++ b/Validation.Infrastructure/Repositories/EfCoreSaveAuditRepository.cs
@@ -1,9 +1,10 @@
 using Microsoft.EntityFrameworkCore;
 using Validation.Infrastructure.Repositories;
+using Validation.Domain.Validation;
 
 namespace Validation.Infrastructure.Repositories;
 
-public class EfCoreSaveAuditRepository : ISaveAuditRepository
+public class EfCoreSaveAuditRepository : ISaveAuditRepository, IAuditMetricRepository
 {
     private readonly DbContext _context;
     private readonly DbSet<SaveAudit> _set;
@@ -47,5 +48,11 @@ public class EfCoreSaveAuditRepository : ISaveAuditRepository
             .Where(a => a.EntityId == entityId)
             .OrderByDescending(a => a.Timestamp)
             .FirstOrDefaultAsync(ct);
+    }
+
+    public async Task<decimal?> GetLastMetricAsync(string id, CancellationToken ct = default)
+    {
+        var guid = Guid.Parse(id);
+        return (await GetLastAsync(guid, ct))?.Metric;
     }
 }

--- a/Validation.Infrastructure/Repositories/MongoSaveAuditRepository.cs
+++ b/Validation.Infrastructure/Repositories/MongoSaveAuditRepository.cs
@@ -1,8 +1,9 @@
 using MongoDB.Driver;
+using Validation.Domain.Validation;
 
 namespace Validation.Infrastructure.Repositories;
 
-public class MongoSaveAuditRepository : ISaveAuditRepository
+public class MongoSaveAuditRepository : ISaveAuditRepository, IAuditMetricRepository
 {
     private readonly IMongoCollection<SaveAudit> _collection;
 
@@ -38,5 +39,12 @@ public class MongoSaveAuditRepository : ISaveAuditRepository
             .Find(x => x.EntityId == entityId)
             .SortByDescending(x => x.Timestamp)
             .FirstOrDefaultAsync(ct);
+    }
+
+    public async Task<decimal?> GetLastMetricAsync(string id, CancellationToken ct = default)
+    {
+        var guid = Guid.Parse(id);
+        var last = await GetLastAsync(guid, ct);
+        return last?.Metric;
     }
 }

--- a/Validation.Tests/InMemorySaveAuditRepository.cs
+++ b/Validation.Tests/InMemorySaveAuditRepository.cs
@@ -1,9 +1,10 @@
 using Validation.Infrastructure;
 using Validation.Infrastructure.Repositories;
+using Validation.Domain.Validation;
 
 namespace Validation.Tests;
 
-public class InMemorySaveAuditRepository : ISaveAuditRepository
+public class InMemorySaveAuditRepository : ISaveAuditRepository, IAuditMetricRepository
 {
     public List<SaveAudit> Audits { get; } = new();
 
@@ -37,5 +38,14 @@ public class InMemorySaveAuditRepository : ISaveAuditRepository
             .OrderByDescending(a => a.Timestamp)
             .FirstOrDefault();
         return Task.FromResult<SaveAudit?>(audit);
+    }
+
+    public Task<decimal?> GetLastMetricAsync(string id, CancellationToken ct = default)
+    {
+        var guid = Guid.Parse(id);
+        var metric = Audits.Where(a => a.EntityId == guid)
+            .OrderByDescending(a => a.Timestamp)
+            .FirstOrDefault()?.Metric;
+        return Task.FromResult(metric);
     }
 }

--- a/Validation.Tests/SequenceValidatorTests.cs
+++ b/Validation.Tests/SequenceValidatorTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Validation.Domain.Entities;
+using Validation.Domain.Validation;
+using Validation.Infrastructure;
+using Validation.Domain;
+using Xunit;
+
+namespace Validation.Tests;
+
+public class SequenceValidatorTests
+{
+    private class IdProvider : IEntityIdProvider
+    {
+        public string GetId<T>(T entity) => ((Item)(object)entity).Id.ToString();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_within_threshold_returns_true()
+    {
+        var repo = new InMemorySaveAuditRepository();
+        var item = new Item(100m);
+        await repo.AddAsync(new SaveAudit { EntityId = item.Id, Metric = 95m });
+
+        var result = await SequenceValidator.ValidateAsync(
+            item,
+            i => i.Metric,
+            repo,
+            new IdProvider(),
+            10m,
+            ThresholdType.RawDifference,
+            CancellationToken.None);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_exceeds_threshold_returns_false()
+    {
+        var repo = new InMemorySaveAuditRepository();
+        var item = new Item(100m);
+        await repo.AddAsync(new SaveAudit { EntityId = item.Id, Metric = 80m });
+
+        var result = await SequenceValidator.ValidateAsync(
+            item,
+            i => i.Metric,
+            repo,
+            new IdProvider(),
+            10m,
+            ThresholdType.RawDifference,
+            CancellationToken.None);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ValidateBatchAsync_validates_each_item()
+    {
+        var repo = new InMemorySaveAuditRepository();
+        var items = new[] { new Item(10m), new Item(20m) };
+        foreach (var i in items)
+            await repo.AddAsync(new SaveAudit { EntityId = i.Id, Metric = 10m });
+
+        var result = await SequenceValidator.ValidateBatchAsync(
+            items,
+            i => i.Metric,
+            repo,
+            new IdProvider(),
+            5m,
+            ThresholdType.RawDifference,
+            null,
+            CancellationToken.None);
+
+        Assert.False(result); // second item diff = 10
+    }
+}


### PR DESCRIPTION
## Summary
- add `SequenceValidator` for validating save sequences
- expose ID and application name providers
- provide audit metric repository abstraction
- implement metric retrieval in save audit repositories
- track failing rules in `EnhancedManualValidatorService`
- adjust reliability policy retry logic
- test sequence validation scenarios

## Testing
- `dotnet test Validation.Tests/Validation.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_688cb8b794d083309c8364335237ea82