### PR TITLE
Add sequence validation utility

### DIFF
--- a/Validation.Domain/IApplicationNameProvider.cs
+++ b/Validation.Domain/IApplicationNameProvider.cs
@@ -1,0 +1,5 @@
+namespace Validation.Domain;
+public interface IApplicationNameProvider
+{
+    string ApplicationName { get; }
+}

--- a/Validation.Domain/IEntityIdProvider.cs
+++ b/Validation.Domain/IEntityIdProvider.cs
@@ -1,0 +1,5 @@
+namespace Validation.Domain;
+public interface IEntityIdProvider
+{
+    string GetId<T>(T entity);
+}

--- a/Validation.Infrastructure/SequenceValidator.cs
+++ b/Validation.Infrastructure/SequenceValidator.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Validation.Domain;
+using Validation.Domain.Validation;
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Infrastructure;
+
+public static class SequenceValidator
+{
+    private static bool Compare(decimal prev, decimal current, decimal threshold, ThresholdType type)
+    {
+        if (prev == 0)
+            return true;
+
+        var diff = Math.Abs(current - prev);
+        var pct  = diff / prev * 100m;
+        return type switch
+        {
+            ThresholdType.RawDifference => diff <= threshold,
+            ThresholdType.PercentChange => pct  <= threshold,
+            _                           => throw new ArgumentOutOfRangeException(nameof(type))
+        };
+    }
+
+    public static async Task<bool> ValidateAsync<T>(
+        T entity,
+        Func<T, decimal> metric,
+        ISaveAuditRepository auditRepo,
+        IEntityIdProvider idProvider,
+        decimal threshold,
+        ThresholdType type,
+        CancellationToken ct)
+    {
+        var key       = idProvider.GetId(entity);
+        var last      = await auditRepo.GetLastAsync(Guid.Parse(key), ct);
+        var prevValue = last?.Metric ?? 0m;
+        return Compare(prevValue, metric(entity), threshold, type);
+    }
+
+    public static async Task<bool> ValidateBatchAsync<T>(
+        IEnumerable<T> items,
+        Func<T, decimal> metric,
+        ISaveAuditRepository auditRepo,
+        IEntityIdProvider idProvider,
+        decimal threshold,
+        ThresholdType type,
+        Func<T,string>? keySelector,
+        CancellationToken ct)
+    {
+        var list    = items.ToList();
+        var history = new Dictionary<string, decimal>();
+
+        foreach (var item in list)
+        {
+            var key = keySelector != null ? keySelector(item) : idProvider.GetId(item);
+
+            if (!history.TryGetValue(key, out var prev))
+            {
+                var audit = await auditRepo.GetLastAsync(Guid.Parse(key), ct);
+                prev = audit?.Metric ?? 0m;
+            }
+
+            if (!Compare(prev, metric(item), threshold, type))
+                return false;
+
+            history[key] = metric(item);
+        }
+        return true;
+    }
+}

--- a/Validation.Tests/SequenceValidatorTests.cs
+++ b/Validation.Tests/SequenceValidatorTests.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Validation.Domain.Entities;
+using Validation.Domain.Validation;
+using Validation.Infrastructure.Repositories;
+
+
+using Validation.Infrastructure;
+using Validation.Domain;
+namespace Validation.Tests;
+
+public class SequenceValidatorTests
+{
+    private class IdProvider : IEntityIdProvider
+    {
+        public string GetId<T>(T entity) => ((Item)(object)entity).Id.ToString();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_NoPreviousRecord_ReturnsTrue()
+    {
+        var repo = new InMemorySaveAuditRepository();
+        var item = new Item(50m);
+        var result = await SequenceValidator.ValidateAsync(
+            item,
+            i => i.Metric,
+            repo,
+            new IdProvider(),
+            10m,
+            ThresholdType.RawDifference,
+            default);
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_ChangeExceedsThreshold_ReturnsFalse()
+    {
+        var repo = new InMemorySaveAuditRepository();
+        var item = new Item(100m);
+        await repo.AddAsync(new SaveAudit { EntityId = item.Id, Metric = 100m }, default);
+        item.UpdateMetric(120m);
+        var result = await SequenceValidator.ValidateAsync(
+            item,
+            i => i.Metric,
+            repo,
+            new IdProvider(),
+            10m,
+            ThresholdType.RawDifference,
+            default);
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ValidateBatchAsync_WhenAnyItemInvalid_ReturnsFalse()
+    {
+        var repo = new InMemorySaveAuditRepository();
+        var a = new Item(100m);
+        var b = new Item(50m);
+        await repo.AddAsync(new SaveAudit { EntityId = a.Id, Metric = 100m }, default);
+        await repo.AddAsync(new SaveAudit { EntityId = b.Id, Metric = 50m }, default);
+        a.UpdateMetric(105m);
+        b.UpdateMetric(70m); // exceeds
+        var items = new[] { a, b };
+        var result = await SequenceValidator.ValidateBatchAsync(
+            items,
+            i => i.Metric,
+            repo,
+            new IdProvider(),
+            10m,
+            ThresholdType.RawDifference,
+            null,
+            default);
+        Assert.False(result);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `IEntityIdProvider` and `IApplicationNameProvider` interfaces
- implement `SequenceValidator` utility in infrastructure
- cover sequence validation with unit tests

## Testing
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_688cb8b794d083309c8364335237ea82