### PR TITLE
Update SaveAudit schema and repositories

### DIFF
--- a/Validation.Infrastructure/EnhancedManualValidatorService.cs
+++ b/Validation.Infrastructure/EnhancedManualValidatorService.cs
@@ -150,6 +150,7 @@ public class EnhancedManualValidatorService : IEnhancedManualValidatorService
                             _logger.LogError(ex, "Error executing named rule {RuleName} for type {Type}",
                                 kvp.Key, type.Name);
                             result.IsValid = false;
+                            result.FailedRules.Add(kvp.Key);
                             result.Errors.Add($"Rule '{kvp.Key}' execution failed: {ex.Message}");
                         }
                     }
@@ -177,6 +178,7 @@ public class EnhancedManualValidatorService : IEnhancedManualValidatorService
                             _logger.LogError(ex, "Error executing anonymous rule {Index} for type {Type}",
                                 i, type.Name);
                             result.IsValid = false;
+                            result.FailedRules.Add($"Anonymous rule {i}");
                             result.Errors.Add($"Anonymous rule {i} execution failed: {ex.Message}");
                         }
                     }

--- a/Validation.Infrastructure/Messaging/ReliableDeleteValidationConsumer.cs
+++ b/Validation.Infrastructure/Messaging/ReliableDeleteValidationConsumer.cs
@@ -78,7 +78,7 @@ public class ReliableDeleteValidationConsumer<T> : IConsumer<DeleteRequested>
     private async Task ValidateDeleteAsync(ConsumeContext<DeleteRequested> context, CancellationToken cancellationToken)
     {
         // Get the last audit record to understand the current state
-        var lastAudit = await _auditRepository.GetLastAsync(context.Message.Id, cancellationToken);
+        var lastAudit = await _auditRepository.GetLastAsync(context.Message.Id.ToString(), cancellationToken);
         
         if (lastAudit == null)
         {
@@ -99,9 +99,11 @@ public class ReliableDeleteValidationConsumer<T> : IConsumer<DeleteRequested>
         var deleteAudit = new SaveAudit
         {
             Id = Guid.NewGuid(),
-            EntityId = context.Message.Id,
+            EntityId = context.Message.Id.ToString(),
+            ApplicationName = string.Empty,
             IsValid = isValid,
             Metric = 0m, // Zero metric for delete operation
+            BatchSize = 1,
             Timestamp = DateTime.UtcNow
         };
 

--- a/Validation.Infrastructure/Messaging/SaveRequestedConsumer.cs
+++ b/Validation.Infrastructure/Messaging/SaveRequestedConsumer.cs
@@ -26,9 +26,11 @@ public class SaveRequestedConsumer : IConsumer<SaveRequested>
         var audit = new SaveAudit
         {
             Id = Guid.NewGuid(),
-            EntityId = context.Message.Id,
+            EntityId = context.Message.Id.ToString(),
+            ApplicationName = string.Empty,
             IsValid = isValid,
-            Metric = metric
+            Metric = metric,
+            BatchSize = 1
         };
         await _repository.AddAsync(audit, context.CancellationToken);
         await context.Publish(new SaveValidated(context.Message.Id, isValid, metric), context.CancellationToken);

--- a/Validation.Infrastructure/Messaging/SaveValidationConsumer.cs
+++ b/Validation.Infrastructure/Messaging/SaveValidationConsumer.cs
@@ -20,7 +20,7 @@ public class SaveValidationConsumer<T> : IConsumer<SaveRequested>
 
     public async Task Consume(ConsumeContext<SaveRequested> context)
     {
-        var last = await _repository.GetLastAsync(context.Message.Id, context.CancellationToken);
+        var last = await _repository.GetLastAsync(context.Message.Id.ToString(), context.CancellationToken);
         var metric = new Random().Next(0, 100);
         var rules = _planProvider.GetRules<T>();
         var isValid = _validator.Validate(last?.Metric ?? 0m, metric, rules);
@@ -28,9 +28,11 @@ public class SaveValidationConsumer<T> : IConsumer<SaveRequested>
         var audit = new SaveAudit
         {
             Id = Guid.NewGuid(),
-            EntityId = context.Message.Id,
+            EntityId = context.Message.Id.ToString(),
+            ApplicationName = string.Empty,
             IsValid = isValid,
-            Metric = metric
+            Metric = metric,
+            BatchSize = 1
         };
 
         await _repository.AddAsync(audit, context.CancellationToken);

--- a/Validation.Infrastructure/Repositories/EfCoreSaveAuditRepository.cs
+++ b/Validation.Infrastructure/Repositories/EfCoreSaveAuditRepository.cs
@@ -14,9 +14,9 @@ public class EfCoreSaveAuditRepository : ISaveAuditRepository
         _set = context.Set<SaveAudit>();
     }
 
-    public async Task AddAsync(SaveAudit entity, CancellationToken ct = default)
+    public async Task AddAsync(SaveAudit audit, CancellationToken ct = default)
     {
-        await _set.AddAsync(entity, ct);
+        await _set.AddAsync(audit, ct);
         await _context.SaveChangesAsync(ct);
     }
 
@@ -41,10 +41,10 @@ public class EfCoreSaveAuditRepository : ISaveAuditRepository
         await _context.SaveChangesAsync(ct);
     }
 
-    public async Task<SaveAudit?> GetLastAsync(Guid entityId, CancellationToken ct = default)
+    public async Task<SaveAudit?> GetLastAsync(string entityKey, CancellationToken ct = default)
     {
         return await _set
-            .Where(a => a.EntityId == entityId)
+            .Where(a => a.EntityId == entityKey)
             .OrderByDescending(a => a.Timestamp)
             .FirstOrDefaultAsync(ct);
     }

--- a/Validation.Infrastructure/Repositories/ISaveAuditRepository.cs
+++ b/Validation.Infrastructure/Repositories/ISaveAuditRepository.cs
@@ -2,5 +2,6 @@ namespace Validation.Infrastructure.Repositories;
 
 public interface ISaveAuditRepository : IRepository<SaveAudit>
 {
-    Task<SaveAudit?> GetLastAsync(Guid entityId, CancellationToken ct = default);
+    Task<SaveAudit?> GetLastAsync(string entityKey, CancellationToken ct = default);
+    Task AddAsync(SaveAudit audit, CancellationToken ct = default);   // NEW
 }

--- a/Validation.Infrastructure/Repositories/MongoSaveAuditRepository.cs
+++ b/Validation.Infrastructure/Repositories/MongoSaveAuditRepository.cs
@@ -11,9 +11,9 @@ public class MongoSaveAuditRepository : ISaveAuditRepository
         _collection = database.GetCollection<SaveAudit>("saveAudits");
     }
 
-    public async Task AddAsync(SaveAudit entity, CancellationToken ct = default)
+    public async Task AddAsync(SaveAudit audit, CancellationToken ct = default)
     {
-        await _collection.InsertOneAsync(entity, null, ct);
+        await _collection.InsertOneAsync(audit, null, ct);
     }
 
     public async Task DeleteAsync(Guid id, CancellationToken ct = default)
@@ -32,10 +32,10 @@ public class MongoSaveAuditRepository : ISaveAuditRepository
         await _collection.ReplaceOneAsync(x => x.Id == entity.Id, entity, cancellationToken: ct);
     }
 
-    public async Task<SaveAudit?> GetLastAsync(Guid entityId, CancellationToken ct = default)
+    public async Task<SaveAudit?> GetLastAsync(string entityKey, CancellationToken ct = default)
     {
         return await _collection
-            .Find(x => x.EntityId == entityId)
+            .Find(x => x.EntityId == entityKey)
             .SortByDescending(x => x.Timestamp)
             .FirstOrDefaultAsync(ct);
     }

--- a/Validation.Infrastructure/SaveAudit.cs
+++ b/Validation.Infrastructure/SaveAudit.cs
@@ -2,9 +2,11 @@ namespace Validation.Infrastructure;
 
 public class SaveAudit
 {
-    public Guid Id { get; set; }
-    public Guid EntityId { get; set; }
-    public bool IsValid { get; set; }
-    public decimal Metric { get; set; }
+    public Guid   Id              { get; set; }
+    public string EntityId        { get; set; } = string.Empty;   // now string
+    public string ApplicationName { get; set; } = string.Empty;   // NEW
+    public bool   IsValid         { get; set; }
+    public decimal Metric         { get; set; }
+    public int    BatchSize       { get; set; }                   // NEW
     public DateTime Timestamp { get; set; } = DateTime.UtcNow;
 }

--- a/Validation.Tests/InMemorySaveAuditRepository.cs
+++ b/Validation.Tests/InMemorySaveAuditRepository.cs
@@ -31,7 +31,7 @@ public class InMemorySaveAuditRepository : ISaveAuditRepository
         return Task.CompletedTask;
     }
 
-    public Task<SaveAudit?> GetLastAsync(Guid entityId, CancellationToken ct = default)
+    public Task<SaveAudit?> GetLastAsync(string entityId, CancellationToken ct = default)
     {
         var audit = Audits.Where(a => a.EntityId == entityId)
             .OrderByDescending(a => a.Timestamp)

--- a/Validation.Tests/SaveCommitConsumerTests.cs
+++ b/Validation.Tests/SaveCommitConsumerTests.cs
@@ -14,9 +14,9 @@ public class SaveCommitConsumerTests
     {
         public Task AddAsync(SaveAudit entity, CancellationToken ct = default) => Task.CompletedTask;
         public Task DeleteAsync(Guid id, CancellationToken ct = default) => Task.CompletedTask;
-        public Task<SaveAudit?> GetAsync(Guid id, CancellationToken ct = default) => Task.FromResult<SaveAudit?>(new SaveAudit { Id = id, EntityId = id });
+        public Task<SaveAudit?> GetAsync(Guid id, CancellationToken ct = default) => Task.FromResult<SaveAudit?>(new SaveAudit { Id = id, EntityId = id.ToString() });
         public Task UpdateAsync(SaveAudit entity, CancellationToken ct = default) => throw new Exception("fail");
-        public Task<SaveAudit?> GetLastAsync(Guid entityId, CancellationToken ct = default) => Task.FromResult<SaveAudit?>(null);
+        public Task<SaveAudit?> GetLastAsync(string entityId, CancellationToken ct = default) => Task.FromResult<SaveAudit?>(null);
     }
 
     [Fact]

--- a/Validation.Tests/SavePipelineTests.cs
+++ b/Validation.Tests/SavePipelineTests.cs
@@ -48,7 +48,7 @@ public class SavePipelineTests
         public Task UpdateAsync(SaveAudit entity, CancellationToken ct = default)
             => throw new Exception("Repository failure for testing");
         
-        public Task<SaveAudit?> GetLastAsync(Guid entityId, CancellationToken ct = default)
+        public Task<SaveAudit?> GetLastAsync(string entityId, CancellationToken ct = default)
         {
             var audit = Audits.Where(a => a.EntityId == entityId)
                 .OrderByDescending(a => a.Timestamp)


### PR DESCRIPTION
## Summary
- introduce `ApplicationName` and `BatchSize` fields for `SaveAudit`
- switch `EntityId` to string everywhere
- adjust EF Core and Mongo repository implementations
- update messaging consumers and reliability policy
- update tests for new repository interface

## Testing
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_688cb90ba3e0833090fbab6b9e048fe4