### PR TITLE
Add entity id and app name providers

### DIFF
--- a/Validation.Domain/IApplicationNameProvider.cs
+++ b/Validation.Domain/IApplicationNameProvider.cs
@@ -1,0 +1,6 @@
+namespace Validation.Domain;
+
+public interface IApplicationNameProvider
+{
+    string GetName();
+}

--- a/Validation.Domain/IEntityIdProvider.cs
+++ b/Validation.Domain/IEntityIdProvider.cs
@@ -1,0 +1,6 @@
+namespace Validation.Domain;
+
+public interface IEntityIdProvider
+{
+    string GetId<T>(T entity);
+}

--- a/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
+++ b/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Hosting;
 using MongoDB.Driver;
 using OpenTelemetry.Trace;
 using Serilog;
+using Validation.Domain;
 using Validation.Domain.Validation;
 using Validation.Domain.Events;
 using Validation.Domain.Repositories;
@@ -31,6 +32,8 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IValidationPlanProvider, InMemoryValidationPlanProvider>();
         services.AddSingleton<IManualValidatorService, ManualValidatorService>();
         services.AddSingleton<IEnhancedManualValidatorService, EnhancedManualValidatorService>();
+        services.AddSingleton<IEntityIdProvider>(new ReflectionBasedEntityIdProvider());
+        services.AddSingleton<IApplicationNameProvider>(new StaticApplicationNameProvider("ValidationService"));
 
         // Add unified event hub
         services.AddSingleton<IValidationEventHub, ValidationEventHub>();

--- a/Validation.Infrastructure/EnhancedManualValidatorService.cs
+++ b/Validation.Infrastructure/EnhancedManualValidatorService.cs
@@ -150,6 +150,7 @@ public class EnhancedManualValidatorService : IEnhancedManualValidatorService
                             _logger.LogError(ex, "Error executing named rule {RuleName} for type {Type}",
                                 kvp.Key, type.Name);
                             result.IsValid = false;
+                            result.FailedRules.Add(kvp.Key);
                             result.Errors.Add($"Rule '{kvp.Key}' execution failed: {ex.Message}");
                         }
                     }

--- a/Validation.Infrastructure/ReflectionBasedEntityIdProvider.cs
+++ b/Validation.Infrastructure/ReflectionBasedEntityIdProvider.cs
@@ -1,0 +1,30 @@
+using System.Reflection;
+using Validation.Domain;
+
+namespace Validation.Infrastructure;
+
+public sealed class ReflectionBasedEntityIdProvider : IEntityIdProvider
+{
+    private readonly string[] _priority;
+
+    public ReflectionBasedEntityIdProvider(params string[] priority)
+        => _priority = priority.Length == 0
+            ? new[] { "Name", "Code", "Key", "Identifier", "Title", "Label" }
+            : priority;
+
+    public string GetId<T>(T entity)
+    {
+        var type = entity!.GetType();
+        foreach (var name in _priority)
+        {
+            var prop = type.GetProperty(name, BindingFlags.Public|BindingFlags.Instance|BindingFlags.IgnoreCase);
+            if (prop != null && prop.PropertyType == typeof(string))
+            {
+                var val = (string?)prop.GetValue(entity);
+                if (!string.IsNullOrWhiteSpace(val)) return val!;
+            }
+        }
+        var idProp = type.GetProperty("Id") ?? type.GetProperty($"{type.Name}Id");
+        return idProp?.GetValue(entity)?.ToString() ?? Guid.Empty.ToString();
+    }
+}

--- a/Validation.Infrastructure/Reliability/DeletePipelineReliabilityPolicy.cs
+++ b/Validation.Infrastructure/Reliability/DeletePipelineReliabilityPolicy.cs
@@ -52,32 +52,30 @@ public class DeletePipelineReliabilityPolicy
                 lastException = ex;
                 attempts++;
                 
-                if (ShouldRetry(ex, attempts - 1))
-                {
-                    Interlocked.Increment(ref _consecutiveFailures);
-                    _lastFailureTime = DateTime.UtcNow;
+                var shouldRetry = ShouldRetry(ex, attempts - 1);
+                var maxReached = attempts >= _options.MaxRetryAttempts;
 
-                    _logger.LogWarning(ex, 
+                if (shouldRetry && !maxReached)
+                {
+                    _logger.LogWarning(ex,
                         "Delete pipeline operation failed. Attempt {Attempt} of {MaxAttempts}. Retrying in {DelayMs}ms",
                         attempts, _options.MaxRetryAttempts, _options.RetryDelayMs);
 
-                    if (attempts < _options.MaxRetryAttempts)
-                    {
-                        await Task.Delay(_options.RetryDelayMs, cancellationToken);
-                        continue;
-                    }
-                    else
-                    {
-                        // Retryable exception but retries exhausted - this will be wrapped below
-                        break;
-                    }
+                    await Task.Delay(_options.RetryDelayMs, cancellationToken);
+                    continue;
                 }
-                else
+
+                // record failure for circuit breaker
+                Interlocked.Increment(ref _consecutiveFailures);
+                _lastFailureTime = DateTime.UtcNow;
+
+                if (maxReached)
                 {
-                    // Non-retryable exception - rethrow immediately
-                    _logger.LogError(ex, "Delete pipeline operation failed with non-retryable exception");
-                    throw;
+                    break;
                 }
+
+                _logger.LogError(ex, "Delete pipeline operation failed with non-retryable exception");
+                throw;
             }
         }
 

--- a/Validation.Infrastructure/StaticApplicationNameProvider.cs
+++ b/Validation.Infrastructure/StaticApplicationNameProvider.cs
@@ -1,0 +1,12 @@
+using Validation.Domain;
+
+namespace Validation.Infrastructure;
+
+public sealed class StaticApplicationNameProvider : IApplicationNameProvider
+{
+    private readonly string _name;
+
+    public StaticApplicationNameProvider(string name) => _name = name;
+
+    public string GetName() => _name;
+}

--- a/Validation.Tests/ReflectionBasedEntityIdProviderTests.cs
+++ b/Validation.Tests/ReflectionBasedEntityIdProviderTests.cs
@@ -1,0 +1,54 @@
+using Microsoft.Extensions.DependencyInjection;
+using Validation.Infrastructure;
+using Validation.Domain;
+using Validation.Infrastructure.DI;
+
+namespace Validation.Tests;
+
+public class ReflectionBasedEntityIdProviderTests
+{
+    private class Sample
+    {
+        public Guid Id { get; set; } = Guid.NewGuid();
+        public string Name { get; set; } = string.Empty;
+    }
+
+    [Fact]
+    public void GetId_returns_priority_property_if_available()
+    {
+        var provider = new ReflectionBasedEntityIdProvider("Name");
+        var sample = new Sample { Name = "Hello" };
+
+        var id = provider.GetId(sample);
+
+        Assert.Equal("Hello", id);
+    }
+
+    [Fact]
+    public void GetId_falls_back_to_Id_property()
+    {
+        var provider = new ReflectionBasedEntityIdProvider("Code");
+        var sample = new Sample { Id = Guid.NewGuid(), Name = string.Empty };
+
+        var id = provider.GetId(sample);
+
+        Assert.Equal(sample.Id.ToString(), id);
+    }
+
+    [Fact]
+    public void AddValidationInfrastructure_registers_providers()
+    {
+        var services = new ServiceCollection();
+        services.AddValidationInfrastructure();
+
+        using var provider = services.BuildServiceProvider();
+        var idProvider = provider.GetService<IEntityIdProvider>();
+        var appNameProvider = provider.GetService<IApplicationNameProvider>();
+
+        Assert.NotNull(idProvider);
+        Assert.NotNull(appNameProvider);
+        Assert.IsType<ReflectionBasedEntityIdProvider>(idProvider);
+        Assert.IsType<StaticApplicationNameProvider>(appNameProvider);
+        Assert.Equal("ValidationService", appNameProvider!.GetName());
+    }
+}


### PR DESCRIPTION
## Summary
- add interfaces for entity id and app name providers
- implement ReflectionBasedEntityIdProvider and StaticApplicationNameProvider
- register new providers in service collection extensions
- record rule failures when exceptions occur
- fix reliability policy retry logic
- add tests for new providers

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688cb940db448330b89c9fc458121c42