### PR TITLE
Implement generic SaveValidationConsumer

### DIFF
--- a/Validation.Domain/IApplicationNameProvider.cs
+++ b/Validation.Domain/IApplicationNameProvider.cs
@@ -1,0 +1,6 @@
+namespace Validation.Domain;
+
+public interface IApplicationNameProvider
+{
+    string ApplicationName { get; }
+}

--- a/Validation.Domain/IEntityIdProvider.cs
+++ b/Validation.Domain/IEntityIdProvider.cs
@@ -1,0 +1,6 @@
+namespace Validation.Domain;
+
+public interface IEntityIdProvider
+{
+    Guid GetId<T>(T entity);
+}

--- a/Validation.Domain/Validation/IValidationPlanProvider.cs
+++ b/Validation.Domain/Validation/IValidationPlanProvider.cs
@@ -4,5 +4,6 @@ public interface IValidationPlanProvider
 {
     IEnumerable<IValidationRule> GetRules<T>();
     ValidationPlan GetPlan(Type t);
+    ValidationPlan GetPlanFor<T>();
     void AddPlan<T>(ValidationPlan plan);
 }

--- a/Validation.Domain/Validation/InMemoryValidationPlanProvider.cs
+++ b/Validation.Domain/Validation/InMemoryValidationPlanProvider.cs
@@ -18,6 +18,8 @@ public class InMemoryValidationPlanProvider : IValidationPlanProvider
         return plan ?? new ValidationPlan(Array.Empty<IValidationRule>());
     }
 
+    public ValidationPlan GetPlanFor<T>() => GetPlan(typeof(T));
+
     public void AddPlan<T>(ValidationPlan plan)
     {
         _plans[typeof(T)] = plan;

--- a/Validation.Domain/Validation/ValidationPlan.cs
+++ b/Validation.Domain/Validation/ValidationPlan.cs
@@ -4,6 +4,7 @@ public class ValidationPlan
 {
     public IEnumerable<IValidationRule> Rules { get; }
     public Func<object, decimal>? MetricSelector { get; }
+    public Func<object, decimal>? Selector => MetricSelector;
     public ThresholdType? ThresholdType { get; }
     public decimal? ThresholdValue { get; }
 

--- a/Validation.Infrastructure/DefaultApplicationNameProvider.cs
+++ b/Validation.Infrastructure/DefaultApplicationNameProvider.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.Hosting;
+using Validation.Domain;
+
+namespace Validation.Infrastructure;
+
+public class DefaultApplicationNameProvider : IApplicationNameProvider
+{
+    public string ApplicationName { get; }
+
+    public DefaultApplicationNameProvider(IHostEnvironment? env = null)
+    {
+        ApplicationName = env?.ApplicationName ?? "App";
+    }
+}

--- a/Validation.Infrastructure/DefaultEntityIdProvider.cs
+++ b/Validation.Infrastructure/DefaultEntityIdProvider.cs
@@ -1,0 +1,15 @@
+using Validation.Domain;
+
+namespace Validation.Infrastructure;
+
+public class DefaultEntityIdProvider : IEntityIdProvider
+{
+    public Guid GetId<T>(T entity)
+    {
+        if (entity == null) throw new ArgumentNullException(nameof(entity));
+        var prop = entity.GetType().GetProperty("Id");
+        if (prop == null || prop.PropertyType != typeof(Guid))
+            throw new InvalidOperationException("Entity must have Guid Id property");
+        return (Guid)(prop.GetValue(entity) ?? Guid.Empty);
+    }
+}

--- a/Validation.Infrastructure/EnhancedManualValidatorService.cs
+++ b/Validation.Infrastructure/EnhancedManualValidatorService.cs
@@ -150,6 +150,7 @@ public class EnhancedManualValidatorService : IEnhancedManualValidatorService
                             _logger.LogError(ex, "Error executing named rule {RuleName} for type {Type}",
                                 kvp.Key, type.Name);
                             result.IsValid = false;
+                            result.FailedRules.Add(kvp.Key);
                             result.Errors.Add($"Rule '{kvp.Key}' execution failed: {ex.Message}");
                         }
                     }
@@ -177,6 +178,7 @@ public class EnhancedManualValidatorService : IEnhancedManualValidatorService
                             _logger.LogError(ex, "Error executing anonymous rule {Index} for type {Type}",
                                 i, type.Name);
                             result.IsValid = false;
+                            result.FailedRules.Add($"Anonymous rule {i}");
                             result.Errors.Add($"Anonymous rule {i} execution failed: {ex.Message}");
                         }
                     }

--- a/Validation.Infrastructure/Reliability/DeletePipelineReliabilityPolicy.cs
+++ b/Validation.Infrastructure/Reliability/DeletePipelineReliabilityPolicy.cs
@@ -54,8 +54,6 @@ public class DeletePipelineReliabilityPolicy
                 
                 if (ShouldRetry(ex, attempts - 1))
                 {
-                    Interlocked.Increment(ref _consecutiveFailures);
-                    _lastFailureTime = DateTime.UtcNow;
 
                     _logger.LogWarning(ex, 
                         "Delete pipeline operation failed. Attempt {Attempt} of {MaxAttempts}. Retrying in {DelayMs}ms",
@@ -68,7 +66,8 @@ public class DeletePipelineReliabilityPolicy
                     }
                     else
                     {
-                        // Retryable exception but retries exhausted - this will be wrapped below
+                        Interlocked.Increment(ref _consecutiveFailures);
+                        _lastFailureTime = DateTime.UtcNow;
                         break;
                     }
                 }
@@ -108,7 +107,7 @@ public class DeletePipelineReliabilityPolicy
 
     private bool ShouldRetry(Exception exception, int attempt)
     {
-        if (attempt >= _options.MaxRetryAttempts - 1)
+        if (attempt >= _options.MaxRetryAttempts)
             return false;
 
         // Don't retry on certain exception types

--- a/Validation.Infrastructure/SaveAudit.cs
+++ b/Validation.Infrastructure/SaveAudit.cs
@@ -4,6 +4,8 @@ public class SaveAudit
 {
     public Guid Id { get; set; }
     public Guid EntityId { get; set; }
+    public string? ApplicationName { get; set; }
+    public int BatchSize { get; set; }
     public bool IsValid { get; set; }
     public decimal Metric { get; set; }
     public DateTime Timestamp { get; set; } = DateTime.UtcNow;

--- a/Validation.Infrastructure/SequenceValidator.cs
+++ b/Validation.Infrastructure/SequenceValidator.cs
@@ -1,0 +1,30 @@
+using Validation.Domain;
+using Validation.Domain.Validation;
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Infrastructure;
+
+public static class SequenceValidator
+{
+    public static async Task<bool> ValidateAsync<T>(
+        T entity,
+        Func<object, decimal>? selector,
+        ISaveAuditRepository repo,
+        IEntityIdProvider idProvider,
+        decimal threshold,
+        ThresholdType type,
+        CancellationToken ct = default)
+    {
+        if (selector == null) return true;
+        var id = idProvider.GetId(entity!);
+        var last = await repo.GetLastAsync(id, ct);
+        if (last == null) return true;
+        var current = selector(entity!);
+        var previous = last.Metric;
+        return type switch
+        {
+            ThresholdType.PercentChange => previous == 0 ? true : Math.Abs((current - previous) / previous) * 100 <= threshold,
+            _ => Math.Abs(current - previous) <= threshold
+        };
+    }
+}

--- a/Validation.Tests/GenericRepositoryTests.cs
+++ b/Validation.Tests/GenericRepositoryTests.cs
@@ -26,6 +26,7 @@ public class GenericRepositoryTests
         }
         public IEnumerable<IValidationRule> GetRules<T>() => new[] { _rule };
         public ValidationPlan GetPlan(Type t) => new ValidationPlan(new[] { _rule });
+        public ValidationPlan GetPlanFor<T>() => GetPlan(typeof(T));
         public void AddPlan<T>(ValidationPlan plan) { }
     }
 

--- a/Validation.Tests/SaveValidationConsumerTests.cs
+++ b/Validation.Tests/SaveValidationConsumerTests.cs
@@ -1,9 +1,11 @@
 using MassTransit;
 using MassTransit.Testing;
 using Validation.Domain.Events;
+using Validation.Domain;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.Messaging;
 using Validation.Domain.Entities;
+using Validation.Infrastructure;
 
 namespace Validation.Tests;
 
@@ -13,14 +15,31 @@ public class SaveValidationConsumerTests
     {
         public IEnumerable<IValidationRule> GetRules<T>() => new[] { new RawDifferenceRule(100) };
         public ValidationPlan GetPlan(Type t) => new ValidationPlan(new[] { new RawDifferenceRule(100) });
+        public ValidationPlan GetPlanFor<T>() => new ValidationPlan(obj => 10m, ThresholdType.RawDifference, 100m);
         public void AddPlan<T>(ValidationPlan plan) { }
+    }
+
+    private class IdProvider : IEntityIdProvider
+    {
+        public Guid GetId<T>(T entity)
+        {
+            return (Guid)entity!.GetType().GetProperty("Id")!.GetValue(entity)!;
+        }
+    }
+
+    private class AppNameProvider : IApplicationNameProvider
+    {
+        public string ApplicationName => "Test";
     }
 
     [Fact]
     public async Task Publish_SaveValidated_after_processing()
     {
         var repository = new InMemorySaveAuditRepository();
-        var consumer = new SaveValidationConsumer<Item>(new TestPlanProvider(), repository, new SummarisationValidator());
+        var manual = new ManualValidatorService();
+        var idProvider = new IdProvider();
+        var app = new AppNameProvider();
+        var consumer = new SaveValidationConsumer<Item>(new TestPlanProvider(), repository, manual, idProvider, app);
 
         var harness = new InMemoryTestHarness();
         harness.Consumer(() => consumer);
@@ -28,7 +47,7 @@ public class SaveValidationConsumerTests
         await harness.Start();
         try
         {
-            await harness.InputQueueSendEndpoint.Send(new SaveRequested(Guid.NewGuid()));
+            await harness.InputQueueSendEndpoint.Send(new SaveRequested<Item>(new Item(5)));
 
             Assert.True(await harness.Published.Any<SaveValidated<Item>>());
         }


### PR DESCRIPTION
## Summary
- overhaul `SaveValidationConsumer` to support generic validation plans and sequence validation
- add new provider interfaces and default implementations
- extend infrastructure DI to register new consumers and providers
- adjust reliability policy and validator service
- update tests for new behavior and ensure all pass

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688cb979f9988330b5d3173639ce24ba