### PR TITLE
Implement batch save validation consumer

### DIFF
--- a/Validation.Domain/Validation/ValidationPlanProviderExtensions.cs
+++ b/Validation.Domain/Validation/ValidationPlanProviderExtensions.cs
@@ -1,0 +1,7 @@
+namespace Validation.Domain.Validation;
+
+public static class ValidationPlanProviderExtensions
+{
+    public static ValidationPlan GetPlanFor<T>(this IValidationPlanProvider provider)
+        => provider.GetPlan(typeof(T));
+}

--- a/Validation.Infrastructure/EnhancedManualValidatorService.cs
+++ b/Validation.Infrastructure/EnhancedManualValidatorService.cs
@@ -149,6 +149,7 @@ public class EnhancedManualValidatorService : IEnhancedManualValidatorService
                         {
                             _logger.LogError(ex, "Error executing named rule {RuleName} for type {Type}",
                                 kvp.Key, type.Name);
+                            result.FailedRules.Add(kvp.Key);
                             result.IsValid = false;
                             result.Errors.Add($"Rule '{kvp.Key}' execution failed: {ex.Message}");
                         }

--- a/Validation.Infrastructure/Messaging/SaveBatchValidationConsumer.cs
+++ b/Validation.Infrastructure/Messaging/SaveBatchValidationConsumer.cs
@@ -1,0 +1,73 @@
+using MassTransit;
+using Validation.Domain.Events;
+using Validation.Domain.Validation;
+using ValidationFlow.Messages;
+using Validation.Infrastructure.Repositories;
+
+namespace Validation.Infrastructure.Messaging;
+
+public class SaveBatchValidationConsumer<T> : IConsumer<SaveBatchRequested<T>> where T : class
+{
+    private readonly IValidationPlanProvider  _plans;
+    private readonly ISaveAuditRepository     _audits;
+    private readonly IManualValidatorService  _manual;
+    private readonly IEntityIdProvider        _ids;
+    private readonly IApplicationNameProvider _app;
+
+    public SaveBatchValidationConsumer(
+        IValidationPlanProvider plans,
+        ISaveAuditRepository audits,
+        IManualValidatorService manual,
+        IEntityIdProvider ids,
+        IApplicationNameProvider app)
+    {
+        _plans  = plans;
+        _audits = audits;
+        _manual = manual;
+        _ids    = ids;
+        _app    = app;
+    }
+
+    public async Task Consume(ConsumeContext<SaveBatchRequested<T>> ctx)
+    {
+        var list = ctx.Message.Entities.ToList();
+        if (list.Any(item => !_manual.Validate(item!)))
+        {
+            await ctx.Publish(new ValidationOperationFailed(_ids.GetId(list.First()), typeof(T).Name, "SaveBatch", "Manual rule failed"));
+            return;
+        }
+
+        var plan = _plans.GetPlan(typeof(T));
+        var selector = plan.MetricSelector ?? (_ => 0m);
+
+        var seqOk = await SequenceValidator.ValidateBatchAsync(
+            list,
+            x => selector(x!),
+            _audits,
+            _ids,
+            plan.ThresholdValue ?? 0m,
+            plan.ThresholdType  ?? ThresholdType.RawDifference,
+            null,
+            ctx.CancellationToken);
+
+        if (!seqOk)
+        {
+            await ctx.Publish(new ValidationOperationFailed(_ids.GetId(list.First()), typeof(T).Name, "SaveBatch", "Sequence validation failed"));
+            return;
+        }
+
+        var metric = list.Sum(x => selector(x!));
+
+        var audit = new SaveAudit
+        {
+            EntityId        = _ids.GetId(list.First()),
+            ApplicationName = _app.ApplicationName,
+            BatchSize       = list.Count,
+            IsValid         = true,
+            Metric          = metric
+        };
+        await _audits.AddAsync(audit, ctx.CancellationToken);
+
+        await ctx.Publish(new Validation.Domain.Events.SaveValidated<T>(_ids.GetId(list.First()), audit.Id));
+    }
+}

--- a/Validation.Infrastructure/SaveAudit.cs
+++ b/Validation.Infrastructure/SaveAudit.cs
@@ -4,6 +4,8 @@ public class SaveAudit
 {
     public Guid Id { get; set; }
     public Guid EntityId { get; set; }
+    public string ApplicationName { get; set; } = string.Empty;
+    public int BatchSize { get; set; }
     public bool IsValid { get; set; }
     public decimal Metric { get; set; }
     public DateTime Timestamp { get; set; } = DateTime.UtcNow;

--- a/Validation.Infrastructure/Validation.Infrastructure.csproj
+++ b/Validation.Infrastructure/Validation.Infrastructure.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Validation.Domain\Validation.Domain.csproj" />
+    <ProjectReference Include="..\ValidationFlow.Messages\ValidationFlow.Messages.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Validation.Infrastructure/Validation/SequenceValidator.cs
+++ b/Validation.Infrastructure/Validation/SequenceValidator.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Validation.Infrastructure.Repositories;
+using Microsoft.Extensions.Logging;
+
+namespace Validation.Domain.Validation;
+
+public static class SequenceValidator
+{
+    public static async Task<bool> ValidateBatchAsync<T>(
+        IEnumerable<T> items,
+        Func<T, decimal> selector,
+        ISaveAuditRepository audits,
+        IEntityIdProvider ids,
+        decimal thresholdValue,
+        ThresholdType thresholdType,
+        ILogger? logger,
+        CancellationToken ct)
+    {
+        foreach (var item in items)
+        {
+            var id = ids.GetId(item);
+            var last = await audits.GetLastAsync(id, ct);
+            if (last == null) continue;
+            var metric = selector(item);
+            var previous = last.Metric;
+            var valid = thresholdType switch
+            {
+                ThresholdType.RawDifference => Math.Abs(metric - previous) <= thresholdValue,
+                ThresholdType.PercentChange => previous == 0 ? true : Math.Abs((metric - previous) / previous) * 100 <= thresholdValue,
+                _ => true
+            };
+            if (!valid)
+                return false;
+        }
+        return true;
+    }
+}
+
+public interface IEntityIdProvider
+{
+    Guid GetId<T>(T entity);
+}
+
+public interface IApplicationNameProvider
+{
+    string ApplicationName { get; }
+}

--- a/Validation.Tests/SaveBatchValidationConsumerTests.cs
+++ b/Validation.Tests/SaveBatchValidationConsumerTests.cs
@@ -1,0 +1,79 @@
+using MassTransit;
+using MassTransit.Testing;
+using Validation.Domain.Entities;
+using Validation.Domain.Events;
+using Validation.Domain.Validation;
+using Validation.Infrastructure.Messaging;
+using Validation.Infrastructure.Repositories;
+using Validation.Infrastructure;
+
+using ValidationFlow.Messages;
+namespace Validation.Tests;
+
+public class SaveBatchValidationConsumerTests
+{
+    private class TestPlanProvider : IValidationPlanProvider
+    {
+        public IEnumerable<IValidationRule> GetRules<T>() => Array.Empty<IValidationRule>();
+        public ValidationPlan GetPlan(Type t) => new ValidationPlan(o => ((Item)o).Metric, ThresholdType.RawDifference, 100m);
+        public void AddPlan<T>(ValidationPlan plan) { }
+    }
+
+    private class IdProvider : IEntityIdProvider
+    {
+        public Guid GetId<T>(T entity) => ((Item)(object)entity).Id;
+    }
+
+    private class AppProvider : IApplicationNameProvider
+    {
+        public string ApplicationName => "TestApp";
+    }
+
+    [Fact]
+    public async Task Publish_SaveValidated_after_valid_batch()
+    {
+        var repo = new InMemorySaveAuditRepository();
+        var consumer = new SaveBatchValidationConsumer<Item>(new TestPlanProvider(), repo, new ManualValidatorService(), new IdProvider(), new AppProvider());
+
+        var harness = new InMemoryTestHarness();
+        harness.Consumer(() => consumer);
+
+        await harness.Start();
+        try
+        {
+            var items = new[] { new Item(1), new Item(2) };
+            await harness.InputQueueSendEndpoint.Send(new SaveBatchRequested<Item>(Guid.NewGuid(), items));
+
+            Assert.True(await harness.Published.Any<Validation.Domain.Events.SaveValidated<Item>>());
+        }
+        finally
+        {
+            await harness.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task Publish_ValidationFailed_when_manual_rule_fails()
+    {
+        var repo = new InMemorySaveAuditRepository();
+        var manual = new ManualValidatorService();
+        manual.AddRule<Item>(i => i.Metric > 0);
+        var consumer = new SaveBatchValidationConsumer<Item>(new TestPlanProvider(), repo, manual, new IdProvider(), new AppProvider());
+
+        var harness = new InMemoryTestHarness();
+        harness.Consumer(() => consumer);
+
+        await harness.Start();
+        try
+        {
+            var items = new[] { new Item(-1) };
+            await harness.InputQueueSendEndpoint.Send(new SaveBatchRequested<Item>(Guid.NewGuid(), items));
+
+            Assert.True(await harness.Published.Any<ValidationOperationFailed>());
+        }
+        finally
+        {
+            await harness.Stop();
+        }
+    }
+}

--- a/ValidationFlow.Messages/SaveBatchRequested.cs
+++ b/ValidationFlow.Messages/SaveBatchRequested.cs
@@ -1,0 +1,2 @@
+namespace ValidationFlow.Messages;
+public record SaveBatchRequested<T>(Guid CorrelationId, IEnumerable<T> Entities);


### PR DESCRIPTION
## Summary
- add new `SaveBatchRequested<T>` message
- implement `SequenceValidator` utilities and provider extensions
- create `SaveBatchValidationConsumer` for validating batches
- extend `SaveAudit` with application and batch info
- update reliability policy and manual validator to satisfy tests
- add unit tests for batch consumer

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688cb98495f48330a73a0d984d149a2d