### PR TITLE
Add batch save consumer and tests

### DIFF
--- a/Validation.Domain/Abstractions/IApplicationNameProvider.cs
+++ b/Validation.Domain/Abstractions/IApplicationNameProvider.cs
@@ -1,0 +1,6 @@
+namespace Validation.Domain;
+
+public interface IApplicationNameProvider
+{
+    string ApplicationName { get; }
+}

--- a/Validation.Domain/Abstractions/IEntityIdProvider.cs
+++ b/Validation.Domain/Abstractions/IEntityIdProvider.cs
@@ -1,0 +1,6 @@
+namespace Validation.Domain;
+
+public interface IEntityIdProvider
+{
+    Guid GetId(object entity);
+}

--- a/Validation.Infrastructure/EnhancedManualValidatorService.cs
+++ b/Validation.Infrastructure/EnhancedManualValidatorService.cs
@@ -150,6 +150,7 @@ public class EnhancedManualValidatorService : IEnhancedManualValidatorService
                             _logger.LogError(ex, "Error executing named rule {RuleName} for type {Type}",
                                 kvp.Key, type.Name);
                             result.IsValid = false;
+                            result.FailedRules.Add(kvp.Key);
                             result.Errors.Add($"Rule '{kvp.Key}' execution failed: {ex.Message}");
                         }
                     }

--- a/Validation.Infrastructure/Messaging/SaveBatchValidationConsumer.cs
+++ b/Validation.Infrastructure/Messaging/SaveBatchValidationConsumer.cs
@@ -1,0 +1,85 @@
+using MassTransit;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Validation.Domain;
+using Validation.Domain.Events;
+using Validation.Domain.Validation;
+using Validation.Infrastructure.Repositories;
+using ValidationFlow.Messages;
+using Validation.Infrastructure;
+
+namespace Validation.Infrastructure.Messaging;
+
+public class SaveBatchValidationConsumer<T> : IConsumer<SaveBatchRequested<T>> where T : class
+{
+    private readonly IValidationPlanProvider  _plans;
+    private readonly ISaveAuditRepository     _audits;
+    private readonly IManualValidatorService  _manual;
+    private readonly IEntityIdProvider        _ids;
+    private readonly IApplicationNameProvider _app;
+
+    public SaveBatchValidationConsumer(
+        IValidationPlanProvider plans,
+        ISaveAuditRepository audits,
+        IManualValidatorService manual,
+        IEntityIdProvider ids,
+        IApplicationNameProvider app)
+    {
+        _plans  = plans;
+        _audits = audits;
+        _manual = manual;
+        _ids    = ids;
+        _app    = app;
+    }
+
+    public async Task Consume(ConsumeContext<SaveBatchRequested<T>> ctx)
+    {
+        var list = ctx.Message.Entities.ToList();
+        if (list.Any(item => !_manual.Validate(item!)))
+        {
+            await ctx.Publish(new ValidationOperationFailed(
+                ctx.Message.CorrelationId,
+                typeof(T).Name,
+                "SaveBatch",
+                "Manual rule failed"));
+            return;
+        }
+
+        var plan = _plans.GetPlan(typeof(T));
+
+        var selector = plan.MetricSelector ?? (_ => 0m);
+
+        var seqOk = await SequenceValidator.ValidateBatchAsync(
+            list, x => selector(x) , _audits, _ids,
+            plan.ThresholdValue ?? 0m,
+            plan.ThresholdType  ?? ThresholdType.RawDifference,
+            null,
+            ctx.CancellationToken);
+
+        if (!seqOk)
+        {
+            await ctx.Publish(new ValidationOperationFailed(
+                ctx.Message.CorrelationId,
+                typeof(T).Name,
+                "SaveBatch",
+                "Sequence validation failed"));
+            return;
+        }
+
+        // Summarisation strategy over batch - basic sum
+        var metric = list.Sum(x => selector(x));
+
+        var audit = new SaveAudit
+        {
+            EntityId        = _ids.GetId(list.First()),
+            ApplicationName = _app.ApplicationName,
+            BatchSize       = list.Count,
+            IsValid         = true,
+            Metric          = metric
+        };
+        await _audits.AddAsync(audit, ctx.CancellationToken);
+
+        await ctx.Publish(new Validation.Domain.Events.SaveValidated<T>(ctx.Message.CorrelationId, audit.Id));
+    }
+}

--- a/Validation.Infrastructure/SaveAudit.cs
+++ b/Validation.Infrastructure/SaveAudit.cs
@@ -4,6 +4,8 @@ public class SaveAudit
 {
     public Guid Id { get; set; }
     public Guid EntityId { get; set; }
+    public string? ApplicationName { get; set; }
+    public int BatchSize { get; set; } = 1;
     public bool IsValid { get; set; }
     public decimal Metric { get; set; }
     public DateTime Timestamp { get; set; } = DateTime.UtcNow;

--- a/Validation.Infrastructure/SequenceValidator.cs
+++ b/Validation.Infrastructure/SequenceValidator.cs
@@ -1,0 +1,24 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Validation.Domain;
+using Validation.Infrastructure.Repositories;
+using Validation.Domain.Validation;
+
+namespace Validation.Infrastructure;
+
+public static class SequenceValidator
+{
+    public static Task<bool> ValidateBatchAsync<T>(
+        IEnumerable<T> entities,
+        Func<T, decimal> selector,
+        ISaveAuditRepository audits,
+        IEntityIdProvider ids,
+        decimal threshold,
+        ThresholdType type,
+        decimal? lastMetric,
+        CancellationToken ct)
+    {
+        // Simple placeholder: always return true
+        return Task.FromResult(true);
+    }
+}

--- a/Validation.Infrastructure/Validation.Infrastructure.csproj
+++ b/Validation.Infrastructure/Validation.Infrastructure.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Validation.Domain\Validation.Domain.csproj" />
+    <ProjectReference Include="..\ValidationFlow.Messages\ValidationFlow.Messages.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Validation.Tests/SaveBatchValidationConsumerTests.cs
+++ b/Validation.Tests/SaveBatchValidationConsumerTests.cs
@@ -1,0 +1,61 @@
+using MassTransit;
+using MassTransit.Testing;
+using Validation.Domain.Entities;
+using Validation.Domain.Validation;
+using Validation.Infrastructure.Messaging;
+using Validation.Infrastructure.Repositories;
+using ValidationFlow.Messages;
+using Validation.Domain;
+using Validation.Infrastructure;
+
+namespace Validation.Tests;
+
+public class SaveBatchValidationConsumerTests
+{
+    private class TestPlanProvider : IValidationPlanProvider
+    {
+        public IEnumerable<IValidationRule> GetRules<T>() => Array.Empty<IValidationRule>();
+        public ValidationPlan GetPlan(Type t) => new ValidationPlan(o => ((Item)o).Metric, ThresholdType.RawDifference, 100m);
+        public void AddPlan<T>(ValidationPlan plan) { }
+    }
+
+    private class DummyIdProvider : IEntityIdProvider
+    {
+        public Guid GetId(object entity) => ((Item)entity).Id;
+    }
+
+    private class DummyAppProvider : IApplicationNameProvider
+    {
+        public string ApplicationName => "TestApp";
+    }
+
+    [Fact]
+    public async Task Publish_SaveValidated_after_processing_batch()
+    {
+        var repo = new InMemorySaveAuditRepository();
+        var consumer = new SaveBatchValidationConsumer<Item>(
+            new TestPlanProvider(),
+            repo,
+            new ManualValidatorService(),
+            new DummyIdProvider(),
+            new DummyAppProvider());
+
+        var harness = new InMemoryTestHarness();
+        harness.Consumer(() => consumer);
+
+        await harness.Start();
+        try
+        {
+            var items = new[] { new Item(10), new Item(20) };
+            await harness.InputQueueSendEndpoint.Send(new SaveBatchRequested<Item>(Guid.NewGuid(), items));
+
+            Assert.True(await harness.Published.Any<Validation.Domain.Events.SaveValidated<Item>>());
+            var audit = Assert.Single(repo.Audits);
+            Assert.Equal(2, audit.BatchSize);
+        }
+        finally
+        {
+            await harness.Stop();
+        }
+    }
+}

--- a/ValidationFlow.Messages/SaveBatchRequested.cs
+++ b/ValidationFlow.Messages/SaveBatchRequested.cs
@@ -1,0 +1,2 @@
+namespace ValidationFlow.Messages;
+public record SaveBatchRequested<T>(Guid CorrelationId, IEnumerable<T> Entities);


### PR DESCRIPTION
## Summary
- add `SaveBatchRequested` message
- implement `SaveBatchValidationConsumer` with basic batch logic
- extend `SaveAudit` to track batch metadata
- provide abstractions for entity id and app name
- adjust reliability policy and manual validator service
- add placeholder `SequenceValidator`
- create tests for the new consumer

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --logger "console;verbosity=minimal"`

------
https://chatgpt.com/codex/tasks/task_e_688cb98495f48330a73a0d984d149a2d