### PR TITLE
Add event publishing in generic repos

### DIFF
--- a/Validation.Domain/Events/SaveBatchRequested.Generic.cs
+++ b/Validation.Domain/Events/SaveBatchRequested.Generic.cs
@@ -1,0 +1,3 @@
+namespace Validation.Domain.Events;
+
+public record SaveBatchRequested<T>(Guid BatchId, IEnumerable<T> Entities);

--- a/Validation.Domain/Events/SaveRequested.Generic.cs
+++ b/Validation.Domain/Events/SaveRequested.Generic.cs
@@ -1,3 +1,3 @@
 namespace Validation.Domain.Events;
 
-public record SaveRequested<T>(T Entity, string? App = null);
+public record SaveRequested<T>(Guid Id, T Entity);

--- a/Validation.Infrastructure/EnhancedManualValidatorService.cs
+++ b/Validation.Infrastructure/EnhancedManualValidatorService.cs
@@ -150,6 +150,7 @@ public class EnhancedManualValidatorService : IEnhancedManualValidatorService
                             _logger.LogError(ex, "Error executing named rule {RuleName} for type {Type}",
                                 kvp.Key, type.Name);
                             result.IsValid = false;
+                            result.FailedRules.Add(kvp.Key);
                             result.Errors.Add($"Rule '{kvp.Key}' execution failed: {ex.Message}");
                         }
                     }
@@ -177,6 +178,7 @@ public class EnhancedManualValidatorService : IEnhancedManualValidatorService
                             _logger.LogError(ex, "Error executing anonymous rule {Index} for type {Type}",
                                 i, type.Name);
                             result.IsValid = false;
+                            result.FailedRules.Add($"Anonymous rule {i}");
                             result.Errors.Add($"Anonymous rule {i} execution failed: {ex.Message}");
                         }
                     }

--- a/Validation.Infrastructure/Reliability/DeletePipelineReliabilityPolicy.cs
+++ b/Validation.Infrastructure/Reliability/DeletePipelineReliabilityPolicy.cs
@@ -54,8 +54,6 @@ public class DeletePipelineReliabilityPolicy
                 
                 if (ShouldRetry(ex, attempts - 1))
                 {
-                    Interlocked.Increment(ref _consecutiveFailures);
-                    _lastFailureTime = DateTime.UtcNow;
 
                     _logger.LogWarning(ex, 
                         "Delete pipeline operation failed. Attempt {Attempt} of {MaxAttempts}. Retrying in {DelayMs}ms",
@@ -68,6 +66,8 @@ public class DeletePipelineReliabilityPolicy
                     }
                     else
                     {
+                        _lastFailureTime = DateTime.UtcNow;
+                        Interlocked.Increment(ref _consecutiveFailures);
                         // Retryable exception but retries exhausted - this will be wrapped below
                         break;
                     }
@@ -108,9 +108,6 @@ public class DeletePipelineReliabilityPolicy
 
     private bool ShouldRetry(Exception exception, int attempt)
     {
-        if (attempt >= _options.MaxRetryAttempts - 1)
-            return false;
-
         // Don't retry on certain exception types
         if (exception is ArgumentException or ArgumentNullException)
             return false;

--- a/Validation.Infrastructure/Repositories/EfGenericRepository.cs
+++ b/Validation.Infrastructure/Repositories/EfGenericRepository.cs
@@ -1,5 +1,7 @@
 using Microsoft.EntityFrameworkCore;
+using MassTransit;
 using Validation.Domain.Validation;
+using Validation.Domain.Events;
 
 namespace Validation.Infrastructure.Repositories;
 
@@ -9,23 +11,25 @@ public class EfGenericRepository<T> : IGenericRepository<T> where T : class
     private readonly DbSet<T> _set;
     private readonly IValidationPlanProvider _planProvider;
     private readonly SummarisationValidator _validator;
+    private readonly IPublishEndpoint _bus;
 
-    public EfGenericRepository(DbContext context, IValidationPlanProvider planProvider, SummarisationValidator validator)
+    public EfGenericRepository(DbContext context, IValidationPlanProvider planProvider, SummarisationValidator validator, IPublishEndpoint bus)
     {
         _context = context;
         _set = context.Set<T>();
         _planProvider = planProvider;
         _validator = validator;
+        _bus = bus;
     }
 
     public async Task AddAsync(T entity, CancellationToken ct = default)
     {
-        await _set.AddAsync(entity, ct);
+        await _bus.Publish(new SaveRequested<T>(Guid.NewGuid(), entity), ct);
     }
 
     public Task AddManyAsync(IEnumerable<T> items, CancellationToken ct = default)
     {
-        _set.AddRange(items);
+        _bus.Publish(new SaveBatchRequested<T>(Guid.NewGuid(), items), ct);
         return Task.CompletedTask;
     }
 

--- a/Validation.Infrastructure/Repositories/EventPublishingRepository.cs
+++ b/Validation.Infrastructure/Repositories/EventPublishingRepository.cs
@@ -15,7 +15,7 @@ public class EventPublishingRepository<T> : IEntityRepository<T>
 
     public Task SaveAsync(T entity, string? app = null, CancellationToken ct = default)
     {
-        return _bus.Publish(new SaveRequested<T>(entity, app), ct);
+        return _bus.Publish(new SaveRequested<T>(Guid.NewGuid(), entity), ct);
     }
 
     public Task DeleteAsync(Guid id, string? app = null, CancellationToken ct = default)

--- a/Validation.Infrastructure/Repositories/MongoGenericRepository.cs
+++ b/Validation.Infrastructure/Repositories/MongoGenericRepository.cs
@@ -1,5 +1,7 @@
 using MongoDB.Driver;
+using MassTransit;
 using Validation.Domain.Validation;
+using Validation.Domain.Events;
 
 namespace Validation.Infrastructure.Repositories;
 
@@ -8,22 +10,25 @@ public class MongoGenericRepository<T> : IGenericRepository<T>
     private readonly IMongoCollection<T> _collection;
     private readonly IValidationPlanProvider _planProvider;
     private readonly SummarisationValidator _validator;
+    private readonly IPublishEndpoint _bus;
 
-    public MongoGenericRepository(IMongoDatabase database, IValidationPlanProvider planProvider, SummarisationValidator validator)
+    public MongoGenericRepository(IMongoDatabase database, IValidationPlanProvider planProvider, SummarisationValidator validator, IPublishEndpoint bus)
     {
         _collection = database.GetCollection<T>(typeof(T).Name.ToLowerInvariant());
         _planProvider = planProvider;
         _validator = validator;
+        _bus = bus;
     }
 
     public async Task AddAsync(T entity, CancellationToken ct = default)
     {
-        await _collection.InsertOneAsync(entity, cancellationToken: ct);
+        await _bus.Publish(new SaveRequested<T>(Guid.NewGuid(), entity), ct);
     }
 
-    public async Task AddManyAsync(IEnumerable<T> items, CancellationToken ct = default)
+    public Task AddManyAsync(IEnumerable<T> items, CancellationToken ct = default)
     {
-        await _collection.InsertManyAsync(items, cancellationToken: ct);
+        _bus.Publish(new SaveBatchRequested<T>(Guid.NewGuid(), items), ct);
+        return Task.CompletedTask;
     }
 
     public async Task<T?> GetAsync(Guid id, CancellationToken ct = default)

--- a/Validation.Tests/UnitOfWorkExampleTests.cs
+++ b/Validation.Tests/UnitOfWorkExampleTests.cs
@@ -1,5 +1,8 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using MassTransit;
+using MassTransit.Testing;
+using Validation.Domain.Events;
 using Validation.Domain.Validation;
 using Validation.Infrastructure;
 
@@ -22,24 +25,32 @@ public class UnitOfWorkExampleTests
     [Fact]
     public async Task UnitOfWork_usage_example()
     {
-        var services = new ServiceCollection();
-        services.AddDbContext<ExampleDbContext>(o => o.UseInMemoryDatabase("uowexample"));
-        services.AddScoped<DbContext>(sp => sp.GetRequiredService<ExampleDbContext>());
-        services.AddSingleton<IValidationPlanProvider, InMemoryValidationPlanProvider>();
-        services.AddScoped<SummarisationValidator>();
-        services.AddScoped<UnitOfWork>();
+        var harness = new InMemoryTestHarness();
+        await harness.Start();
+        try
+        {
+            var services = new ServiceCollection();
+            services.AddDbContext<ExampleDbContext>(o => o.UseInMemoryDatabase("uowexample"));
+            services.AddScoped<DbContext>(sp => sp.GetRequiredService<ExampleDbContext>());
+            services.AddSingleton<IValidationPlanProvider, InMemoryValidationPlanProvider>();
+            services.AddScoped<SummarisationValidator>();
+            services.AddSingleton<IPublishEndpoint>(harness.Bus);
+            services.AddScoped<UnitOfWork>();
 
-        var provider = services.BuildServiceProvider();
-        using var scope = provider.CreateScope();
-        var planProvider = scope.ServiceProvider.GetRequiredService<IValidationPlanProvider>();
-        planProvider.AddPlan<YourEntity>(new ValidationPlan(e => ((YourEntity)e).Id, ThresholdType.RawDifference, 5));
+            var provider = services.BuildServiceProvider();
+            using var scope = provider.CreateScope();
+            var planProvider = scope.ServiceProvider.GetRequiredService<IValidationPlanProvider>();
+            planProvider.AddPlan<YourEntity>(new ValidationPlan(e => ((YourEntity)e).Id, ThresholdType.RawDifference, 5));
 
-        var uow = scope.ServiceProvider.GetRequiredService<UnitOfWork>();
-        await uow.Repository<YourEntity>().AddAsync(new YourEntity { Id = 50 });
-        var count = await uow.SaveChangesWithPlanAsync<YourEntity>();
+            var uow = scope.ServiceProvider.GetRequiredService<UnitOfWork>();
+            await uow.Repository<YourEntity>().AddAsync(new YourEntity { Id = 50 });
+            await uow.SaveChangesWithPlanAsync<YourEntity>();
 
-        var ctx = scope.ServiceProvider.GetRequiredService<ExampleDbContext>();
-        Assert.Equal(1, ctx.Entities.Count());
-        Assert.Equal(1, count);
+            Assert.True(await harness.Published.Any<SaveRequested<YourEntity>>());
+        }
+        finally
+        {
+            await harness.Stop();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- publish `SaveRequested<T>` and `SaveBatchRequested<T>` events from EF and Mongo repositories
- inject `IPublishEndpoint` into repositories and unit of work
- update EventPublishingRepository for new event shape
- extend EnhancedManualValidatorService to record failed rules on exceptions
- fix delete reliability policy logic
- adjust tests for new messaging behavior

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688cb9c96d388330956aab0ddfe1a760