### PR TITLE
Implement event publishing in generic repositories

### DIFF
--- a/Validation.Domain/Events/SaveBatchRequested.Generic.cs
+++ b/Validation.Domain/Events/SaveBatchRequested.Generic.cs
@@ -1,0 +1,3 @@
+namespace Validation.Domain.Events;
+
+public record SaveBatchRequested<T>(Guid BatchId, IEnumerable<T> Items);

--- a/Validation.Domain/Events/SaveRequested.Generic.cs
+++ b/Validation.Domain/Events/SaveRequested.Generic.cs
@@ -1,3 +1,3 @@
 namespace Validation.Domain.Events;
 
-public record SaveRequested<T>(T Entity, string? App = null);
+public record SaveRequested<T>(Guid Id, T Entity);

--- a/Validation.Infrastructure/EnhancedManualValidatorService.cs
+++ b/Validation.Infrastructure/EnhancedManualValidatorService.cs
@@ -150,6 +150,7 @@ public class EnhancedManualValidatorService : IEnhancedManualValidatorService
                             _logger.LogError(ex, "Error executing named rule {RuleName} for type {Type}",
                                 kvp.Key, type.Name);
                             result.IsValid = false;
+                            result.FailedRules.Add(kvp.Key);
                             result.Errors.Add($"Rule '{kvp.Key}' execution failed: {ex.Message}");
                         }
                     }
@@ -177,6 +178,7 @@ public class EnhancedManualValidatorService : IEnhancedManualValidatorService
                             _logger.LogError(ex, "Error executing anonymous rule {Index} for type {Type}",
                                 i, type.Name);
                             result.IsValid = false;
+                            result.FailedRules.Add($"Anonymous rule {i}");
                             result.Errors.Add($"Anonymous rule {i} execution failed: {ex.Message}");
                         }
                     }

--- a/Validation.Infrastructure/Repositories/EventPublishingRepository.cs
+++ b/Validation.Infrastructure/Repositories/EventPublishingRepository.cs
@@ -15,7 +15,7 @@ public class EventPublishingRepository<T> : IEntityRepository<T>
 
     public Task SaveAsync(T entity, string? app = null, CancellationToken ct = default)
     {
-        return _bus.Publish(new SaveRequested<T>(entity, app), ct);
+        return _bus.Publish(new SaveRequested<T>(Guid.NewGuid(), entity), ct);
     }
 
     public Task DeleteAsync(Guid id, string? app = null, CancellationToken ct = default)

--- a/Validation.Tests/GenericRepositoryTests.cs
+++ b/Validation.Tests/GenericRepositoryTests.cs
@@ -1,5 +1,7 @@
 using Microsoft.EntityFrameworkCore;
+using MassTransit.Testing;
 using Validation.Domain.Entities;
+using Validation.Domain.Events;
 using Validation.Domain.Validation;
 using Validation.Infrastructure.Repositories;
 
@@ -30,22 +32,47 @@ public class GenericRepositoryTests
     }
 
     [Fact]
-    public async Task AddMany_SaveChanges_ValidatesOnce()
+    public async Task AddAsync_publishes_event()
     {
-        var options = new DbContextOptionsBuilder<TestDbContext>()
-            .UseInMemoryDatabase("genericrepo")
-            .Options;
-        using var context = new TestDbContext(options);
-        var rule = new CountingRule();
-        var planProvider = new TestPlanProvider(rule);
-        var validator = new SummarisationValidator();
-        var repo = new EfGenericRepository<Item>(context, planProvider, validator);
+        var harness = new InMemoryTestHarness();
+        await harness.Start();
+        try
+        {
+            var options = new DbContextOptionsBuilder<TestDbContext>()
+                .UseInMemoryDatabase("addasync")
+                .Options;
+            using var context = new TestDbContext(options);
+            var repo = new EfGenericRepository<Item>(context, new InMemoryValidationPlanProvider(), new SummarisationValidator(), harness.Bus);
+            await repo.AddAsync(new Item(5));
 
-        var items = Enumerable.Range(0, 100).Select(i => new Item(i));
-        await repo.AddManyAsync(items);
-        await repo.SaveChangesWithPlanAsync();
+            Assert.True(await harness.Published.Any<SaveRequested<Item>>());
+        }
+        finally
+        {
+            await harness.Stop();
+        }
+    }
 
-        Assert.Equal(1, rule.Calls);
-        Assert.Equal(100, context.Items.Count());
+    [Fact]
+    public async Task AddManyAsync_publishes_batch_event()
+    {
+        var harness = new InMemoryTestHarness();
+        await harness.Start();
+        try
+        {
+            var options = new DbContextOptionsBuilder<TestDbContext>()
+                .UseInMemoryDatabase("addmany")
+                .Options;
+            using var context = new TestDbContext(options);
+            var repo = new EfGenericRepository<Item>(context, new InMemoryValidationPlanProvider(), new SummarisationValidator(), harness.Bus);
+            var items = new[] { new Item(1), new Item(2) };
+            await repo.AddManyAsync(items);
+
+            Assert.True(await harness.Published.Any<SaveBatchRequested<Item>>());
+        }
+        finally
+        {
+            await harness.Stop();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add `SaveBatchRequested<T>` event and update `SaveRequested<T>` signature
- publish save events from EF and Mongo generic repositories
- inject `IPublishEndpoint` into repositories and `UnitOfWork`
- publish events in `EventPublishingRepository`
- adjust reliability policy and validator service
- update repository and unit of work tests

## Testing
- `dotnet test Validation.Tests/Validation.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_688cb9c96d388330956aab0ddfe1a760