### PR TITLE
Add entity id and application name providers

### DIFF
--- a/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
+++ b/Validation.Infrastructure/DI/ServiceCollectionExtensions.cs
@@ -18,6 +18,7 @@ using Validation.Infrastructure.Metrics;
 using Validation.Infrastructure.Auditing;
 using Validation.Infrastructure.Observability;
 using Validation.Infrastructure.Pipeline;
+using Validation.Infrastructure.Providers;
 
 namespace Validation.Infrastructure.DI;
 
@@ -203,6 +204,20 @@ public static class ServiceCollectionExtensions
         services.AddLogging(b => b.AddSerilog());
         services.AddOpenTelemetry().WithTracing(b => b.AddAspNetCoreInstrumentation());
 
+        return services;
+    }
+
+    public static IServiceCollection AddReflectionBasedEntityIdProvider(
+        this IServiceCollection services, params string[] priority)
+    {
+        services.AddSingleton<IEntityIdProvider>(new ReflectionBasedEntityIdProvider(priority));
+        return services;
+    }
+
+    public static IServiceCollection WithStaticApplicationName(
+        this IServiceCollection services, string name)
+    {
+        services.AddSingleton<IApplicationNameProvider>(new StaticApplicationNameProvider(name));
         return services;
     }
 }

--- a/Validation.Infrastructure/EnhancedManualValidatorService.cs
+++ b/Validation.Infrastructure/EnhancedManualValidatorService.cs
@@ -150,6 +150,7 @@ public class EnhancedManualValidatorService : IEnhancedManualValidatorService
                             _logger.LogError(ex, "Error executing named rule {RuleName} for type {Type}",
                                 kvp.Key, type.Name);
                             result.IsValid = false;
+                            result.FailedRules.Add(kvp.Key);
                             result.Errors.Add($"Rule '{kvp.Key}' execution failed: {ex.Message}");
                         }
                     }
@@ -177,6 +178,7 @@ public class EnhancedManualValidatorService : IEnhancedManualValidatorService
                             _logger.LogError(ex, "Error executing anonymous rule {Index} for type {Type}",
                                 i, type.Name);
                             result.IsValid = false;
+                            result.FailedRules.Add($"Anonymous rule {i}");
                             result.Errors.Add($"Anonymous rule {i} execution failed: {ex.Message}");
                         }
                     }

--- a/Validation.Infrastructure/Providers/IApplicationNameProvider.cs
+++ b/Validation.Infrastructure/Providers/IApplicationNameProvider.cs
@@ -1,0 +1,6 @@
+namespace Validation.Infrastructure.Providers;
+
+public interface IApplicationNameProvider
+{
+    string Name { get; }
+}

--- a/Validation.Infrastructure/Providers/IEntityIdProvider.cs
+++ b/Validation.Infrastructure/Providers/IEntityIdProvider.cs
@@ -1,0 +1,6 @@
+namespace Validation.Infrastructure.Providers;
+
+public interface IEntityIdProvider
+{
+    Guid GetEntityId(object entity);
+}

--- a/Validation.Infrastructure/Providers/ReflectionBasedEntityIdProvider.cs
+++ b/Validation.Infrastructure/Providers/ReflectionBasedEntityIdProvider.cs
@@ -1,0 +1,29 @@
+using System.Reflection;
+
+namespace Validation.Infrastructure.Providers;
+
+public class ReflectionBasedEntityIdProvider : IEntityIdProvider
+{
+    private readonly string[] _priority;
+
+    public ReflectionBasedEntityIdProvider(params string[] priority)
+    {
+        _priority = priority.Length > 0 ? priority : new[] { "Id" };
+    }
+
+    public Guid GetEntityId(object entity)
+    {
+        if (entity == null) throw new ArgumentNullException(nameof(entity));
+        var type = entity.GetType();
+        foreach (var name in _priority)
+        {
+            var prop = type.GetProperty(name, BindingFlags.Public | BindingFlags.Instance);
+            if (prop != null && prop.PropertyType == typeof(Guid))
+            {
+                if (prop.GetValue(entity) is Guid id)
+                    return id;
+            }
+        }
+        throw new InvalidOperationException($"Could not find Guid Id on type {type.FullName}");
+    }
+}

--- a/Validation.Infrastructure/Providers/StaticApplicationNameProvider.cs
+++ b/Validation.Infrastructure/Providers/StaticApplicationNameProvider.cs
@@ -1,0 +1,11 @@
+namespace Validation.Infrastructure.Providers;
+
+public class StaticApplicationNameProvider : IApplicationNameProvider
+{
+    public StaticApplicationNameProvider(string name)
+    {
+        Name = name ?? throw new ArgumentNullException(nameof(name));
+    }
+
+    public string Name { get; }
+}

--- a/Validation.Infrastructure/Reliability/DeletePipelineReliabilityPolicy.cs
+++ b/Validation.Infrastructure/Reliability/DeletePipelineReliabilityPolicy.cs
@@ -51,33 +51,30 @@ public class DeletePipelineReliabilityPolicy
             {
                 lastException = ex;
                 attempts++;
-                
-                if (ShouldRetry(ex, attempts - 1))
-                {
-                    Interlocked.Increment(ref _consecutiveFailures);
-                    _lastFailureTime = DateTime.UtcNow;
 
-                    _logger.LogWarning(ex, 
+                var retryable = ShouldRetry(ex, attempts - 1);
+
+                if (retryable && attempts < _options.MaxRetryAttempts)
+                {
+                    _logger.LogWarning(ex,
                         "Delete pipeline operation failed. Attempt {Attempt} of {MaxAttempts}. Retrying in {DelayMs}ms",
                         attempts, _options.MaxRetryAttempts, _options.RetryDelayMs);
 
-                    if (attempts < _options.MaxRetryAttempts)
-                    {
-                        await Task.Delay(_options.RetryDelayMs, cancellationToken);
-                        continue;
-                    }
-                    else
-                    {
-                        // Retryable exception but retries exhausted - this will be wrapped below
-                        break;
-                    }
+                    await Task.Delay(_options.RetryDelayMs, cancellationToken);
+                    continue;
                 }
-                else
+
+                Interlocked.Increment(ref _consecutiveFailures);
+                _lastFailureTime = DateTime.UtcNow;
+
+                if (!retryable)
                 {
-                    // Non-retryable exception - rethrow immediately
                     _logger.LogError(ex, "Delete pipeline operation failed with non-retryable exception");
                     throw;
                 }
+
+                // Retryable exception but retries exhausted - this will be wrapped below
+                break;
             }
         }
 
@@ -108,14 +105,10 @@ public class DeletePipelineReliabilityPolicy
 
     private bool ShouldRetry(Exception exception, int attempt)
     {
-        if (attempt >= _options.MaxRetryAttempts - 1)
-            return false;
-
-        // Don't retry on certain exception types
         if (exception is ArgumentException or ArgumentNullException)
             return false;
 
-        return true;
+        return attempt < _options.MaxRetryAttempts;
     }
 
     private bool IsCircuitOpen()

--- a/Validation.Tests/EntityIdAndAppNameProviderTests.cs
+++ b/Validation.Tests/EntityIdAndAppNameProviderTests.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.DependencyInjection;
+using Validation.Infrastructure.DI;
+using Validation.Infrastructure.Providers;
+using Xunit;
+
+namespace Validation.Tests;
+
+public class EntityIdAndAppNameProviderTests
+{
+    [Fact]
+    public void AddReflectionBasedEntityIdProvider_registers_provider()
+    {
+        var services = new ServiceCollection();
+        services.AddReflectionBasedEntityIdProvider();
+
+        using var provider = services.BuildServiceProvider();
+        var idProvider = provider.GetService<IEntityIdProvider>();
+
+        Assert.NotNull(idProvider);
+    }
+
+    [Fact]
+    public void WithStaticApplicationName_registers_provider()
+    {
+        const string name = "TestApp";
+        var services = new ServiceCollection();
+        services.WithStaticApplicationName(name);
+
+        using var provider = services.BuildServiceProvider();
+        var nameProvider = provider.GetRequiredService<IApplicationNameProvider>();
+
+        Assert.Equal(name, nameProvider.Name);
+    }
+}


### PR DESCRIPTION
## Summary
- add IEntityIdProvider and IApplicationNameProvider with concrete implementations
- register providers via new service collection extensions
- enhance error tracking in `EnhancedManualValidatorService`
- refine retry logic in DeletePipelineReliabilityPolicy
- add tests for new DI methods

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688cb9d1a8b483309eaca27adb7dc868